### PR TITLE
Add a VS Code workspace

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.tabSize": 4,
+  "editor.insertSpaces": false
+}

--- a/roronline.code-workspace
+++ b/roronline.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"path": ".",
+			"name": "root"
+		},
+		{
+			"path": "backend",
+			"name": "backend project"
+		},
+		{
+			"path": "frontend",
+			"name": "frontend project"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Add a VS Code workspace so that new scripts in the backend folder have a tab size of 4 spaces by default, because it was annoying me that they didn't.