### PR TITLE
Centralize CSS color definitions

### DIFF
--- a/frontend/src/css/Auth.css
+++ b/frontend/src/css/Auth.css
@@ -25,8 +25,8 @@
   flex-direction: column;
   border-radius: 4px;
 
-  background-color: #f0f0f0;
-  border: solid 2px rgba(102, 2, 60, 0.5);
+  background-color: var(--bg-color-light);
+  border: solid 2px var(--border-color-light);
   border-collapse: separate;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
 }

--- a/frontend/src/css/Auth.css
+++ b/frontend/src/css/Auth.css
@@ -1,11 +1,3 @@
-:root {
-  --border-color: #66023C;
-  --bg-color: #dfd6e6;
-  --bg-emphasis-color: #cabad5;
-  --highlight-color: gold;
-  --error-color: #dd4c4c;
-}
-
 .auth_area {
   display: flex;
   flex-direction: column;

--- a/frontend/src/css/Master.css
+++ b/frontend/src/css/Master.css
@@ -1,6 +1,8 @@
 :root {
   --border-color: #66023C;
+  --border-color-light: rgba(102, 2, 60, 0.5);
   --bg-color: #dfd6e6;
+  --bg-color-light: #f0f0f0;
   --bg-emphasis-color: #cabad5;
   --highlight-color: gold;
   --error-color: #dd4c4c;
@@ -21,7 +23,7 @@ body {
   color: #66023C;
   font-family: "Open Sans", sans-serif;
   font-size: 16px;
-  background-color: #fafafa;
+  background-color: var(--bg-color-light);
 }
 
 #root {

--- a/frontend/src/css/Master.css
+++ b/frontend/src/css/Master.css
@@ -1,3 +1,11 @@
+:root {
+  --border-color: #66023C;
+  --bg-color: #dfd6e6;
+  --bg-emphasis-color: #cabad5;
+  --highlight-color: gold;
+  --error-color: #dd4c4c;
+}
+
 @font-face {
   font-family: 'Trajan Pro Regular';
   src: url("../fonts/Trajan Pro Regular.ttf");


### PR DESCRIPTION
Move color vars from Auth.css to Master.css. CSS color vars in Master.css will be available everywhere in the app.

This change fixes the problem that issue #14 aims to fix, but without using Sass. When I wrote that issue, I didn't realise you could use 'global' variables so easily in plain old CSS.