### PR TITLE
Make the account button width dynamic

### DIFF
--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -24,7 +24,7 @@
   flex-wrap: wrap;
 }
 
-@media (max-width: 850px) {
+@media (max-width: 975px) {
   .top-bar {
     flex-direction: column;
   }

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -26,12 +26,12 @@ const TopBar = (props: TopBarProps) => {
       <Link to="/" className="no-decor inherit-color" ><h1>Republic of Rome Online</h1></Link>
       {props.username ?
         <nav aria-label="User Navigation">
-          <Link to="/account" className="button inherit-color" style={{width: "130px"}} aria-label="Your Account">
+          <Link to="/account" className="button inherit-color" style={{padding: "0 10px", maxWidth: "300px"}} aria-label="Your Account">
             <FontAwesomeIcon icon={faUser} style={{ marginRight: "10px" }} />
             <span className="sr-only">User: </span>
-            {props.username}
+            <span className="overflow-ellipsis">{props.username}</span>
           </Link>
-          <button onClick={handleSignOut} className="button" style={{width: "80px"}}>Sign out</button>
+          <button onClick={handleSignOut} className="button" style={{width: "85px"}}>Sign out</button>
         </nav>
         :
         <nav aria-label="User Navigation">

--- a/frontend/src/css/master.css
+++ b/frontend/src/css/master.css
@@ -47,6 +47,11 @@ input, button, textarea {
   text-transform: capitalize;
 }
 
+.overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Prevent users from highlighting text */
 .no-highlight {
   -webkit-touch-callout: none;  /* iOS Safari */


### PR DESCRIPTION
Closes #50

Make the account button width dynamic by implementing a new CSS class for text overflow that uses ellipsis. This change fixes a UI bug where the username could overflow from the account button.

Also update the media `max-width` breakpoint for the top bar to accommodate the max possible width of the account button.