### PR TITLE
Add throttling to the waitlist API endpoint

### DIFF
--- a/backend/rorapp/views/waitlist_entry.py
+++ b/backend/rorapp/views/waitlist_entry.py
@@ -2,10 +2,15 @@ from rest_framework import viewsets
 from rorapp.models import WaitlistEntry
 from rorapp.serializers import WaitlistEntryCreateSerializer
 from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.throttling import UserRateThrottle
+
+class CustomRateThrottle(UserRateThrottle):
+    rate = "10/hour"
 
 class WaitlistEntryViewSet(viewsets.ModelViewSet):
     queryset = WaitlistEntry.objects.all()
     serializer_class = WaitlistEntryCreateSerializer
+    throttle_classes = [CustomRateThrottle]
     
     def list(self, request, *args, **kwargs):
         raise MethodNotAllowed('GET')

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -44,6 +44,8 @@ const HomePage = () => {
         setEmail("");
         setEmailFeedback("");
         setOpen(true);
+      } else if (response.status === 429) {
+        setEmailFeedback("Too many requests.");
       } else {
         if (response.data) {
           if (response.data.email && Array.isArray(response.data.email) && response.data.email.length > 0) {


### PR DESCRIPTION
Closes #136 by adding throttling, with a rate limit of 10 requests per hour, to the waitlist API endpoint. If this rate limit is exceeded, a 429 response is returned.

Also allow the frontend `handleSubmit` method for the waitlist form to gracefully handle 429 responses.

### Screenshot

![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/62638c0e-5096-48c4-9876-7575400b83a3)

