### PR TITLE
Use normalization for state in the game play page

### DIFF
--- a/backend/rorapp/serializers/__init__.py
+++ b/backend/rorapp/serializers/__init__.py
@@ -1,5 +1,5 @@
 # Package used to group the serializer scripts
-from .game import GameSerializer, GameCreateSerializer, GameUpdateSerializer
+from .game import GameSerializer, GameDetailSerializer, GameCreateSerializer, GameUpdateSerializer
 from .token import MyTokenObtainPairSerializer, TokenObtainPairByEmailSerializer
 from .user import UserSerializer, UserDetailSerializer
 from .game_participant import GameParticipantSerializer, GameParticipantDetailSerializer, GameParticipantCreateSerializer

--- a/backend/rorapp/serializers/game.py
+++ b/backend/rorapp/serializers/game.py
@@ -1,10 +1,20 @@
 from rest_framework import serializers
 from rorapp.models import Game
+from rorapp.serializers.user import UserSerializer
 
 
 # Serializer used to read and delete games
 class GameSerializer(serializers.ModelSerializer):
-    host = serializers.ReadOnlyField(source='host.username')
+    
+    class Meta:
+        model = Game
+        fields = ('id', 'name', 'description', 'creation_date', 'start_date', 'host', 'step')
+        read_only_fields = ['id', 'name', 'description', 'creation_date', 'start_date', 'host', 'step']
+
+
+# Serializer used to read games in detail and prefetch users
+class GameDetailSerializer(serializers.ModelSerializer):
+    host = UserSerializer(read_only=True)
     
     class Meta:
         model = Game
@@ -27,5 +37,5 @@ class GameUpdateSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Game
-        fields = ('id', 'name', 'description', 'creation_date', 'start_date', 'host')
-        read_only_fields = ['id', 'name', 'creation_date', 'start_date', 'host']
+        fields = ('id', 'name', 'description', 'creation_date', 'start_date', 'host', 'step')
+        read_only_fields = ['id', 'name', 'creation_date', 'start_date', 'host', 'step']

--- a/backend/rorapp/views/game.py
+++ b/backend/rorapp/views/game.py
@@ -5,7 +5,7 @@ from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 from rorapp.models import Game
 from rorapp.models import GameParticipant
-from rorapp.serializers import GameSerializer, GameCreateSerializer, GameUpdateSerializer
+from rorapp.serializers import GameSerializer, GameDetailSerializer, GameCreateSerializer, GameUpdateSerializer
 
 
 class GameViewSet(viewsets.ModelViewSet):
@@ -21,6 +21,8 @@ class GameViewSet(viewsets.ModelViewSet):
             return GameCreateSerializer
         elif self.action == 'partial_update':
             return GameUpdateSerializer
+        elif 'prefetch_user' in self.request.query_params:
+            return GameDetailSerializer
         else:
             return GameSerializer
 

--- a/backend/rorapp/views/game_participant.py
+++ b/backend/rorapp/views/game_participant.py
@@ -32,10 +32,6 @@ class GameParticipantViewSet(viewsets.ModelViewSet):
         game_id = self.request.query_params.get('game', None)
         if game_id is not None:
             queryset = queryset.filter(game__id=game_id)
-        
-        # Optionally prefetch usernames of related users
-        if 'prefetch_user' in self.request.query_params:
-            queryset = queryset.prefetch_related(Prefetch('user', queryset=User.objects.only('username'))) 
             
         return queryset
     

--- a/backend/rorapp/views/start_game.py
+++ b/backend/rorapp/views/start_game.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 from rorapp.models import Game, GameParticipant, Faction, FamilySenator
-from rorapp.serializers import GameSerializer
+from rorapp.serializers import GameDetailSerializer
 
 
 class StartGameViewset(viewsets.ViewSet):
@@ -83,7 +83,7 @@ class StartGameViewset(viewsets.ViewSet):
         game.save()  # Update game to DB
         
         # Serialize the instance
-        instance_data = GameSerializer(game).data
+        instance_data = GameDetailSerializer(game).data
         
         # Send message to WebSocket
         channel_layer = get_channel_layer()

--- a/frontend/classes/Collection.ts
+++ b/frontend/classes/Collection.ts
@@ -1,0 +1,44 @@
+interface Identifiable {
+  id: string;
+  [key: string]: any;
+}
+
+class Collection<T extends Identifiable> {
+  byId: { [key: string]: T };
+  allIds: string[];
+
+  constructor(instances: T[] = []) {
+    this.byId = {};
+    this.allIds = [];
+
+    for (let instance of instances) {
+      this.add(instance);
+    }
+  }
+
+  add(instance: T) {
+    this.byId[instance.id] = instance;
+    this.allIds.push(instance.id);
+  }
+
+  remove(id: string) {
+    delete this.byId[id];
+    this.allIds = this.allIds.filter(instanceId => instanceId !== id);
+  }
+
+  update(instance: T) {
+    this.byId[instance.id] = instance;
+  }
+
+  filterByAttribute(attribute: string, value: any): T[] {
+    return this.allIds
+      .map(id => this.byId[id])  // get the instances
+      .filter(instance => instance[attribute] === value);  // filter by attribute
+  }
+
+  get asArray(): T[] {
+    return this.allIds.map(id => this.byId[id]);
+  }
+}
+
+export default Collection;

--- a/frontend/classes/Game.ts
+++ b/frontend/classes/Game.ts
@@ -1,31 +1,34 @@
+import { deserializeToInstance } from "@/functions/serialize"
+import User from "@/classes/User"
+
 interface GameData {
-  id: string;
-  name: string;
-  host: string | null;
-  description: string | null;
-  creation_date: string;
-  start_date: string | null;
-  step: number;
+  id: string
+  name: string
+  host: string
+  description: string | null
+  creation_date: string
+  start_date: string | null
+  step: number
 }
 
 class Game {
-  id: string;
-  name: string;
-  host: string | null;
-  description: string | null;
-  creation_date: Date;
-  start_date: Date | null;
-  step: number;
+  id: string
+  name: string
+  host: User | null
+  description: string | null
+  creation_date: Date
+  start_date: Date | null
+  step: number
 
   constructor(data: GameData) {
-    this.id = data.id;
-    this.name = data.name;
-    this.host = data.host;
-    this.description = data.description;
-    this.creation_date = new Date(data.creation_date);
-    this.start_date = data.start_date ? new Date(data.start_date) : null;
-    this.step = data.step;
+    this.id = data.id
+    this.name = data.name
+    this.host = deserializeToInstance<User>(User, data.host)  // Expects user to be preloaded with game participant
+    this.description = data.description
+    this.creation_date = new Date(data.creation_date)
+    this.start_date = data.start_date ? new Date(data.start_date) : null
+    this.step = data.step
   }
 }
 
-export default Game;
+export default Game

--- a/frontend/classes/GameParticipant.ts
+++ b/frontend/classes/GameParticipant.ts
@@ -1,24 +1,24 @@
-import User from "@/classes/User";
-import { deserializeToInstance } from "@/functions/serialize";
+import User from "@/classes/User"
+import { deserializeToInstance } from "@/functions/serialize"
 
 interface GameParticipantData {
-  id: string,
-  user: string,
-  game: string,
+  id: string
+  user: string
+  game: string
   join_date: string
 }
 
 class GameParticipant {
-  id: string;
-  user: string | User;
-  game: string;
-  joinDate: Date;
+  id: string
+  user: User | null
+  game: string
+  joinDate: Date
 
   constructor(data: GameParticipantData) {
-    this.id = data.id;
-    this.user = deserializeToInstance<User>(User, data.user) ?? data.user;
-    this.game = data.game;
-    this.joinDate = new Date(data.join_date);
+    this.id = data.id
+    this.user = deserializeToInstance<User>(User, data.user)  // Expects user to be preloaded with game participant
+    this.game = data.game
+    this.joinDate = new Date(data.join_date)
   }
 }
 

--- a/frontend/classes/User.ts
+++ b/frontend/classes/User.ts
@@ -1,18 +1,18 @@
 interface IUser {
-  id: number;
-  username: string;
-  email: string;
+  id: string
+  username: string
+  email: string
 }
 
 class User {
-  id: number;
-  username: string;
-  email: string;
+  id: string
+  username: string
+  email: string
 
   constructor(data: IUser) {
-    this.id = data.id;
-    this.username = data.username;
-    this.email = data.email;
+    this.id = data.id
+    this.username = data.username
+    this.email = data.email
   }
 }
 

--- a/frontend/pages/games/[id]/edit.tsx
+++ b/frontend/pages/games/[id]/edit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { GetServerSidePropsContext } from 'next';
 import router from 'next/router';
 import Head from 'next/head';
@@ -75,7 +75,7 @@ const EditGamePage = (props: GamePageProps) => {
   }
 
   // Render page error if user is not signed in or not game owner
-  if (user === null || (game !== null && (game?.host !== user?.username || game.step !== 0))) {
+  if (user === null || (game !== null && (game.host?.id !== user?.id || game.step !== 0))) {
     return <PageError statusCode={401} />;
   } else if (game == null) {
     return <PageError statusCode={404} />
@@ -126,7 +126,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { clientAccessToken, clientRefreshToken, clientUser, clientTimezone } = getInitialCookieData(context);
   
   const id = context.params?.id;
-  const response = await request('GET', 'games/' + id, clientAccessToken, clientRefreshToken);
+  const response = await request('GET', `games/${id}?prefetch_user`, clientAccessToken, clientRefreshToken);
 
   const game = JSON.stringify(getGame(response));
 

--- a/frontend/pages/games/[id]/index.tsx
+++ b/frontend/pages/games/[id]/index.tsx
@@ -35,7 +35,7 @@ const webSocketURL: string = process.env.NEXT_PUBLIC_WS_URL ?? "";
 
 interface GameLobbyPageProps {
   clientTimezone: string
-  gameID: string
+  gameId: string
   authFailure: boolean
   initialGame: string
   initialUsers: string
@@ -53,7 +53,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
 
   // Establish a WebSocket connection and provide a state containing the last message
   const [firstConnection, setFirstConnection] = useState<boolean>(true)
-  const { lastMessage } = useWebSocket(webSocketURL + `games/${props.gameID}/`, {
+  const { lastMessage } = useWebSocket(webSocketURL + `games/${props.gameId}/`, {
 
     // On connection open, if this isn't the first render then perform a full sync
     onOpen: () => {
@@ -73,12 +73,12 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
 
   // Fetch game participants
   const fetchGameParticipants = useCallback(async () => {
-    const gameParticipantsResponse = await request('GET', `game-participants/?game=${props.gameID}&prefetch_user`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+    const gameParticipantsResponse = await request('GET', `game-participants/?game=${props.gameId}&prefetch_user`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
     if (gameParticipantsResponse.status === 200) {
       const newGameParticipants = deserializeToInstances<GameParticipant>(GameParticipant, gameParticipantsResponse.data)
       setGameParticipants(newGameParticipants)
     }
-  }, [props.gameID, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
+  }, [props.gameId, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
 
   // Fetch game participants once on initial render
   useEffect(() => {
@@ -91,8 +91,8 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
     const startTime = performance.now();
 
     // Fetch game and game participants
-    const gameRequest = request('GET', `games/${props.gameID}/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
-    const gameParticipantsRequest = request('GET', `game-participants/?game=${props.gameID}&prefetch_user`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+    const gameRequest = request('GET', `games/${props.gameId}/?prefetch_user`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+    const gameParticipantsRequest = request('GET', `game-participants/?game=${props.gameId}&prefetch_user`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
     const [gameResponse, gameParticipantsResponse] = await Promise.all([gameRequest, gameParticipantsRequest])
 
     // Deserialize the game and game participants
@@ -112,7 +112,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
     const timeTaken = Math.round(endTime - startTime);
 
     console.log(`Full synchronization completed in ${timeTaken}ms`)
-  }, [props.gameID, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
+  }, [props.gameId, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
 
   // Read WebSocket messages and use payloads to update state
   useEffect(() => {
@@ -159,7 +159,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
   const handleDelete = () => {
     const deleteGame = async () => {
       if (window.confirm(`Are you sure you want to permanently delete this game?`)) {
-        const response = await request('DELETE', `games/${props.gameID}/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+        const response = await request('DELETE', `games/${props.gameId}/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
         if (response.status === 204) {
           router.push('/games/');
         }
@@ -170,27 +170,21 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
 
   // Handle join game (create a game participant)
   const handleJoin = () => {
-    const data = { "game": props.gameID }
+    const data = { "game": props.gameId }
     request('POST', 'game-participants/', accessToken, refreshToken, setAccessToken, setRefreshToken, setUser, data);
   }
 
   // Handle leave game (delete a game participant)
   const handleLeave = () => {
     if (gameParticipants && user) {
-      const id = gameParticipants.find(participant => {
-        if (participant.user instanceof User) {
-          return participant.user.id.toString() === user.id.toString()
-        } else {
-          return participant.user.toString() === user.id.toString()
-        }
-      })?.id
+      const id = gameParticipants.find(participant => participant.user?.id === user.id)?.id
       if (id !== null) {
         request('DELETE', `game-participants/${id}/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser)
       }
     }
   }
 
-  // `handleKick` is similar to `handleLeave`, except participant ID is passed as an argument,
+  // `handleKick` is similar to `handleLeave`, except participant Id is passed as an argument,
   // so it could be another participant other than this user.
   const handleKick = (id: string) => {
     request('DELETE', `game-participants/${id}/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
@@ -199,7 +193,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
   // Handle game start - this triggers start and setup of the game
   const handleStart = () => {
     if (window.confirm(`Are you sure you want to start this game?`)) {
-      request('POST', `games/${props.gameID}/start-game/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+      request('POST', `games/${props.gameId}/start-game/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
     }
   }
 
@@ -226,7 +220,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
   }
 
   const details = [
-    { key: "Host", value: game.host ?? '' },
+    { key: "Host", value: game.host?.username ?? '' },
     { key: "Creation Date", value: formatDate(game.creation_date, props.clientTimezone) },
     { key: "Start Date", value: getFormattedStartDate() }
   ]
@@ -270,8 +264,9 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
                     let canKick = true
 
                     if (game.step > 0) canKick = false
-                    if (game.host !== user.username) canKick = false
-                    if (participant.user === user.id.toString()) canKick = false
+                    if (game.host?.id === participant.user?.id) canKick = false
+                    if (game.host?.id !== user.id) canKick = false
+                    if (participant.user?.id === user.id) canKick = false
 
                     const kickButton = canKick ? (
                       <IconButton edge="end" aria-label="delete" style={{ width: 40 }} onClick={() => handleKick(participant.id)}>
@@ -288,7 +283,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
                             <Avatar>{capitalize(participant.user.username.substring(0, 1))}</Avatar>
                           </ListItemAvatar>
                           <ListItemText>
-                            <span><b>{participant.user.username} {participant.user.username == game.host && <span>(host)</span>}</b></span>
+                            <span><b>{participant.user.username} {participant.user.id === game.host?.id && <span>(host)</span>}</b></span>
                           </ListItemText>
                         </ListItem>
                       )
@@ -309,7 +304,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
             <Card variant='outlined' style={{ padding: "16px" }}>
               <h3 style={{ marginTop: 0 }}>Actions</h3>
               <Stack spacing={2} direction={{ xs: "column", sm: "row" }}>
-                {game.host === user.username &&
+                {game.host?.id === user.id &&
                   <>
                     <Button variant="outlined" color="error" onClick={handleDelete}>
                       <FontAwesomeIcon icon={faTrash} style={{ marginRight: "8px" }} width={14} height={14} />
@@ -335,7 +330,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
                     Join
                   </Button>
                 }
-                {game.host !== user.username && gameParticipants.some(p => p.user instanceof User && p.user.id === user.id) && game.step === 0 &&
+                {game.host?.id !== user.id && gameParticipants.some(p => p.user instanceof User && p.user.id === user.id) && game.step === 0 &&
                   <Button variant="outlined" onClick={handleLeave} color="warning">
                     Leave
                   </Button>
@@ -363,11 +358,11 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // Get client cookie data from the page request
   const { clientAccessToken, clientRefreshToken, clientUser, clientTimezone } = getInitialCookieData(context)
 
-  // Get game ID from the URL
-  const gameID = context.params?.id
+  // Get game Id from the URL
+  const gameId = context.params?.id
 
   // Asynchronously retrieve the game
-  const gameResponse = await request('GET', `games/${gameID}/`, clientAccessToken, clientRefreshToken)
+  const gameResponse = await request('GET', `games/${gameId}/?prefetch_user`, clientAccessToken, clientRefreshToken)
 
   // Track whether there has been an authentication failure due to bad credentials
   let authFailure = false
@@ -387,7 +382,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       clientRefreshToken: clientRefreshToken,
       clientUser: clientUser,
       clientTimezone: clientTimezone,
-      gameID: gameID,
+      gameId: gameId,
       authFailure: authFailure,
       initialGame: gameJSON
     }

--- a/frontend/pages/games/[id]/play.tsx
+++ b/frontend/pages/games/[id]/play.tsx
@@ -16,12 +16,13 @@ import request from '@/functions/request';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { deserializeToInstance, deserializeToInstances } from '@/functions/serialize';
 import User from '@/classes/User';
+import Collection from '@/classes/Collection';
 
 const webSocketURL: string = process.env.NEXT_PUBLIC_WS_URL ?? "";
 
 interface PlayGamePageProps {
   clientTimezone: string
-  gameID: string
+  gameId: string
   authFailure: boolean
   initialGame: string
 }
@@ -34,39 +35,42 @@ const PlayGamePage = (props: PlayGamePageProps) => {
   const [game, setGame] = useState<Game | null>(() =>
     props.initialGame ? deserializeToInstance<Game>(Game, props.initialGame) : null
   );
-  const [gameParticipants, setGameParticipants] = useState<GameParticipant[]>([]);
-  const [factions, setFactions] = useState<Faction[]>([]);
-  const [familySenators, setFamilySenators] = useState<FamilySenator[]>([]);
+  const [gameParticipants, setGameParticipants] = useState<Collection<GameParticipant>>(new Collection<GameParticipant>());
+  const [factions, setFactions] = useState<Collection<Faction>>(new Collection<Faction>());
+  const [familySenators, setFamilySenators] = useState<Collection<FamilySenator>>(new Collection<FamilySenator>());
 
   // Fetch game participants
   const fetchGameParticipants = useCallback(async () => {
-    const response = await request('GET', `game-participants/?game=${props.gameID}&prefetch_user`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+    const response = await request('GET', `game-participants/?game=${props.gameId}&prefetch_user`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
     if (response.status === 200) {
-      setGameParticipants(deserializeToInstances<GameParticipant>(GameParticipant, response.data));
+      const deserializedInstances = deserializeToInstances<GameParticipant>(GameParticipant, response.data)
+      setGameParticipants(new Collection<GameParticipant>(deserializedInstances));
     } else {
-      setGameParticipants([]);
+      setGameParticipants(new Collection<GameParticipant>());
     }
-  }, [props.gameID, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
+  }, [props.gameId, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
 
   // Fetch factions
   const fetchFactions = useCallback(async () => {
-    const response = await request('GET', `factions/?game=${props.gameID}`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+    const response = await request('GET', `factions/?game=${props.gameId}`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
     if (response.status === 200) {
-      setFactions(deserializeToInstances<Faction>(Faction, response.data));
+      const deserializedInstances = deserializeToInstances<Faction>(Faction, response.data)
+      setFactions(new Collection<Faction>(deserializedInstances));
     } else {
-      setFactions([]);
+      setFactions(new Collection<Faction>());
     }
-  }, [props.gameID, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
+  }, [props.gameId, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
 
   // Fetch family senators
   const fetchFamilySenators = useCallback(async () => {
-    const response = await request('GET', `family-senators/?game=${props.gameID}`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+    const response = await request('GET', `family-senators/?game=${props.gameId}`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
     if (response.status === 200) {
-      setFamilySenators(deserializeToInstances<FamilySenator>(FamilySenator, response.data));
+      const deserializedInstances = deserializeToInstances<FamilySenator>(FamilySenator, response.data)
+      setFamilySenators(new Collection<FamilySenator>(deserializedInstances));
     } else {
-      setFamilySenators([]);
+      setFamilySenators(new Collection<FamilySenator>());
     }
-  }, [props.gameID, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
+  }, [props.gameId, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser])
 
   // Fetch game participants, factions and family senators once on initial render
   useEffect(() => {
@@ -95,17 +99,14 @@ const PlayGamePage = (props: PlayGamePageProps) => {
           <Card>
             <Card variant='outlined' style={{margin: 0, padding: "16px"}}>
               <h3 style={{ marginTop: 0 }}>Senators</h3>
-              {factions.map((faction: Faction) => {
-                const gameParticipant = gameParticipants.find(participant => participant.id == faction.player)
-                const user = gameParticipant?.user
-                if (gameParticipant && user instanceof User) {
+              {factions.asArray.map((faction: Faction) => {
+                const user = gameParticipants.byId[faction.player]?.user
+                if (user && user instanceof User) {
                   return (
                     <div key={faction.id}>
                       <h4>Faction of {user?.username}</h4>
                       <ul>
-                        {familySenators.filter((senator: FamilySenator) => {
-                          return senator.faction === faction.id
-                        }).map((senator: FamilySenator) => {
+                        {familySenators.filterByAttribute('faction', faction.id).map((senator: FamilySenator) => {
                           return <li key={senator.id}>{senator.name}</li>
                         })}
                       </ul>
@@ -131,11 +132,11 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // Get client cookie data from the page request
   const { clientAccessToken, clientRefreshToken, clientUser, clientTimezone } = getInitialCookieData(context)
 
-  // Get game ID from the URL
-  const gameID = context.params?.id
+  // Get game Id from the URL
+  const gameId = context.params?.id
 
   // Asynchronously retrieve the game
-  const gameResponse = await request('GET', `games/${gameID}/`, clientAccessToken, clientRefreshToken)
+  const gameResponse = await request('GET', `games/${gameId}/`, clientAccessToken, clientRefreshToken)
 
   // Track whether there has been an authentication failure due to bad credentials
   let authFailure = false
@@ -155,7 +156,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       clientRefreshToken: clientRefreshToken,
       clientUser: clientUser,
       clientTimezone: clientTimezone,
-      gameID: gameID,
+      gameId: gameId,
       authFailure: authFailure,
       initialGame: gameJSON
     }

--- a/frontend/pages/games/index.tsx
+++ b/frontend/pages/games/index.tsx
@@ -10,7 +10,7 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 
 import { useAuthContext } from '@/contexts/AuthContext';
-import request, { ResponseType } from "@/functions/request";
+import request from "@/functions/request";
 import Game from "@/classes/Game";
 import getInitialCookieData from '@/functions/cookies';
 import Breadcrumb from '@/components/Breadcrumb';
@@ -66,7 +66,8 @@ const BrowseGamesPage = (props: BrowseGamesPageProps) => {
       field: 'host',
       headerName: 'Host',
       minWidth: 150,
-      flex: 2
+      flex: 2,
+      valueGetter: (params: GridValueGetterParams) => params.row.host.username
     },
     {
       field: 'creationDate',
@@ -99,7 +100,7 @@ const BrowseGamesPage = (props: BrowseGamesPageProps) => {
   ];
 
   const fetchGames = useCallback(async () => {
-    const response = await request('GET', 'games/', accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
+    const response = await request('GET', 'games/?prefetch_user', accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
     if (response.status === 200) {
       setGames(deserializeToInstances<Game>(Game, response.data));
     } else {
@@ -200,7 +201,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { clientAccessToken, clientRefreshToken, clientUser, clientTimezone } = getInitialCookieData(context)
   
   // Asynchronously retrieve games and game participants
-  const gamesRequest = request('GET', 'games/', clientAccessToken, clientRefreshToken)
+  const gamesRequest = request('GET', 'games/?prefetch_user', clientAccessToken, clientRefreshToken)
   const gameParticipantsRequest = request('GET', 'game-participants/', clientAccessToken, clientRefreshToken)
   const [gamesResponse, gameParticipantsResponse] = await Promise.all([gamesRequest, gameParticipantsRequest]);
 

--- a/frontend/pages/sign-in.tsx
+++ b/frontend/pages/sign-in.tsx
@@ -83,7 +83,7 @@ const SignInPage = () => {
       setFeedback(`Incorrect ${identity.includes('@') ? "email" : "username"} or password - please try again`);
 
     } else if (result === 'success' && response?.data) {
-      // If the sign in request succeeded, set the user ID and JWT tokens
+      // If the sign in request succeeded, set the user Id and JWT tokens
       setAccessToken(response.data.access);
       setRefreshToken(response.data.refresh);
 

--- a/roronline.code-workspace
+++ b/roronline.code-workspace
@@ -34,6 +34,7 @@
 			"Furius",
 			"gameparticipant",
 			"Glaucia",
+			"hideable",
 			"inventa",
 			"Laenas",
 			"Licinius",


### PR DESCRIPTION
Introduce a generic `Collection` class for storing state in a normalized structure in the frontend. This is used in the play game page for family senators, factions, and game participants. Using normalization will be essential when the game play page grows larger and more complicated.

The host user is now prefetched with the `Game` instance, however this is not the default behavior of the API and must be specified via the "prefetch_user" URL parameter (like the `GameParticipant`).