### PR TITLE
Changed styling of join waitlist to full width on mobile and fixed size for bigger screens

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -82,13 +82,12 @@ const HomePage = () => {
 
       <h3 id="waitlist">Join our waitlist</h3>
         <form onSubmit={handleSubmit}>
-          <Stack alignItems="start" spacing={2}>
+          <Stack alignItems="stretch" spacing={2} width={{sm: "380px"}}>
             <TextField required
                 error={emailFeedback != ""}
                 id="email"
                 label="Email"
                 onChange={handleEmailChange}
-                style={{width: "300px"}}
                 helperText={capitalize(emailFeedback)}
                 value={email} />
             <Button variant="contained" type="submit">Join waitlist</Button>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -90,7 +90,7 @@ const HomePage = () => {
                 onChange={handleEmailChange}
                 helperText={capitalize(emailFeedback)}
                 value={email} />
-            <Button variant="contained" type="submit">Join waitlist</Button>
+            <Button variant="contained" type="submit" sx={{width: { xs: '100%', sm: 'auto' }, alignSelf: 'flex-start'}}>Join waitlist</Button>
           </Stack>
           <Snackbar
           open={open}


### PR DESCRIPTION
Closes #140 

The join waitlist form takes full width for extra small screens. For bigger screens it is set to a fixed width of 380 px to align the style with the exclusive features buttons.

![Join waitlist form responsivness](https://github.com/iamlogand/republic-of-rome-online/assets/4649153/3afdb6e6-e83a-4195-9e6a-cca62fe622ba)

