### PR TITLE
Add praenomens

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
-        "Fabius",
-        "Valerius"
+        "fabius",
+        "quintus",
+        "valerius"
     ]
 }

--- a/frontend/public/SampleGame.json
+++ b/frontend/public/SampleGame.json
@@ -1,7 +1,7 @@
 {
   "senators": [
     {
-      "praenomen": "l",
+      "praenomen": "lucius",
       "name": "cornelius",
       "alive": true,
       "faction": 1,
@@ -9,149 +9,63 @@
       "majorOffice": "rome consul"
     },
     {
-      "praenomen": "l",
+      "praenomen": "gaius",
       "name": "fabius",
       "alive": true,
       "faction": 1
     },
     {
-      "praenomen": "l",
+      "praenomen": "gaius",
       "name": "valerius",
       "alive": true,
       "faction": 1
     },
     {
-      "praenomen": "l",
+      "praenomen": "titus",
       "name": "julius",
       "alive": true,
       "faction": 2,
       "factionLeader": true
     },
     {
-      "praenomen": "l",
-      "name": "valerius",
+      "praenomen": "lucius",
+      "name": "cornelius",
       "alive": true,
       "faction": 2
     },
     {
-      "praenomen": "l",
-      "name": "valerius",
+      "praenomen": "titus",
+      "name": "fabius",
       "alive": true,
       "faction": 3,
       "factionLeader": true
     },
     {
-      "praenomen": "l",
-      "name": "cornelius",
-      "alive": true,
-      "faction": 3,
-      "factionLeader": false
-    },
-    {
-      "praenomen": "l",
-      "name": "fabius",
-      "alive": true,
-      "faction": 4,
-      "factionLeader": true
-    },
-    {
-      "praenomen": "l",
-      "name": "cornelius",
-      "alive": true,
-      "faction": 4
-    },
-    {
-      "praenomen": "l",
+      "praenomen": "quintus",
       "name": "valerius",
       "alive": true,
-      "faction": 4
+      "faction": 3
     },
     {
-      "praenomen": "l",
-      "name": "cornelius",
-      "alive": true,
-      "faction": 4
-    },
-    {
-      "praenomen": "l",
-      "name": "fabius",
-      "alive": true,
-      "faction": 4,
-      "majorOffice": "censor"
-    },
-    {
-      "praenomen": "l",
+      "praenomen": "lucius",
       "name": "julius",
       "alive": true,
-      "faction": 4
+      "faction": 4,
+      "factionLeader": true
     },
     {
-      "praenomen": "l",
-      "name": "valerius",
+      "praenomen": "quintus",
+      "name": "fabius",
       "alive": true,
       "faction": 5,
       "factionLeader": true
     },
     {
-      "praenomen": "l",
-      "name": "fabius",
-      "alive": true,
-      "faction": 5
-    },
-    {
-      "praenomen": "l",
+      "praenomen": "lucius",
       "name": "valerius",
       "alive": true,
       "faction": 6,
       "factionLeader": true
-    },
-    {
-      "praenomen": "l",
-      "name": "cornelius",
-      "alive": true,
-      "faction": 6
-    },
-    {
-      "praenomen": "l",
-      "name": "julius",
-      "alive": true,
-      "faction": 6,
-      "majorOffice": "field consul"
-    },
-    {
-      "praenomen": "l",
-      "name": "cornelius",
-      "alive": true
-    },
-    {
-      "praenomen": "l",
-      "name": "fabius",
-      "alive": true
-    },
-    {
-      "praenomen": "l",
-      "name": "valerius",
-      "alive": true
-    },
-    {
-      "praenomen": "l",
-      "name": "julius",
-      "alive": false
-    },
-    {
-      "praenomen": "l",
-      "name": "fabius",
-      "alive": false
-    },
-    {
-      "praenomen": "l",
-      "name": "cornelius",
-      "alive": false
-    },
-    {
-      "praenomen": "l",
-      "name": "julius",
-      "alive": false
     }
   ]
 }

--- a/frontend/public/SampleGame.json
+++ b/frontend/public/SampleGame.json
@@ -1,6 +1,7 @@
 {
   "senators": [
     {
+      "praenomen": "l",
       "name": "cornelius",
       "alive": true,
       "faction": 1,
@@ -8,123 +9,147 @@
       "majorOffice": "rome consul"
     },
     {
+      "praenomen": "l",
       "name": "fabius",
       "alive": true,
       "faction": 1
     },
     {
+      "praenomen": "l",
       "name": "valerius",
       "alive": true,
       "faction": 1
     },
     {
+      "praenomen": "l",
       "name": "julius",
       "alive": true,
       "faction": 2,
       "factionLeader": true
     },
     {
+      "praenomen": "l",
       "name": "valerius",
       "alive": true,
       "faction": 2
     },
     {
+      "praenomen": "l",
       "name": "valerius",
       "alive": true,
       "faction": 3,
       "factionLeader": true
     },
     {
+      "praenomen": "l",
       "name": "cornelius",
       "alive": true,
       "faction": 3,
       "factionLeader": false
     },
     {
+      "praenomen": "l",
       "name": "fabius",
       "alive": true,
       "faction": 4,
       "factionLeader": true
     },
     {
+      "praenomen": "l",
       "name": "cornelius",
       "alive": true,
       "faction": 4
     },
     {
+      "praenomen": "l",
       "name": "valerius",
       "alive": true,
       "faction": 4
     },
     {
+      "praenomen": "l",
       "name": "cornelius",
       "alive": true,
       "faction": 4
     },
     {
+      "praenomen": "l",
       "name": "fabius",
       "alive": true,
       "faction": 4,
       "majorOffice": "censor"
     },
     {
+      "praenomen": "l",
       "name": "julius",
       "alive": true,
       "faction": 4
     },
     {
+      "praenomen": "l",
       "name": "valerius",
       "alive": true,
       "faction": 5,
       "factionLeader": true
     },
     {
+      "praenomen": "l",
       "name": "fabius",
       "alive": true,
       "faction": 5
     },
     {
+      "praenomen": "l",
       "name": "valerius",
       "alive": true,
       "faction": 6,
       "factionLeader": true
     },
     {
+      "praenomen": "l",
       "name": "cornelius",
       "alive": true,
       "faction": 6
     },
     {
+      "praenomen": "l",
       "name": "julius",
       "alive": true,
       "faction": 6,
       "majorOffice": "field consul"
     },
     {
+      "praenomen": "l",
       "name": "cornelius",
       "alive": true
     },
     {
+      "praenomen": "l",
       "name": "fabius",
       "alive": true
     },
     {
+      "praenomen": "l",
       "name": "valerius",
       "alive": true
     },
     {
+      "praenomen": "l",
       "name": "julius",
       "alive": false
     },
     {
+      "praenomen": "l",
       "name": "fabius",
       "alive": false
     },
     {
+      "praenomen": "l",
       "name": "cornelius",
       "alive": false
     },
     {
+      "praenomen": "l",
       "name": "julius",
       "alive": false
     }

--- a/frontend/src/components/Senator/SenatorInspector.tsx
+++ b/frontend/src/components/Senator/SenatorInspector.tsx
@@ -3,6 +3,7 @@ import Senator from "../../objects/Senator";
 import MajorOfficeIcon from "./MajorOfficeIcon";
 import "./SenatorInspector.css";
 import SenatorPortrait from "./SenatorPortrait";
+import GetPraenomenAbbr from "../../helpers/PraenomenHelper";
 
 interface SenatorInspectorProps {
   instance: Senator;
@@ -92,7 +93,7 @@ const SenatorInspector = (props: SenatorInspectorProps) => {
         </div>
       }
       <div className="title">
-        <h1>{props.instance.name}</h1>
+        <h1>{GetPraenomenAbbr(props.instance.praenomen)} {props.instance.name}</h1>
       </div>
       <div className="content">
         {getFaction()}

--- a/frontend/src/helpers/PraenomenHelper.ts
+++ b/frontend/src/helpers/PraenomenHelper.ts
@@ -1,0 +1,14 @@
+import Praenomen from "../types/Praenomen";
+
+const abbreviations = {
+    "gaius": "c",
+    "lucius": "l",
+    "quintus": "q",
+    "titus": "t"
+}
+
+const getPraenomenAbbr = (praenomen: Praenomen) => {
+    return abbreviations[praenomen] + "."
+}
+
+export default getPraenomenAbbr;

--- a/frontend/src/objects/Senator.ts
+++ b/frontend/src/objects/Senator.ts
@@ -2,10 +2,12 @@ import MajorOffice from "../types/MajorOffice";
 import Faction from "../types/Faction";
 import Colors from "../data/Colors.json";
 import FactionNames from "../data/FactionNames.json";
+import Praenomen from "../types/Praenomen";
 
 type Name = 'cornelius' | 'fabius' | 'valerius' | 'julius';
 
 class Senator {
+  praenomen: Praenomen;
   name: Name;
   alive: boolean;
   faction: Faction;
@@ -13,12 +15,14 @@ class Senator {
   majorOffice: MajorOffice;
 
   constructor(
+    praenomen: Praenomen,
     name: Name,
     alive: boolean,
     faction: Faction,
     factionLeader: boolean,
     majorOffice: MajorOffice,
   ) {
+    this.praenomen = praenomen;
     this.name = name;
     this.alive = alive;
     this.faction = faction;

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -23,6 +23,7 @@ const GamePage = (props: GamePageProps) => {
       let senators: Senator[] = [];
       for (let i = 0; i < objects.length; i++) {
         const senator: Senator = new Senator(
+          objects[i].praenomen,
           objects[i].name,
           objects[i].alive,
           objects[i].faction,
@@ -39,34 +40,28 @@ const GamePage = (props: GamePageProps) => {
     <div id="page_container">
       <TopBar username={props.username} />
       <div id="wide_page">
-        {senators.length > 0 &&
           <div id="page_content">
-            <h1>Republic of Rome Online</h1>
-            <div>
-              <Link to="/">Back to Main Menu</Link>
-            </div>
-              <h2>Examples of the "Senator Name" component</h2>
-              <p>
-                Sometimes senators may be referred to by name within a body of text, for example:
-                The leader of the Cyan faction is called <SenatorName senator={senators[7]} setInspectorRef={setInspectorRef} />. This <SenatorName senator={senators[7]} setInspectorRef={setInspectorRef} /> is joined by <SenatorName senator={senators[8]} setInspectorRef={setInspectorRef} />, <SenatorName senator={senators[9]} setInspectorRef={setInspectorRef} />, <SenatorName senator={senators[10]} setInspectorRef={setInspectorRef} /> again, <SenatorName senator={senators[11]} setInspectorRef={setInspectorRef} /> the Censor
-                and <SenatorName senator={senators[12]} setInspectorRef={setInspectorRef} />.
-                If only I had added more than four senators!</p>
-              <p>There are only three senators in the red faction:</p>
-              <ul>
-                <li><SenatorName senator={senators[0]} setInspectorRef={setInspectorRef} /></li>
-                <li><SenatorName senator={senators[1]} setInspectorRef={setInspectorRef} /></li>
-                <li><SenatorName senator={senators[2]} setInspectorRef={setInspectorRef} /></li>
-              </ul>
-              <p>Some senators, such as <SenatorName senator={senators[21]} setInspectorRef={setInspectorRef} /> and <SenatorName senator={senators[22]} setInspectorRef={setInspectorRef} /> are dead. Others like <SenatorName senator={senators[18]} setInspectorRef={setInspectorRef} /> and <SenatorName senator={senators[19]} setInspectorRef={setInspectorRef} /> are unaligned.</p>
-            <h2>Examples of the "Senator Portrait" component </h2>
-            <div className="container">
-              {senators.map((senator, index) => <SenatorPortrait 
-                key={index}
-                senator={senator}
-                setInspectorRef={setInspectorRef} /> )}
-            </div>
+            <h1>Some UI components</h1>
+            <Link to="/">Back to Main Menu</Link>
+            {senators.length > 0 &&
+              <div>
+                <h2>Senator names</h2>
+                <ul>
+                  {senators.map((senator, index) =>
+                    <li key={index}>
+                      Senator {index + 1}: <SenatorName senator={senator} setInspectorRef={setInspectorRef} />
+                    </li>
+                  )}
+                </ul>
+                <h2>Senator portraits</h2>
+                <div className="container">
+                  {senators.map((senator, index) =>
+                    <SenatorPortrait key={index} senator={senator} setInspectorRef={setInspectorRef} />
+                  )}
+                </div>
+              </div>
+            }
           </div>
-        }
       </div>
       {inspectorRef && <SenatorInspector {...inspectorRef} />}
     </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -20,7 +20,7 @@ const Home = (props: HomeProps) => {
             <h3>Play:</h3>
             <div><Link to="/join-game">Join Game</Link></div>
             <div><Link to="/#">Create Game</Link></div>
-            <div><Link to="/game">Mock User Interface</Link></div>
+            <div><Link to="/game">Some UI components</Link></div>
           </div>
         </div>
       </div>

--- a/frontend/src/types/Praenomen.ts
+++ b/frontend/src/types/Praenomen.ts
@@ -1,0 +1,3 @@
+type Praenomen = 'gaius' | 'lucius' | 'quintus' | 'titus';
+
+export default Praenomen;


### PR DESCRIPTION
The purpose behind adding praenomens is to differentiate between living and dead senators of the same family.