### PR TITLE
Make the frontend use number type IDs

### DIFF
--- a/frontend/classes/Collection.ts
+++ b/frontend/classes/Collection.ts
@@ -1,11 +1,11 @@
 interface Identifiable {
-  id: string;
+  id: number;
   [key: string]: any;
 }
 
 class Collection<T extends Identifiable> {
-  byId: { [key: string]: T };
-  allIds: string[];
+  byId: { [key: number]: T };
+  allIds: number[];
 
   constructor(instances: T[] = []) {
     this.byId = {};
@@ -21,7 +21,7 @@ class Collection<T extends Identifiable> {
     this.allIds.push(instance.id);
   }
 
-  remove(id: string) {
+  remove(id: number) {
     delete this.byId[id];
     this.allIds = this.allIds.filter(instanceId => instanceId !== id);
   }

--- a/frontend/classes/Faction.ts
+++ b/frontend/classes/Faction.ts
@@ -3,17 +3,17 @@ import Colors from "@/data/colors.json"
 export type FactionPosition = "1" | "2" | "3" | "4" | "5" | "6"
 
 interface FactionData {
-  id: string,
-  game: string,
+  id: number,
+  game: number,
   position: FactionPosition,
-  player: string
+  player: number
 }
 
 class Faction {
-  id: string
-  game: string
+  id: number
+  game: number
   position: FactionPosition
-  player: string
+  player: number
 
   constructor(data: FactionData) {
     this.id = data.id

--- a/frontend/classes/FamilySenator.ts
+++ b/frontend/classes/FamilySenator.ts
@@ -2,17 +2,17 @@ import Colors from "@/data/colors.json"
 import { FactionPosition } from "@/classes/Faction"
 
 interface FamilySenatorData {
-  id: string,
+  id: number,
   name: string,
-  game: string,
-  faction: string
+  game: number,
+  faction: number
 }
 
 class FamilySenator {
-  id: string;
+  id: number;
   name: string;
-  game: string;
-  faction: string;
+  game: number;
+  faction: number;
 
   constructor(data: FamilySenatorData) {
     this.id = data.id;

--- a/frontend/classes/Game.ts
+++ b/frontend/classes/Game.ts
@@ -2,7 +2,7 @@ import { deserializeToInstance } from "@/functions/serialize"
 import User from "@/classes/User"
 
 interface GameData {
-  id: string
+  id: number
   name: string
   host: string
   description: string | null
@@ -12,7 +12,7 @@ interface GameData {
 }
 
 class Game {
-  id: string
+  id: number
   name: string
   host: User | null
   description: string | null

--- a/frontend/classes/GameParticipant.ts
+++ b/frontend/classes/GameParticipant.ts
@@ -2,16 +2,16 @@ import User from "@/classes/User"
 import { deserializeToInstance } from "@/functions/serialize"
 
 interface GameParticipantData {
-  id: string
+  id: number
   user: string
-  game: string
+  game: number
   join_date: string
 }
 
 class GameParticipant {
-  id: string
+  id: number
   user: User | null
-  game: string
+  game: number
   joinDate: Date
 
   constructor(data: GameParticipantData) {

--- a/frontend/classes/User.ts
+++ b/frontend/classes/User.ts
@@ -1,11 +1,11 @@
 interface IUser {
-  id: string
+  id: number
   username: string
   email: string
 }
 
 class User {
-  id: string
+  id: number
   username: string
   email: string
 

--- a/frontend/pages/games/[id]/index.tsx
+++ b/frontend/pages/games/[id]/index.tsx
@@ -193,7 +193,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
 
   // `handleKick` is similar to `handleLeave`, except participant Id is passed as an argument,
   // so it could be another participant other than this user.
-  const handleKick = (id: string) => {
+  const handleKick = (id: number) => {
     request('DELETE', `game-participants/${id}/`, accessToken, refreshToken, setAccessToken, setRefreshToken, setUser);
   }
 


### PR DESCRIPTION
Make the frontend use number IDs rather than string IDs. Representing numerical IDs like 5 or 181 as strings was a bad move.