### PR TITLE
Detach scrolling on different main tabs

### DIFF
--- a/frontend/components/MainTab.module.css
+++ b/frontend/components/MainTab.module.css
@@ -1,0 +1,10 @@
+.tabContent {
+  padding: 8px;
+}
+
+@media (min-width: 1200px) {
+  .tabContent {
+    flex: 2;
+    overflow-y: scroll;
+  }
+}

--- a/frontend/components/MainTab_FactionsTab.tsx
+++ b/frontend/components/MainTab_FactionsTab.tsx
@@ -1,10 +1,11 @@
-import Stack from '@mui/material/Stack';
+import Stack from '@mui/material/Stack'
 
-import Collection from '@/classes/Collection';
-import GameParticipant from '@/classes/GameParticipant';
-import Faction from '@/classes/Faction';
-import FamilySenator from '@/classes/FamilySenator';
-import FactionListItem from '@/components/FactionListItem';
+import Collection from '@/classes/Collection'
+import GameParticipant from '@/classes/GameParticipant'
+import Faction from '@/classes/Faction'
+import FamilySenator from '@/classes/FamilySenator'
+import FactionListItem from '@/components/FactionListItem'
+import mainTabStyles from "./MainTab.module.css"
 
 interface FactionsTabProps {
   gameParticipants: Collection<GameParticipant>
@@ -16,7 +17,7 @@ interface FactionsTabProps {
 // Tab containing a list of factions
 const FactionsTab = (props: FactionsTabProps) => {
   return (
-    <>
+    <div className={mainTabStyles.tabContent}>
       <Stack direction="column" spacing={1} useFlexGap flexWrap="wrap">
         {props.factions.asArray.map((faction: Faction) => {
 
@@ -30,7 +31,7 @@ const FactionsTab = (props: FactionsTabProps) => {
           }
         })}
       </Stack>
-    </>
+    </div>
   )
 }
 

--- a/frontend/components/MainTab_Senators.tsx
+++ b/frontend/components/MainTab_Senators.tsx
@@ -5,6 +5,7 @@ import GameParticipant from '@/classes/GameParticipant'
 import Faction from '@/classes/Faction'
 import FamilySenator from '@/classes/FamilySenator'
 import SenatorListItem from '@/components/SenatorListItem'
+import mainTabStyles from "./MainTab.module.css"
 
 interface SenatorsTabProps {
   gameParticipants: Collection<GameParticipant>
@@ -16,7 +17,7 @@ interface SenatorsTabProps {
 // Tab containing a list of senators
 const SenatorsTab = (props: SenatorsTabProps) => {
   return (
-    <>
+    <div className={mainTabStyles.tabContent}>
       <Stack direction="column" spacing={1} useFlexGap flexWrap="wrap">
         {props.senators.asArray.map((senator: FamilySenator) => {
 
@@ -30,7 +31,7 @@ const SenatorsTab = (props: SenatorsTabProps) => {
           }
         })}
       </Stack>
-    </>
+    </div>
   )
 }
 

--- a/frontend/components/SenatorDetailSection.tsx
+++ b/frontend/components/SenatorDetailSection.tsx
@@ -38,7 +38,6 @@ const SenatorDetailSection = (props: DetailSectionProps) => {
   // so it necessary to do something like this to make the portrait responsive.
   const getPortraitSize = () => {
     const detailDivWidth = props.detailSectionRef.current?.offsetWidth
-    console.log(detailDivWidth)
     if (detailDivWidth && detailDivWidth < 416) {
       return (detailDivWidth - 20) / 2
     } else {

--- a/frontend/pages/games/[id]/edit.tsx
+++ b/frontend/pages/games/[id]/edit.tsx
@@ -58,7 +58,6 @@ const EditGamePage = (props: GamePageProps) => {
 
     const response = await request('PATCH', 'games/' + props.gameId + '/', accessToken, refreshToken, setAccessToken, setRefreshToken, setUser, gameData);
     if (response) {
-      console.log(response.status)
       if (response.status === 200) {
         sendMessage('status change');
         await router.push('/games/' + game?.id);

--- a/frontend/pages/games/[id]/play.module.css
+++ b/frontend/pages/games/[id]/play.module.css
@@ -24,10 +24,6 @@
   padding: 0 8px 8px;
 }
 
-.tabContent {
-  padding: 8px;
-}
-
 @media (min-width: 1200px) {
   .playPage {
     overflow: auto;
@@ -60,10 +56,5 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-  }
-
-  .tabContent {
-    flex: 2;
-    overflow-y: scroll;
   }
 }

--- a/frontend/pages/games/[id]/play.tsx
+++ b/frontend/pages/games/[id]/play.tsx
@@ -19,8 +19,8 @@ import { useAuthContext } from '@/contexts/AuthContext'
 import { deserializeToInstance, deserializeToInstances } from '@/functions/serialize'
 import Collection from '@/classes/Collection'
 import styles from "./play.module.css"
-import SenatorsTab from '@/components/SenatorsTab'
-import FactionsTab from '@/components/FactionsTab'
+import SenatorsTab from '@/components/MainTab_Senators'
+import FactionsTab from '@/components/MainTab_FactionsTab'
 import DetailSection from '@/components/DetailSection';
 
 const webSocketURL: string = process.env.NEXT_PUBLIC_WS_URL ?? "";
@@ -123,10 +123,8 @@ const PlayGamePage = (props: PlayGamePageProps) => {
                     <Tab label="Senators" />
                   </Tabs>
                 </Box>
-                <div className={styles.tabContent}>
-                  {mainTab === 0 && <FactionsTab gameParticipants={gameParticipants} factions={factions} senators={senators} setSelectedEntity={setSelectedEntity} />}
-                  {mainTab === 1 && <SenatorsTab gameParticipants={gameParticipants} factions={factions} senators={senators} setSelectedEntity={setSelectedEntity} />}
-                </div>
+                {mainTab === 0 && <FactionsTab gameParticipants={gameParticipants} factions={factions} senators={senators} setSelectedEntity={setSelectedEntity} />}
+                {mainTab === 1 && <SenatorsTab gameParticipants={gameParticipants} factions={factions} senators={senators} setSelectedEntity={setSelectedEntity} />}
               </section>
             </Card>
             <Card variant="outlined" className={styles.normalSection}>


### PR DESCRIPTION
Closes #161

Make scroll bars on main tabs use separate scrolling from each other by making the element with the `overflow-y: scroll` be different for each tab.