### PR TITLE
Make the README link to BGG instead of Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Republic of Rome Online
 
-A fan-made online adaption of a board game called [The Republic of Rome](https://en.wikipedia.org/wiki/Republic_of_Rome_(game)). Currently in early development. The production version of this site can be found at [www.roronline.com](https://www.roronline.com). For more info, check out the [wiki](https://github.com/iamlogand/republic-of-rome-online/wiki).
+A fan-made online adaption of a board game called [The Republic of Rome](https://boardgamegeek.com/boardgame/1513/republic-rome). Currently in early development. The production version of this site can be found at [www.roronline.com](https://www.roronline.com). For more info, check out the [wiki](https://github.com/iamlogand/republic-of-rome-online/wiki).

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -16,7 +16,7 @@ const Home = () => {
       
       <section aria-labelledby="notice">
         <h3 id="notice">Early Development Notice</h3>
-        <p>Welcome to Republic of Rome Online! We're in the early stages of developing this fan-made online adaptation of the classic strategy board game <a href="https://boardgamegeek.com/boardgame/1513/republic-rome" className="link">Republic of Rome</a>. User registration is currently closed as we work to create an immersive Ancient Rome experience. Stay tuned for updates and the opening of user registration. Thank you for your interest!</p>
+        <p>Welcome to Republic of Rome Online! We're in the early stages of developing this fan-made online adaptation of the classic strategy board game <a href="https://boardgamegeek.com/boardgame/1513/republic-rome" className="link">The Republic of Rome</a>. User registration is currently closed as we work to create an immersive Ancient Rome experience. Stay tuned for updates and the opening of user registration. Thank you for your interest!</p>
       </section>
 
       {username &&


### PR DESCRIPTION
Make the README link to Board Game Geek (BGG) instead of Wikipedia because BGG is more interesting. Also fix the reference to the name of the original game in the home page by appending the "The".