### PR TITLE
Refactor frontend - add page wrapper

### DIFF
--- a/frontend/components/PageWrapper.tsx
+++ b/frontend/components/PageWrapper.tsx
@@ -1,0 +1,29 @@
+import { useAuthContext } from "@/contexts/AuthContext";
+import { useModalContext } from "@/contexts/ModalContext";
+import { ReactNode, useEffect } from "react";
+
+interface PageWrapperProps {
+  children: ReactNode;
+  pageStatus: number | null;
+  setPageStatus: Function;
+  ref: any
+}
+
+// Wraps the top bar, page content and footer
+const PageWrapper = (props: PageWrapperProps) => {
+  const { username } = useAuthContext();
+  const { setModal } = useModalContext();
+
+  // Ensure that the sign in modal appears immediately after a 401 with a forced sign out
+  // This gives the user an opportunity to sign in and continue at that address
+  useEffect(() => {
+    if (props.pageStatus == 401 && username == '') {
+      setModal("sign-in-required");
+      props.setPageStatus(null)
+    }
+  }, [props, username, setModal])
+
+  return <div ref={props.ref} className='non-modal-content'>{props.children}</div>;
+}
+
+export default PageWrapper;

--- a/frontend/components/TopBar.tsx
+++ b/frontend/components/TopBar.tsx
@@ -5,35 +5,17 @@ import { useAuthContext } from "../contexts/AuthContext";
 import styles from './TopBar.module.css';
 import Button from "./Button";
 import { useModalContext } from "@/contexts/ModalContext";
-import { useEffect } from "react";
 
 interface TopBarProps {
   ssrEnabled: boolean;
-  pageStatus: number;
-  setPageStatus: Function;
 }
 
 /**
  * The component at the top of the page containing the "Republic of Rome Online" title
  */
 const TopBar = (props: TopBarProps) => {
-  const { username, setAccessToken, setRefreshToken, setUsername } = useAuthContext();
+  const { username } = useAuthContext();
   const { setModal } = useModalContext();
-
-  useEffect(() => {
-    if (props.pageStatus == 401 && username == '') {
-      setModal("sign-in-required");
-      props.setPageStatus(null)
-    }
-  }, [props, username, setModal])
-  
-  useEffect(() => {
-    if (props.pageStatus == 401 && username != '') {
-      setAccessToken('');
-      setRefreshToken('');
-      setUsername('');
-    }
-  }, [props, username, setAccessToken, setRefreshToken, setUsername]);
   
   const handleSignIn = () => {
     setModal('sign-in')
@@ -45,7 +27,7 @@ const TopBar = (props: TopBarProps) => {
 
   // This is where the `ssrEnabled` page prop is used. To prevent hydration issues,
   // the TopBar will render a generic version of itself if `ssrEnabled` is undefined.
-
+  // The only page where SSR should not be enabled is the 404 page.
   return (
     <header className={styles.topBar} role="banner" aria-label="Website Header">
       <Link href="/" className="no-decor inherit-color" ><h1>Republic of Rome Online</h1></Link>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,10 +1,12 @@
 import { AppProps } from 'next/app';
+import { useEffect, useRef, useState } from 'react';
 import Head from 'next/head';
+
 import TopBar from "@/components/TopBar";
 import { RootProvider } from '@/contexts/RootContext';
 import BottomBar from '@/components/BottomBar';
 import ModalContainer from '@/components/modals/ModalContainer';
-import { useEffect, useRef, useState } from 'react';
+import PageWrapper from '@/components/PageWrapper';
 
 import "../styles/color.css";
 import "../styles/space.css";
@@ -15,6 +17,7 @@ import "../styles/layout.css";
 import "../styles/link.css";
 import "../styles/heading.css";
 
+// Highest level component in the app, except _document.tsx
 function App({ Component, pageProps }: AppProps) {
   const nonModalContentRef = useRef<HTMLDivElement>(null);
   const [pageStatus, setPageStatus] = useState<number | null>(null);
@@ -28,11 +31,11 @@ function App({ Component, pageProps }: AppProps) {
       <Head>
         <title>Republic of Rome Online</title>
       </Head>
-      <div ref={nonModalContentRef} className='non-modal-content'>
-        <TopBar {...pageProps} pageStatus={pageStatus} setPageStatus={setPageStatus} />
+      <PageWrapper ref={nonModalContentRef} pageStatus={pageStatus} setPageStatus={setPageStatus}>
+        <TopBar {...pageProps} />
         <Component {...pageProps} pageStatus={pageStatus} />
         <BottomBar />
-      </div>
+      </PageWrapper>
       <ModalContainer nonModalContentRef={nonModalContentRef} />
     </RootProvider>
   );

--- a/frontend/pages/account.tsx
+++ b/frontend/pages/account.tsx
@@ -20,6 +20,14 @@ const AccountPage = (props : GamePageProps) => {
   const [email, setEmail] = useState<string>(props.initialEmail);
 
   useEffect(() => {
+    if (props.pageStatus == 401 && username != '') {
+      setAccessToken('');
+      setRefreshToken('');
+      setUsername('');
+    }
+  }, [props, username, setAccessToken, setRefreshToken, setUsername]);
+
+  useEffect(() => {
     // Get the current user's email
     const fetchData = async () => {
       if (username) {

--- a/frontend/pages/demo.tsx
+++ b/frontend/pages/demo.tsx
@@ -17,6 +17,7 @@ interface GamePageProps {
   pageStatus: number;
 }
 
+// This page is probably temporary because it's just a sandbox for some UI components.
 const DemoPage = (props: GamePageProps) => {
   const { username } = useAuthContext();
   const [senators, setSenators] = useState<Senator[]>([]);

--- a/frontend/pages/games/[id].tsx
+++ b/frontend/pages/games/[id].tsx
@@ -18,7 +18,6 @@ interface GamePageProps {
 const GamePage = (props: GamePageProps) => {
   const { username, accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername } = useAuthContext();
   const [game, setGame] = useState<Game | undefined>(() => {
-    console.log(props.initialGame);
     if (props.initialGame) {
       const gameObject = JSON.parse(props.initialGame);
       if (gameObject.name) {  // Might be invalid data, so check for name property
@@ -38,7 +37,7 @@ const GamePage = (props: GamePageProps) => {
       }
     }
     fetchData();
-  }, [username, accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername])
+  }, [props.gameId, accessToken, refreshToken, setAccessToken, setRefreshToken, setUsername])
 
   // Render page error if user is not signed in
   if (username == '' || props.pageStatus == 401) {
@@ -50,12 +49,12 @@ const GamePage = (props: GamePageProps) => {
   return (
     <>
       <Head>
-        <title>Game Dashboard - Republic of Rome Online</title>
+        <title>Game Lobby - Republic of Rome Online</title>
       </Head>
       <main>
         <section className='row'>
           <Button href="/games">◀ Back</Button>
-          <h2 id="page-title">Game Dashboard</h2>
+          <h2 id="page-title">Game Lobby</h2>
         </section>
         <div className='table-container' style={{maxWidth: "100%"}}>
           <table>


### PR DESCRIPTION
Moved some of the logic that was in top bar (but had no business being there) into a new wrapper called `PageWrapper` that wraps top bar, content and footer.