### PR TITLE
Tweaks to CSS and names

### DIFF
--- a/frontend/src/components/Senator/SenatorInspector.css
+++ b/frontend/src/components/Senator/SenatorInspector.css
@@ -1,4 +1,4 @@
-dialog.senator-inspector {
+dialog.senator {
   position: absolute;
   box-sizing: border-box;
   z-index: 100;
@@ -15,12 +15,12 @@ dialog.senator-inspector {
   color: inherit;
 }
 
-dialog.senator-inspector>.title {
+dialog.senator>.title {
   padding: 2px 6px;
   background-color: var(--bg-color);
 }
 
-dialog.senator-inspector h1 {
+dialog.senator h1 {
   font-size: 20px;
   font-family: inherit;
   font-weight: 400;
@@ -29,17 +29,17 @@ dialog.senator-inspector h1 {
   margin-block-end: 0em;
 }
 
-dialog.senator-inspector>.content {
+dialog.senator>.content {
   padding: 0 6px;
 }
 
-dialog.senator-inspector p {
+dialog.senator p {
   text-transform: capitalize;
   margin-block-start: 4px;
   margin-block-end: 4px;
 }
 
-dialog.senator-inspector p>img {
+dialog.senator p>img {
   vertical-align: baseline;
   height: 26px;
   width: 26px;
@@ -49,7 +49,7 @@ dialog.senator-inspector p>img {
   margin-right: 2px;
 }
 
-dialog.senator-inspector>.portrait {
+dialog.senator>.portrait {
   display: flex;
   justify-content: center;
   padding: 4px;

--- a/frontend/src/components/Senator/SenatorInspector.css
+++ b/frontend/src/components/Senator/SenatorInspector.css
@@ -1,4 +1,4 @@
-.senator-summary {
+.senator-inspector {
   position: absolute;
   box-sizing: border-box;
   z-index: 100;
@@ -8,12 +8,12 @@
   background-color: var(--bg-color-light);
 }
 
-.senator-summary>.title {
+.senator-inspector>.title {
   padding: 2px 6px;
   background-color: var(--bg-color);
 }
 
-.senator-summary h1 {
+.senator-inspector h1 {
   font-size: 20px;
   font-family: inherit;
   font-weight: 400;
@@ -22,17 +22,17 @@
   margin-block-end: 0em;
 }
 
-.senator-summary>.content {
+.senator-inspector>.content {
   padding: 0 6px;
 }
 
-.senator-summary p {
+.senator-inspector p {
   text-transform: capitalize;
   margin-block-start: 4px;
   margin-block-end: 4px;
 }
 
-.senator-summary p>img {
+.senator-inspector p>img {
   vertical-align: baseline;
   height: 26px;
   width: 26px;
@@ -42,7 +42,7 @@
   margin-right: 2px;
 }
 
-.senator-summary>.portrait {
+.senator-inspector>.portrait {
   display: flex;
   justify-content: center;
   padding: 4px;

--- a/frontend/src/components/Senator/SenatorInspector.css
+++ b/frontend/src/components/Senator/SenatorInspector.css
@@ -1,4 +1,4 @@
-.senator-inspector {
+dialog.senator-inspector {
   position: absolute;
   box-sizing: border-box;
   z-index: 100;
@@ -6,14 +6,21 @@
   border: solid 2px var(--border-color-light);
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   background-color: var(--bg-color-light);
+
+  /* Override default dialog attributes */
+  inset-inline-start: auto;
+  inset-inline-end: auto;
+  margin: 0px;
+  padding: 0px;
+  color: inherit;
 }
 
-.senator-inspector>.title {
+dialog.senator-inspector>.title {
   padding: 2px 6px;
   background-color: var(--bg-color);
 }
 
-.senator-inspector h1 {
+dialog.senator-inspector h1 {
   font-size: 20px;
   font-family: inherit;
   font-weight: 400;
@@ -22,17 +29,17 @@
   margin-block-end: 0em;
 }
 
-.senator-inspector>.content {
+dialog.senator-inspector>.content {
   padding: 0 6px;
 }
 
-.senator-inspector p {
+dialog.senator-inspector p {
   text-transform: capitalize;
   margin-block-start: 4px;
   margin-block-end: 4px;
 }
 
-.senator-inspector p>img {
+dialog.senator-inspector p>img {
   vertical-align: baseline;
   height: 26px;
   width: 26px;
@@ -42,7 +49,7 @@
   margin-right: 2px;
 }
 
-.senator-inspector>.portrait {
+dialog.senator-inspector>.portrait {
   display: flex;
   justify-content: center;
   padding: 4px;

--- a/frontend/src/components/Senator/SenatorInspector.tsx
+++ b/frontend/src/components/Senator/SenatorInspector.tsx
@@ -85,11 +85,12 @@ const SenatorInspector = (props: SenatorInspectorProps) => {
   }
   
   return (
-    <dialog open className='senator-inspector' style={getStyle()}>
+    <dialog open className='senator' style={getStyle()}>
       {props.showPortrait &&
         <div className="portrait" style={getPortraitStyle()}>
           <SenatorPortrait senator={props.instance} setInspectorRef={null} />
-        </div>}
+        </div>
+      }
       <div className="title">
         <h1>{props.instance.name}</h1>
       </div>

--- a/frontend/src/components/Senator/SenatorInspector.tsx
+++ b/frontend/src/components/Senator/SenatorInspector.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import Senator from "../../objects/Senator";
 import MajorOfficeIcon from "./MajorOfficeIcon";
-import "./SenatorSummary.css";
+import "./SenatorInspector.css";
 import SenatorPortrait from "./SenatorPortrait";
 
-interface SenatorSummaryProps {
+interface SenatorInspectorProps {
   instance: Senator;
   XOffset: number;
   YOffset: number;
@@ -13,14 +13,14 @@ interface SenatorSummaryProps {
 }
 
 /**
- * The `SenatorSummary` contains a summary of the senator to which it relates.
+ * The `SenatorInspector` contains a inspector for the senator to which it relates.
  */
-const SenatorSummary = (props: SenatorSummaryProps) => {
+const SenatorInspector = (props: SenatorInspectorProps) => {
 
   const [height, setHeight] = useState<number>(0);
 
   /**
-   * Height of the summary is determined prior to rendering and is based on the approximate height of it's children
+   * Height of the inspector is determined prior to rendering and is based on the approximate height of it's children
    */
   useEffect(() => {
     let newHeight = 70;
@@ -34,8 +34,8 @@ const SenatorSummary = (props: SenatorSummaryProps) => {
   }, [props.showPortrait, props.instance.majorOffice]);
 
   /**
-   * Get the style of the root element of SenatorSummary.
-   * This function is responsible for setting the size and absolute position of the summary component.
+   * Get the style of the root element of SenatorInspector.
+   * This function is responsible for setting the size and absolute position of the inspector component.
    * @returns style object with height, width, top and left attributes
    */
   const getStyle = () => {
@@ -85,10 +85,10 @@ const SenatorSummary = (props: SenatorSummaryProps) => {
   }
   
   return (
-    <div className='senator-summary' style={getStyle()}>
+    <div className='senator-inspector' style={getStyle()}>
       {props.showPortrait &&
         <div className="portrait" style={getPortraitStyle()}>
-          <SenatorPortrait senator={props.instance} setSummaryRef={null} />
+          <SenatorPortrait senator={props.instance} setInspectorRef={null} />
         </div>}
       <div className="title">
         <h1>{props.instance.name}</h1>
@@ -106,4 +106,4 @@ const SenatorSummary = (props: SenatorSummaryProps) => {
   )
 }
 
-export default SenatorSummary;
+export default SenatorInspector;

--- a/frontend/src/components/Senator/SenatorInspector.tsx
+++ b/frontend/src/components/Senator/SenatorInspector.tsx
@@ -85,7 +85,7 @@ const SenatorInspector = (props: SenatorInspectorProps) => {
   }
   
   return (
-    <div className='senator-inspector' style={getStyle()}>
+    <dialog open className='senator-inspector' style={getStyle()}>
       {props.showPortrait &&
         <div className="portrait" style={getPortraitStyle()}>
           <SenatorPortrait senator={props.instance} setInspectorRef={null} />
@@ -102,7 +102,7 @@ const SenatorInspector = (props: SenatorInspectorProps) => {
           </p>
         }
       </div>
-    </div>
+    </dialog>
   )
 }
 

--- a/frontend/src/components/Senator/SenatorName.tsx
+++ b/frontend/src/components/Senator/SenatorName.tsx
@@ -3,21 +3,21 @@ import Senator from '../../objects/Senator';
 
 interface SenatorNameProps {
   senator: Senator;
-  setSummaryRef: Function;
+  setInspectorRef: Function;
 }
 
 const SenatorName = (props: SenatorNameProps) => {
 
   const nameRef = useRef<HTMLDivElement>(null);
 
-  const [summaryTimer, setSummaryTimer] = useState<any>(null);
+  const [inspectorTimer, setInspectorTimer] = useState<any>(null);
 
   const mouseEnter = () => {
-    clearTimeout(summaryTimer);
-    setSummaryTimer(setTimeout(() => {
+    clearTimeout(inspectorTimer);
+    setInspectorTimer(setTimeout(() => {
       const selfPosition = nameRef.current?.getBoundingClientRect();
       if (selfPosition) {
-        props.setSummaryRef({
+        props.setInspectorRef({
           XOffset: Math.round(selfPosition.x - 4),
           YOffset: Math.round(selfPosition.y),
           width: Math.round(selfPosition.width + 8),
@@ -29,9 +29,9 @@ const SenatorName = (props: SenatorNameProps) => {
   }
 
   const mouseLeave = () => {
-    clearTimeout(summaryTimer);
-    setSummaryTimer(null);
-    props.setSummaryRef(null);
+    clearTimeout(inspectorTimer);
+    setInspectorTimer(null);
+    props.setInspectorRef(null);
   }
 
   return (

--- a/frontend/src/components/Senator/SenatorPortrait.css
+++ b/frontend/src/components/Senator/SenatorPortrait.css
@@ -8,7 +8,7 @@
   margin-inline-start: 0;
   margin-inline-end: 0;
 }
-.senator-summary .senator-portrait {
+.senator-inspector .senator-portrait {
   width: 76px;
   height: 76px;
 }
@@ -35,7 +35,7 @@
   outline: solid 3px var(--highlight-color);
   outline-offset: 0;
 }
-.senator-summary .senator-portrait>a:focus {
+.senator-inspector .senator-portrait>a:focus {
   margin: 0;
   outline: none;
 }

--- a/frontend/src/components/Senator/SenatorPortrait.css
+++ b/frontend/src/components/Senator/SenatorPortrait.css
@@ -1,4 +1,4 @@
-.senator-portrait {
+figure.senator {
   width: 80px;
   height: 80px;
 
@@ -8,12 +8,12 @@
   margin-inline-start: 0;
   margin-inline-end: 0;
 }
-.senator-inspector .senator-portrait {
+dialog.senator figure.senator {
   width: 76px;
   height: 76px;
 }
 
-.senator-portrait>a {
+figure.senator>a {
   display: block;
   position: relative;
   width: 76px;
@@ -21,7 +21,7 @@
   overflow: hidden;
   border: solid 2px var(--border-color);
 }
-.senator-portrait>div {
+figure.senator>div {
   position: relative;
   width: 76px;
   height: 76px;
@@ -29,23 +29,23 @@
   border: none;
 }
 
-.senator-portrait>a:focus {
+figure.senator>a:focus {
   margin: -1px;
   border: solid 3px var(--border-color);
   outline: solid 3px var(--highlight-color);
   outline-offset: 0;
 }
-.senator-inspector .senator-portrait>a:focus {
+dialog.senator figure.senator>a:focus {
   margin: 0;
   outline: none;
 }
 
-.senator-portrait .picture {
+figure.senator .picture {
   position: absolute;
   z-index: 2;
 }
 
-.senator-portrait .major-office-icon {
+figure.senator .major-office-icon {
   position: absolute;
   z-index: 3;
   top: 46px;
@@ -54,7 +54,7 @@
   width: 30px;
 }
 
-.senator-portrait .faction-leader {
+figure.senator .faction-leader {
   position: absolute;
   z-index: 1;
   top: 3px;

--- a/frontend/src/components/Senator/SenatorPortrait.tsx
+++ b/frontend/src/components/Senator/SenatorPortrait.tsx
@@ -13,32 +13,32 @@ import Julius from "../../images/portraits/Julius.72.png";
 
 interface SenatorPortraitProps {
   senator: Senator;
-  setSummaryRef: Function | null;
+  setInspectorRef: Function | null;
 }
 
 /**
  * The `SenatorPortrait` contains a picture of the senator it represents.
  * Icons, colors and patterns are used to express basic information about the senator.
  * 
- * Portraits linked to a summary (see `props.setSummaryRef`) can be considered "active"
- * and portraits not linked to a summary can be considered "inactive".
+ * Portraits linked to a inspector (see `props.setInspectorRef`) can be considered "active"
+ * and portraits not linked to a inspector can be considered "inactive".
  */
 const SenatorPortrait = (props: SenatorPortraitProps) => {
   
   const portraitRef = useRef<HTMLDivElement>(null);
 
   const [mouseHover, setMouseHover] = useState<boolean>(false);
-  const [summaryTimer, setSummaryTimer] = useState<any>(null);
+  const [inspectorTimer, setInspectorTimer] = useState<any>(null);
 
   const mouseEnter = () => {
-    // Only react to this trigger if the portrait is linked to a summary
-    if (props.setSummaryRef !== null) {
+    // Only react to this trigger if the portrait is linked to a inspector
+    if (props.setInspectorRef !== null) {
       setMouseHover(true)
-      clearTimeout(summaryTimer);
-      setSummaryTimer(setTimeout(() => {
+      clearTimeout(inspectorTimer);
+      setInspectorTimer(setTimeout(() => {
         const selfPosition = portraitRef.current?.getBoundingClientRect();
-        if (selfPosition && props.setSummaryRef !== null) {
-          props.setSummaryRef({
+        if (selfPosition && props.setInspectorRef !== null) {
+          props.setInspectorRef({
             XOffset: Math.round(selfPosition.x + 2),
             YOffset: Math.round(selfPosition.y),
             width: Math.round(selfPosition.width - 4),
@@ -50,11 +50,11 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
   }
 
   const mouseLeave = () => {
-    if (props.setSummaryRef !== null) {
-      clearTimeout(summaryTimer);
+    if (props.setInspectorRef !== null) {
+      clearTimeout(inspectorTimer);
       setMouseHover(false);
-      setSummaryTimer(null);
-      props.setSummaryRef(null);
+      setInspectorTimer(null);
+      props.setInspectorRef(null);
     }
   }
 
@@ -109,8 +109,8 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
     }
   }
 
-  // For semantic reasons, use the `a` tag only if the portrait is linked to a senator summary
-  const DynamicTag = props.setSummaryRef ? "a" : "div";
+  // For semantic reasons, use the `a` tag only if the portrait is linked to a senator inspector
+  const DynamicTag = props.setInspectorRef ? "a" : "div";
 
   return (
     <figure ref={portraitRef} className="senator-portrait">

--- a/frontend/src/components/Senator/SenatorPortrait.tsx
+++ b/frontend/src/components/Senator/SenatorPortrait.tsx
@@ -113,7 +113,7 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
   const DynamicTag = props.setInspectorRef ? "a" : "div";
 
   return (
-    <figure ref={portraitRef} className="senator-portrait">
+    <figure ref={portraitRef} className="senator">
       <DynamicTag href='#' style={getStyle()} onMouseEnter={mouseEnter} onMouseLeave={mouseLeave}>
         <img className={getPictureClass()} style={getPictureStyle()} src={getPicture()} alt={"Portrait of " + props.senator.name} />
         {props.senator.factionLeader && <img className='faction-leader' src={FactionLeaderPattern} alt="Faction Leader" width="70"/>}

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -6,7 +6,7 @@ import SenatorName from "../components/Senator/SenatorName";
 import Senator from '../objects/Senator';
 import { useEffect, useState } from "react";
 import axios from "axios";
-import SenatorSummary from "../components/Senator/SenatorSummary";
+import SenatorInspector from "../components/Senator/SenatorInspector";
 
 interface GamePageProps {
   username: string;
@@ -15,7 +15,7 @@ interface GamePageProps {
 const GamePage = (props: GamePageProps) => {
 
   const [senators, setSenators] = useState<Senator[]>([]);
-  const [summaryRef, setSummaryRef] = useState<any>(null);  // Props for the Summary component
+  const [inspectorRef, setInspectorRef] = useState<any>(null);  // Props for the Inspector component
 
   useEffect(() => {
     axios.get("/SampleGame.json").then(response => {
@@ -48,27 +48,27 @@ const GamePage = (props: GamePageProps) => {
               <h2>Examples of the "Senator Name" component</h2>
               <p>
                 Sometimes senators may be referred to by name within a body of text, for example:
-                The leader of the Cyan faction is called <SenatorName senator={senators[7]} setSummaryRef={setSummaryRef} />. This <SenatorName senator={senators[7]} setSummaryRef={setSummaryRef} /> is joined by <SenatorName senator={senators[8]} setSummaryRef={setSummaryRef} />, <SenatorName senator={senators[9]} setSummaryRef={setSummaryRef} />, <SenatorName senator={senators[10]} setSummaryRef={setSummaryRef} /> again, <SenatorName senator={senators[11]} setSummaryRef={setSummaryRef} /> the Censor
-                and <SenatorName senator={senators[12]} setSummaryRef={setSummaryRef} />.
+                The leader of the Cyan faction is called <SenatorName senator={senators[7]} setInspectorRef={setInspectorRef} />. This <SenatorName senator={senators[7]} setInspectorRef={setInspectorRef} /> is joined by <SenatorName senator={senators[8]} setInspectorRef={setInspectorRef} />, <SenatorName senator={senators[9]} setInspectorRef={setInspectorRef} />, <SenatorName senator={senators[10]} setInspectorRef={setInspectorRef} /> again, <SenatorName senator={senators[11]} setInspectorRef={setInspectorRef} /> the Censor
+                and <SenatorName senator={senators[12]} setInspectorRef={setInspectorRef} />.
                 If only I had added more than four senators!</p>
               <p>There are only three senators in the red faction:</p>
               <ul>
-                <li><SenatorName senator={senators[0]} setSummaryRef={setSummaryRef} /></li>
-                <li><SenatorName senator={senators[1]} setSummaryRef={setSummaryRef} /></li>
-                <li><SenatorName senator={senators[2]} setSummaryRef={setSummaryRef} /></li>
+                <li><SenatorName senator={senators[0]} setInspectorRef={setInspectorRef} /></li>
+                <li><SenatorName senator={senators[1]} setInspectorRef={setInspectorRef} /></li>
+                <li><SenatorName senator={senators[2]} setInspectorRef={setInspectorRef} /></li>
               </ul>
-              <p>Some senators, such as <SenatorName senator={senators[21]} setSummaryRef={setSummaryRef} /> and <SenatorName senator={senators[22]} setSummaryRef={setSummaryRef} /> are dead. Others like <SenatorName senator={senators[18]} setSummaryRef={setSummaryRef} /> and <SenatorName senator={senators[19]} setSummaryRef={setSummaryRef} /> are unaligned.</p>
+              <p>Some senators, such as <SenatorName senator={senators[21]} setInspectorRef={setInspectorRef} /> and <SenatorName senator={senators[22]} setInspectorRef={setInspectorRef} /> are dead. Others like <SenatorName senator={senators[18]} setInspectorRef={setInspectorRef} /> and <SenatorName senator={senators[19]} setInspectorRef={setInspectorRef} /> are unaligned.</p>
             <h2>Examples of the "Senator Portrait" component </h2>
             <div className="container">
               {senators.map((senator, index) => <SenatorPortrait 
                 key={index}
                 senator={senator}
-                setSummaryRef={setSummaryRef} /> )}
+                setInspectorRef={setInspectorRef} /> )}
             </div>
           </div>
         }
       </div>
-      {summaryRef && <SenatorSummary {...summaryRef} />}
+      {inspectorRef && <SenatorInspector {...inspectorRef} />}
     </div>
   )
 }


### PR DESCRIPTION
Changes:
- The senator summary is now called the "senator inspector"
- The senator inspector now uses the `dialog` HTML tag
- CSS class names no longer make any reference to the words "portrait" or "summary" :
  - `senator-portrait` is now `figure.senator`
  - `senator-summary` is now `dialog.senator`