### PR TITLE
Fix MUI X DataGrid font color

### DIFF
--- a/frontend/themes/rootTheme.ts
+++ b/frontend/themes/rootTheme.ts
@@ -13,6 +13,15 @@ declare module '@mui/material/styles' {
       danger?: string;
     };
   }
+  interface Components {
+    MuiDataGrid?: {
+      styleOverrides?: {
+        root?: {
+          color: string;
+        };
+      };
+    };
+  }
 }
 
 const rootTheme = createTheme({
@@ -39,6 +48,13 @@ const rootTheme = createTheme({
       }
     },
     MuiTablePagination: {
+      styleOverrides: {
+        root: {
+          color: 'inherit'
+        }
+      }
+    },
+    MuiDataGrid: {
       styleOverrides: {
         root: {
           color: 'inherit'


### PR DESCRIPTION
Fix an issue where the MUI X DataGrid was not inheriting font color, instead it was defaulting to black color. The peculiar thing about this bug was that it only affected the production build, not the development build.