### PR TITLE
Fix the browse games timer bug

### DIFF
--- a/frontend/pages/games/index.tsx
+++ b/frontend/pages/games/index.tsx
@@ -119,8 +119,11 @@ const BrowseGamesPage = (props: BrowseGamesPageProps) => {
 
   // Refresh the game list
   const refreshGames = useCallback(async () => {
-    fetchGames()
-    fetchGameParticipants()
+    const requests = [
+      fetchGames(),
+      fetchGameParticipants()
+    ]
+    await Promise.all(requests)
     setTimeResetKey(e => e + 1);
   }, [fetchGames, fetchGameParticipants, setTimeResetKey]);
 


### PR DESCRIPTION
Closes #179

Fix a bug in the browse games timer where it wouldn't wait for the request before starting the timer.