### PR TITLE
Add a context provider for auth members

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,47 +21,13 @@ import SignInDialog from "./dialogs/SignInDialog";
 import SignOutDialog from "./dialogs/SignOutDialog";
 import DialogBackdrop from "./dialogs/DialogBackdrop";
 import GameCreatePage from "./pages/GameCreatePage";
-
-interface AuthData {
-  accessToken: string,
-  refreshToken: string,
-  username: string
-}
+import useLocalStorage from "./helpers/useLocalStorage";
 
 const App = () => {
-  const [accessToken, setAccessToken] = useState<string>(localStorage.getItem('accessToken') || '');
-  const [refreshToken, setRefreshToken] = useState<string>(localStorage.getItem('refreshToken') || '');
-  const [username, setUsername] = useState<string>(localStorage.getItem('username') || '');
+  const [accessToken, setAccessToken] = useLocalStorage<string>('accessToken', '');
+  const [refreshToken, setRefreshToken] = useLocalStorage<string>('refreshToken', '');
+  const [username, setUsername] = useLocalStorage<string>('username', '');
   const [dialog, setDialog] = useState<string>('');
-
-  /**
-   * Sets any of these auth values: `accessToken`, `refreshToken`, `username`.
-   * Values are saved to both the `App` state and local storage
-   * @param {Object} data the key-value pairs to set
-   */
-  const setAuthData = (data: AuthData) => {
-    if (data.accessToken === '') {
-      setAccessToken('');
-      localStorage.setItem('accessToken', '');
-    } else if (data.accessToken) {
-      setAccessToken(data.accessToken);
-      localStorage.setItem('accessToken', data.accessToken);
-    }
-    if (data.refreshToken === '') {
-      setRefreshToken('');
-      localStorage.setItem('refreshToken', '');
-    } else if (data.refreshToken) {
-      setRefreshToken(data.refreshToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
-    }
-    if (data.username === '') {
-      setUsername('');
-      localStorage.setItem('username', '');
-    } else if (data.username) {
-      setUsername(data.username);
-      localStorage.setItem('username', data.username);
-    }
-  }
 
   return (
     <BrowserRouter>
@@ -80,14 +46,18 @@ const App = () => {
             : <GameListPage
               accessToken={accessToken}
               refreshToken={refreshToken}
-              setAuthData={setAuthData} />} />
+              setAccessToken={setAccessToken}
+              setRefreshToken={setRefreshToken}
+              setUsername={setUsername} />} />
 
           <Route path="game-create" element={username === ""
             ? <Navigate to='/' />
             : <GameCreatePage
               accessToken={accessToken}
               refreshToken={refreshToken}
-              setAuthData={setAuthData} />} />
+              setAccessToken={setAccessToken}
+              setRefreshToken={setRefreshToken}
+              setUsername={setUsername} />} />
 
           <Route path="account" element={username === ""
             ? <Navigate to='/' />
@@ -95,16 +65,26 @@ const App = () => {
               username={username}
               accessToken={accessToken}
               refreshToken={refreshToken}
-              setAuthData={setAuthData} />} />
+              setAccessToken={setAccessToken}
+              setRefreshToken={setRefreshToken}
+              setUsername={setUsername} />} />
         </Routes>
         {dialog !== "" &&
           <DialogBackdrop setDialog={setDialog} />
         }
         {dialog === "sign-in" &&
-          <SignInDialog setAuthData={setAuthData} setDialog={setDialog} />
+          <SignInDialog
+            setAccessToken={setAccessToken}
+            setRefreshToken={setRefreshToken}
+            setUsername={setUsername}
+            setDialog={setDialog} />
         }
         {dialog === "sign-out" &&
-          <SignOutDialog setAuthData={setAuthData} setDialog={setDialog} />
+          <SignOutDialog
+            setAccessToken={setAccessToken}
+            setRefreshToken={setRefreshToken}
+            setUsername={setUsername}
+            setDialog={setDialog} />
         }
       </div>
   </BrowserRouter>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,21 +21,19 @@ import SignInDialog from "./dialogs/SignInDialog";
 import SignOutDialog from "./dialogs/SignOutDialog";
 import DialogBackdrop from "./dialogs/DialogBackdrop";
 import GameCreatePage from "./pages/GameCreatePage";
-import useLocalStorage from "./helpers/useLocalStorage";
+import { useAuth } from './AuthContext';
 
 const App = () => {
-  const [accessToken, setAccessToken] = useLocalStorage<string>('accessToken', '');
-  const [refreshToken, setRefreshToken] = useLocalStorage<string>('refreshToken', '');
-  const [username, setUsername] = useLocalStorage<string>('username', '');
   const [dialog, setDialog] = useState<string>('');
+  const { username } = useAuth();
 
   return (
     <BrowserRouter>
       <div id="page_container">
-        <TopBar username={username} setDialog={setDialog} />
+        <TopBar setDialog={setDialog} />
         <Routes>
           <Route index element={
-            <Home username={username} />} />
+            <Home />} />
 
           <Route path="game" element={username === ""
             ? <Navigate to='/' />
@@ -43,51 +41,27 @@ const App = () => {
 
           <Route path="game-list" element={username === ""
             ? <Navigate to='/' />
-            : <GameListPage
-              accessToken={accessToken}
-              refreshToken={refreshToken}
-              setAccessToken={setAccessToken}
-              setRefreshToken={setRefreshToken}
-              setUsername={setUsername} />} />
+            : <GameListPage />} />
 
           <Route path="game-create" element={username === ""
             ? <Navigate to='/' />
-            : <GameCreatePage
-              accessToken={accessToken}
-              refreshToken={refreshToken}
-              setAccessToken={setAccessToken}
-              setRefreshToken={setRefreshToken}
-              setUsername={setUsername} />} />
+            : <GameCreatePage />} />
 
           <Route path="account" element={username === ""
             ? <Navigate to='/' />
-            : <AccountPage
-              username={username}
-              accessToken={accessToken}
-              refreshToken={refreshToken}
-              setAccessToken={setAccessToken}
-              setRefreshToken={setRefreshToken}
-              setUsername={setUsername} />} />
+            : <AccountPage />} />
         </Routes>
         {dialog !== "" &&
           <DialogBackdrop setDialog={setDialog} />
         }
         {dialog === "sign-in" &&
-          <SignInDialog
-            setAccessToken={setAccessToken}
-            setRefreshToken={setRefreshToken}
-            setUsername={setUsername}
-            setDialog={setDialog} />
+          <SignInDialog setDialog={setDialog} />
         }
         {dialog === "sign-out" &&
-          <SignOutDialog
-            setAccessToken={setAccessToken}
-            setRefreshToken={setRefreshToken}
-            setUsername={setUsername}
-            setDialog={setDialog} />
+          <SignOutDialog setDialog={setDialog} />
         }
       </div>
-  </BrowserRouter>
+    </BrowserRouter>
   )
 }
 

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext } from 'react';
+import useLocalStorage from './helpers/useLocalStorage';
+
+interface AuthContextType {
+  accessToken: string;
+  refreshToken: string;
+  username: string;
+  setAccessToken: (value: string) => void;
+  setRefreshToken: (value: string) => void;
+  setUsername: (value: string) => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export const AuthProvider = ({ children }: React.PropsWithChildren<{}>) => {
+  const [accessToken, setAccessToken] = useLocalStorage<string>('accessToken', '');
+  const [refreshToken, setRefreshToken] = useLocalStorage<string>('refreshToken', '');
+  const [username, setUsername] = useLocalStorage<string>('username', '');
+
+  return (
+    <AuthContext.Provider
+      value={{
+        accessToken,
+        refreshToken,
+        username,
+        setAccessToken,
+        setRefreshToken,
+        setUsername,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,9 +2,9 @@ import "./TopBar.css";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faUser } from '@fortawesome/free-solid-svg-icons'
+import { useAuth } from "../AuthContext";
 
 interface TopBarProps {
-  username: string,
   setDialog: Function
 }
 
@@ -12,6 +12,7 @@ interface TopBarProps {
  * The component at the top of the page containing the "Republic of Rome Online" title
  */
 const TopBar = (props: TopBarProps) => {
+  const { username } = useAuth();
   
   const handleSignIn = () => {
     props.setDialog('sign-in')
@@ -24,12 +25,12 @@ const TopBar = (props: TopBarProps) => {
   return (
     <header className="top-bar" role="banner" aria-label="Website Header">
       <Link to="/" className="no-decor inherit-color" ><h1>Republic of Rome Online</h1></Link>
-      {props.username ?
+      {username ?
         <nav aria-label="User Navigation">
           <Link to="/account" className="button inherit-color" style={{padding: "0 10px", maxWidth: "300px"}} aria-label="Your Account">
             <FontAwesomeIcon icon={faUser} style={{ marginRight: "10px" }} />
             <span className="sr-only">User: </span>
-            <span className="no-wrap-ellipsis">{props.username}</span>
+            <span className="no-wrap-ellipsis">{username}</span>
           </Link>
           <button onClick={handleSignOut} className="button" style={{width: "85px"}}>Sign out</button>
         </nav>

--- a/frontend/src/dialogs/SignInDialog.tsx
+++ b/frontend/src/dialogs/SignInDialog.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import axios from "axios";
 
 interface SignInDialogProps {
-  setAuthData: Function,
-  setDialog: Function
+  setDialog: Function,
+  setAccessToken: Function,
+  setRefreshToken: Function,
+  setUsername: Function
 }
 
 /**
@@ -84,11 +86,9 @@ const SignInDialog = (props: SignInDialogProps) => {
 
     } else if (result === 'success' && response) {
       // If the sign in request succeeded, set the username and JWT tokens
-      props.setAuthData({
-        accessToken: response.data.access,
-        refreshToken: response.data.refresh,
-        username: identity
-      });
+      props.setAccessToken(response.data.access);
+      props.setRefreshToken(response.data.refresh);
+      props.setUsername(identity);
       props.setDialog('')
     }
   }

--- a/frontend/src/dialogs/SignInDialog.tsx
+++ b/frontend/src/dialogs/SignInDialog.tsx
@@ -1,18 +1,16 @@
 import { useState } from 'react';
 import axios from "axios";
+import { useAuth } from '../AuthContext';
 
 interface SignInDialogProps {
-  setDialog: Function,
-  setAccessToken: Function,
-  setRefreshToken: Function,
-  setUsername: Function
+  setDialog: Function
 }
 
 /**
  * The component for the sign in form for existing users
  */
 const SignInDialog = (props: SignInDialogProps) => {
-
+  const { setAccessToken, setRefreshToken, setUsername } = useAuth();
   const [identity, setIdentity] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [feedback, setFeedback] = useState<string>('');
@@ -86,9 +84,9 @@ const SignInDialog = (props: SignInDialogProps) => {
 
     } else if (result === 'success' && response) {
       // If the sign in request succeeded, set the username and JWT tokens
-      props.setAccessToken(response.data.access);
-      props.setRefreshToken(response.data.refresh);
-      props.setUsername(identity);
+      setAccessToken(response.data.access);
+      setRefreshToken(response.data.refresh);
+      setUsername(identity);
       props.setDialog('')
     }
   }

--- a/frontend/src/dialogs/SignOutDialog.tsx
+++ b/frontend/src/dialogs/SignOutDialog.tsx
@@ -1,17 +1,17 @@
+import { useAuth } from "../AuthContext";
+
 interface SignOutDialogProps {
-  setDialog: Function,
-  setAccessToken: Function,
-  setRefreshToken: Function,
-  setUsername: Function
+  setDialog: Function
 }
 
 const SignOutDialog = (props: SignOutDialogProps) => {
+  const { setAccessToken, setRefreshToken, setUsername } = useAuth();
 
   const handleSubmit = () => {
     // Clear auth data
-    props.setAccessToken('');
-    props.setRefreshToken('');
-    props.setUsername('');
+    setAccessToken('');
+    setRefreshToken('');
+    setUsername('');
     props.setDialog('')
   }
 

--- a/frontend/src/dialogs/SignOutDialog.tsx
+++ b/frontend/src/dialogs/SignOutDialog.tsx
@@ -1,17 +1,17 @@
 interface SignOutDialogProps {
-  setAuthData: Function,
-  setDialog: Function
+  setDialog: Function,
+  setAccessToken: Function,
+  setRefreshToken: Function,
+  setUsername: Function
 }
 
 const SignOutDialog = (props: SignOutDialogProps) => {
 
   const handleSubmit = () => {
     // Clear auth data
-    props.setAuthData({
-      accessToken: '',
-      refreshToken: '',
-      username: ''
-    });
+    props.setAccessToken('');
+    props.setRefreshToken('');
+    props.setUsername('');
     props.setDialog('')
   }
 

--- a/frontend/src/helpers/requestHelper.ts
+++ b/frontend/src/helpers/requestHelper.ts
@@ -4,9 +4,11 @@ import axios from "axios";
  * Makes a request to the backend API using JWT authentication tokens.
  * @param {string} method HTTP method
  * @param {string} path the URL path
- * @param {string} accessToken the current JWT access token
- * @param {string} refreshToken the current JWT refresh token
- * @param {Function} setAuthData the function used to save a new access token
+ * @param {string} accessToken the access token
+ * @param {string} refreshToken the refresh token
+ * @param {Function} setAccessToken the function used to set the access token
+ * @param {Function} setRefreshToken the function used to set the refresh token
+ * @param {Function} setUsername the function used to set the username
  * @returns the response
  */
 export default async function request(
@@ -14,7 +16,9 @@ export default async function request(
   path: string,
   accessToken: string,
   refreshToken: string,
-  setAuthData: Function,
+  setAccessToken: Function,
+  setRefreshToken: Function,
+  setUsername: Function,
   data: object | null = null
 ) {
   const baseUrl = process.env.REACT_APP_BACKEND_ORIGIN + '/rorapp/api/';
@@ -51,17 +55,14 @@ export default async function request(
   } catch (error) {
 
     // If the request for a new access token fails, sign the user out
-    setAuthData({
-      accessToken: '',
-      refreshToken: '',
-      username: ''
-    });
+    setAccessToken('');
+    setRefreshToken('');
+    setUsername('');
     return;
   }
 
   // If the request for a new access token succeeds, save it
-  accessToken = refreshResponse.data.access;
-  setAuthData({ accessToken: accessToken });
+  setAccessToken(refreshResponse.data.access);
 
   // Retry the original request using the new access token
   try {

--- a/frontend/src/helpers/useLocalStorage.ts
+++ b/frontend/src/helpers/useLocalStorage.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+const useLocalStorage = <T>(key: string, initialValue: T): [T, React.Dispatch<React.SetStateAction<T>>] => {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      if (storedValue === "") {
+        window.localStorage.removeItem(key);
+      } else {
+        const serializedValue = JSON.stringify(storedValue);
+        window.localStorage.setItem(key, serializedValue);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue];
+}
+
+export default useLocalStorage;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { AuthProvider } from './AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );
 

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -5,8 +5,10 @@ import { Link } from 'react-router-dom';
 interface AccountPageProps {
   accessToken: string,
   refreshToken: string,
-  username: string
-  setAuthData: Function
+  username: string,
+  setAccessToken: Function,
+  setRefreshToken: Function,
+  setUsername: Function
 }
 
 /**
@@ -18,13 +20,13 @@ const AccountPage = (props: AccountPageProps) => {
   useEffect(() => {
     // Get the current user's email
     const fetchData = async () => {
-      const response = await request('GET', 'user/detail/', props.accessToken, props.refreshToken, props.setAuthData);
+      const response = await request('GET', 'user/detail/', props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername);
       if (response) {
         setEmail(response.data.email);
       }
     }
     fetchData();
-  }, [props.accessToken, props.refreshToken, props.setAuthData]);
+  }, [props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername]);
 
   return (
     <main id="standard_page" aria-labelledby="page-title">

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -1,32 +1,25 @@
 import { useEffect, useState } from 'react';
 import request from "../helpers/requestHelper"
 import { Link } from 'react-router-dom';
-
-interface AccountPageProps {
-  accessToken: string,
-  refreshToken: string,
-  username: string,
-  setAccessToken: Function,
-  setRefreshToken: Function,
-  setUsername: Function
-}
+import { useAuth } from '../AuthContext';
 
 /**
  * The component for the account page
  */
-const AccountPage = (props: AccountPageProps) => {
+const AccountPage = () => {
+  const { accessToken, refreshToken, username, setAccessToken, setRefreshToken, setUsername } = useAuth();
   const [email, setEmail] = useState<string>();
 
   useEffect(() => {
     // Get the current user's email
     const fetchData = async () => {
-      const response = await request('GET', 'user/detail/', props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername);
+      const response = await request('GET', 'user/detail/', accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername);
       if (response) {
         setEmail(response.data.email);
       }
     }
     fetchData();
-  }, [props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername]);
+  }, [accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername]);
 
   return (
     <main id="standard_page" aria-labelledby="page-title">
@@ -43,7 +36,7 @@ const AccountPage = (props: AccountPageProps) => {
             <thead>
               <tr>
                 <th scope="row">Username</th>
-                <td>{props.username}</td>
+                <td>{username}</td>
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/GameCreatePage.tsx
+++ b/frontend/src/pages/GameCreatePage.tsx
@@ -1,16 +1,10 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import request from "../helpers/requestHelper";
+import { useAuth } from "../AuthContext";
 
-interface GameCreatePageProps {
-  accessToken: string,
-  refreshToken: string,
-  setAccessToken: Function,
-  setRefreshToken: Function,
-  setUsername: Function
-}
-
-const GameCreatePage = (props: GameCreatePageProps) => {
+const GameCreatePage = () => {
+  const { accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername } = useAuth();
   const [name, setName] = useState<string>('');
   const [nameFeedback, setNameFeedback] = useState<string>('');
   const [description, setDescription] = useState<string>('');
@@ -33,7 +27,7 @@ const GameCreatePage = (props: GameCreatePageProps) => {
       description: description
     }
 
-    const response = await request('POST', 'games/', props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername, gameData);
+    const response = await request('POST', 'games/', accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername, gameData);
     if (response) {
       if (response.status === 201) {
         navigate('/game-list');

--- a/frontend/src/pages/GameCreatePage.tsx
+++ b/frontend/src/pages/GameCreatePage.tsx
@@ -5,7 +5,9 @@ import request from "../helpers/requestHelper";
 interface GameCreatePageProps {
   accessToken: string,
   refreshToken: string,
-  setAuthData: Function
+  setAccessToken: Function,
+  setRefreshToken: Function,
+  setUsername: Function
 }
 
 const GameCreatePage = (props: GameCreatePageProps) => {
@@ -31,7 +33,7 @@ const GameCreatePage = (props: GameCreatePageProps) => {
       description: description
     }
 
-    const response = await request('POST', 'games/', props.accessToken, props.refreshToken, props.setAuthData, gameData);
+    const response = await request('POST', 'games/', props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername, gameData);
     if (response) {
       if (response.status === 201) {
         navigate('/game-list');

--- a/frontend/src/pages/GameListPage.tsx
+++ b/frontend/src/pages/GameListPage.tsx
@@ -3,19 +3,13 @@ import { Link } from "react-router-dom";
 import request from "../helpers/requestHelper"
 import Game from "../objects/Game"
 import formatDate from '../helpers/dateHelper';
-
-interface GameListPageProps {
-  accessToken: string,
-  refreshToken: string,
-  setAccessToken: Function,
-  setRefreshToken: Function,
-  setUsername: Function
-}
+import { useAuth } from '../AuthContext';
 
 /**
  * The component for the join game page
  */
-const GameListPage = (props: GameListPageProps) => {
+const GameListPage = () => {
+  const { accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername } = useAuth();
   const [gameList, setGameList] = useState<Game[]>([]);
   const [elapsedMinutes, setElapsedMinutes] = useState(0);
   const [refreshPending, setRefreshPending] = useState<boolean>(false);
@@ -33,7 +27,7 @@ const GameListPage = (props: GameListPageProps) => {
 
   // Refresh the game list
   const refreshGame = useCallback(async () => {
-    const response = await request('GET', 'games/', props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername);
+    const response = await request('GET', 'games/', accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername);
     if (response && response.data) {
       let games: Game[] = [];
       for (let i = 0; i < response.data.length; i++) {
@@ -56,7 +50,7 @@ const GameListPage = (props: GameListPageProps) => {
   
       setGameList(games);
     }
-  }, [props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername]);
+  }, [accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername]);
 
   // On page load, refresh the game list because it's initially empty
   useEffect(() => {

--- a/frontend/src/pages/GameListPage.tsx
+++ b/frontend/src/pages/GameListPage.tsx
@@ -7,7 +7,9 @@ import formatDate from '../helpers/dateHelper';
 interface GameListPageProps {
   accessToken: string,
   refreshToken: string,
-  setAuthData: Function
+  setAccessToken: Function,
+  setRefreshToken: Function,
+  setUsername: Function
 }
 
 /**
@@ -31,7 +33,7 @@ const GameListPage = (props: GameListPageProps) => {
 
   // Refresh the game list
   const refreshGame = useCallback(async () => {
-    const response = await request('GET', 'games/', props.accessToken, props.refreshToken, props.setAuthData);
+    const response = await request('GET', 'games/', props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername);
     if (response && response.data) {
       let games: Game[] = [];
       for (let i = 0; i < response.data.length; i++) {
@@ -54,7 +56,7 @@ const GameListPage = (props: GameListPageProps) => {
   
       setGameList(games);
     }
-  }, [props.accessToken, props.refreshToken, props.setAuthData]);
+  }, [props.accessToken, props.refreshToken, props.setAccessToken, props.setRefreshToken, props.setUsername]);
 
   // On page load, refresh the game list because it's initially empty
   useEffect(() => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,13 +1,12 @@
 import { Link } from "react-router-dom";
-
-interface HomeProps {
-  username: string
-}
+import { useAuth } from "../AuthContext";
 
 /**
  * The component for the home page
  */
-const Home = (props: HomeProps) => {
+const Home = () => {
+  const { username } = useAuth();
+
   return (
     <main id="standard_page" aria-label="Home Page">
       <section aria-labelledby="page-title">
@@ -20,7 +19,7 @@ const Home = (props: HomeProps) => {
         <p>Welcome to Republic of Rome Online! We're in the early stages of developing this fan-made online adaptation of the classic strategy board game <a href="https://boardgamegeek.com/boardgame/1513/republic-rome" className="link">Republic of Rome</a>. User registration is currently closed as we work to create an immersive Ancient Rome experience. Stay tuned for updates and the opening of user registration. Thank you for your interest!</p>
       </section>
 
-      {props.username &&
+      {username &&
       <section aria-labelledby="features">
         <h3 id="features">Exclusive Features</h3>
         <p>As a logged-in user, you can now discover and explore existing features and demos.</p>


### PR DESCRIPTION
Resolve #66.

Remove the `setAuthData` method, isolating the auth members (values and setters) as preparation for their transfer into a React context provider. Standardize auth states by wrapping them in the `useLocalStorage` method to reduce code repetition.

Move the auth members into a context provider and wrap the entire application in the provider. Refactor every component that already accessed auth members to do so using the provider's `useAuth` method, eliminating the need for auth members to be passed down the component tree as props.