### PR TITLE
Allow senator list to be sorted and grouped by faction

### DIFF
--- a/frontend/classes/Faction.ts
+++ b/frontend/classes/Faction.ts
@@ -1,6 +1,6 @@
 import Colors from "@/data/colors.json"
 
-export type FactionPosition = "1" | "2" | "3" | "4" | "5" | "6"
+export type FactionPosition = 1 | 2 | 3 | 4 | 5 | 6
 
 interface FactionData {
   id: number,

--- a/frontend/components/SenatorList.module.css
+++ b/frontend/components/SenatorList.module.css
@@ -18,11 +18,12 @@
 }
 
 .headers {
-  height: 40px;
+  height: 54px;
   width: 100%;
   display: flex;
   flex-direction: row;
   gap: 2px;
+  align-items: flex-start;
   border-bottom: 1px solid var(--divider-line-color);
 }
 
@@ -32,15 +33,29 @@
 }
 
 .headers>div {
+  margin-top: 4px;
   width: 32px;
   text-align: center;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
 }
 
-.headers>div:first-child {
-  margin-left: 100px;
+.headers>div>svg {
+  margin: -3px;
+}
+
+.headers>.groupButton {
+  height: 34px;
+  width: 98px;
+  flex-direction: row;
+}
+
+.headers>.groupButton>label>span:last-child {
+  width: 53px;
+  font-size: 12px;
+  line-height: 1;
 }
 
 .listItem {

--- a/frontend/components/SenatorList.module.css
+++ b/frontend/components/SenatorList.module.css
@@ -53,9 +53,13 @@
 }
 
 .headers>.groupButton>label>span:last-child {
-  width: 53px;
-  font-size: 12px;
-  line-height: 1;
+  width: 57px;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.header {
+  cursor: pointer;
 }
 
 .listItem {

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -23,7 +23,7 @@ import Collection from '@/classes/Collection';
 
 type SortAttribute = "military" | "oratory" | "loyalty" | "influence" | "talents" | "popularity" | "knights"
 
-interface SenatorsTabProps {
+interface SenatorListProps {
   selectable?: boolean
   height?: number
   margin?: number
@@ -33,7 +33,7 @@ interface SenatorsTabProps {
 }
 
 // List of senators
-const SenatorsTab = (props: SenatorsTabProps) => {
+const SenatorList = (props: SenatorListProps) => {
   const { allFactions, allSenators } = useGameContext()
 
   const [sort, setSort] = useState<string>('')  // Attribute to sort by, prefixed with '-' for descending order
@@ -175,4 +175,4 @@ const SenatorsTab = (props: SenatorsTabProps) => {
   );
 }
 
-export default SenatorsTab
+export default SenatorList

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -136,40 +136,41 @@ const SenatorsTab = (props: SenatorsTabProps) => {
         <div className={styles.groupButton}>
           {!props.faction &&
             <FormControlLabel control={<Checkbox style={{ marginLeft: 0, marginRight: -8 }} checked={grouped} />}
-              label="Group by Faction" onChange={handleGroupClick} style={{marginRight: 0}} />
+              label="Group by Faction" onChange={handleGroupClick}
+              style={{marginRight: 0}} className={styles.header}/>
           }
         </div>
-        <div onClick={() => handleSortClick("military")}>
+        <div onClick={() => handleSortClick("military")} className={styles.header}>
           <Image src={MilitaryIcon} height={iconSize} width={iconSize} alt="Military Icon" />
           {sort === "military" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
           {sort === "-military" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
         </div>
-        <div onClick={() => handleSortClick("oratory")}>
+        <div onClick={() => handleSortClick("oratory")} className={styles.header}>
           <Image src={OratoryIcon} height={iconSize} width={iconSize} alt="Oratory Icon" />
           {sort === "oratory" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
           {sort === "-oratory" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
         </div>
-        <div onClick={() => handleSortClick("loyalty")}>
+        <div onClick={() => handleSortClick("loyalty")} className={styles.header}>
           <Image src={LoyaltyIcon} height={iconSize} width={iconSize} alt="Loyalty Icon" />
           {sort === "loyalty" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
           {sort === "-loyalty" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
         </div>
-        <div onClick={() => handleSortClick("influence")}>
+        <div onClick={() => handleSortClick("influence")} className={styles.header}>
           <Image src={InfluenceIcon} height={iconSize} width={iconSize} alt="Influence Icon" />
           {sort === "influence" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
           {sort === "-influence" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
         </div>
-        <div onClick={() => handleSortClick("talents")}>
+        <div onClick={() => handleSortClick("talents")} className={styles.header}>
           <Image src={TalentsIcon} height={iconSize} width={iconSize} alt="Talents Icon" />
           {sort === "talents" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
           {sort === "-talents" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
         </div>
-        <div onClick={() => handleSortClick("popularity")}>
+        <div onClick={() => handleSortClick("popularity")} className={styles.header}>
           <Image src={PopularityIcon} height={iconSize} width={iconSize} alt="Popularity Icon" />
           {sort === "popularity" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
           {sort === "-popularity" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
         </div>
-        <div onClick={() => handleSortClick("knights")}>
+        <div onClick={() => handleSortClick("knights")} className={styles.header}>
           <Image src={KnightsIcon} height={iconSize} width={iconSize} alt="Knights Icon" />
           {sort === "knights" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
           {sort === "-knights" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -128,6 +128,16 @@ const SenatorsTab = (props: SenatorsTabProps) => {
 
   const iconSize = 34
 
+  const headers = [
+    { sort: "military", icon: MilitaryIcon, alt: "Military Icon" },
+    { sort: "oratory", icon: OratoryIcon, alt: "Oratory Icon" },
+    { sort: "loyalty", icon: LoyaltyIcon, alt: "Loyalty Icon" },
+    { sort: "influence", icon: InfluenceIcon, alt: "Influence Icon" },
+    { sort: "talents", icon: TalentsIcon, alt: "Talents Icon" },
+    { sort: "popularity", icon: PopularityIcon, alt: "Popularity Icon" },
+    { sort: "knights", icon: KnightsIcon, alt: "Knights Icon" },
+  ];
+
   return (
     <div className={styles.listContainer} style={{height: props.height, margin: props.margin ?? 0}}>
       <div className={`${styles.headers} ${props.setRadioSelectedSenator ? styles.radioHeaderMargin : ''}`}
@@ -140,41 +150,13 @@ const SenatorsTab = (props: SenatorsTabProps) => {
               style={{marginRight: 0}} className={styles.header}/>
           }
         </div>
-        <div onClick={() => handleSortClick("military")} className={styles.header}>
-          <Image src={MilitaryIcon} height={iconSize} width={iconSize} alt="Military Icon" />
-          {sort === "military" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
-          {sort === "-military" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
-        </div>
-        <div onClick={() => handleSortClick("oratory")} className={styles.header}>
-          <Image src={OratoryIcon} height={iconSize} width={iconSize} alt="Oratory Icon" />
-          {sort === "oratory" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
-          {sort === "-oratory" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
-        </div>
-        <div onClick={() => handleSortClick("loyalty")} className={styles.header}>
-          <Image src={LoyaltyIcon} height={iconSize} width={iconSize} alt="Loyalty Icon" />
-          {sort === "loyalty" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
-          {sort === "-loyalty" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
-        </div>
-        <div onClick={() => handleSortClick("influence")} className={styles.header}>
-          <Image src={InfluenceIcon} height={iconSize} width={iconSize} alt="Influence Icon" />
-          {sort === "influence" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
-          {sort === "-influence" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
-        </div>
-        <div onClick={() => handleSortClick("talents")} className={styles.header}>
-          <Image src={TalentsIcon} height={iconSize} width={iconSize} alt="Talents Icon" />
-          {sort === "talents" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
-          {sort === "-talents" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
-        </div>
-        <div onClick={() => handleSortClick("popularity")} className={styles.header}>
-          <Image src={PopularityIcon} height={iconSize} width={iconSize} alt="Popularity Icon" />
-          {sort === "popularity" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
-          {sort === "-popularity" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
-        </div>
-        <div onClick={() => handleSortClick("knights")} className={styles.header}>
-          <Image src={KnightsIcon} height={iconSize} width={iconSize} alt="Knights Icon" />
-          {sort === "knights" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
-          {sort === "-knights" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
-        </div>
+        {headers.map(header => (
+          <div onClick={() => handleSortClick(header.sort)} className={styles.header} key={header.sort}>
+            <Image src={header.icon} height={iconSize} width={iconSize} alt={header.alt} />
+            {sort === header.sort && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+            {sort === `-${header.sort}` && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+          </div>
+        ))}
       </div>
       <div className={styles.list}>
         <AutoSizer>
@@ -190,7 +172,7 @@ const SenatorsTab = (props: SenatorsTabProps) => {
         </AutoSizer>
       </div>
     </div>
-  )
+  );
 }
 
 export default SenatorsTab

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -3,7 +3,9 @@ import Image from 'next/image'
 import { List, ListRowProps } from 'react-virtualized';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { Radio } from '@mui/material';
+import { Checkbox, FormControlLabel, Radio } from '@mui/material';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 
 import SenatorListItem from '@/components/SenatorListItem'
 import { useGameContext } from '@/contexts/GameContext'
@@ -19,6 +21,8 @@ import KnightsIcon from "@/images/icons/knights.svg"
 import Faction from '@/classes/Faction';
 import Collection from '@/classes/Collection';
 
+type SortAttribute = "military" | "oratory" | "loyalty" | "influence" | "talents" | "popularity" | "knights"
+
 interface SenatorsTabProps {
   selectable?: boolean
   height?: number
@@ -30,9 +34,12 @@ interface SenatorsTabProps {
 
 // List of senators
 const SenatorsTab = (props: SenatorsTabProps) => {
-  const { allSenators } = useGameContext()
+  const { allFactions, allSenators } = useGameContext()
 
-  const [filteredAndSortedSenators, setFilteredSenators] = useState<Collection<Senator>>(new Collection<Senator>())
+  const [sort, setSort] = useState<string>('')  // Attribute to sort by, prefixed with '-' for descending order
+  const [grouped, setGrouped] = useState<boolean>(false)  // Whether to group senators by faction
+
+  const [filteredSortedSenators, setFilteredSortedSenators] = useState<Collection<Senator>>(new Collection<Senator>())
 
   // Filter and sort the senator list
   useEffect(() => {
@@ -41,19 +48,66 @@ const SenatorsTab = (props: SenatorsTabProps) => {
       senators = senators.filter(s => s.faction === props.faction?.id)
     }
 
-    // Sort by name in alphabetical order
+    // Sort by name in alphabetical order as base/default order
     senators = senators.sort((a, b) => a.name.localeCompare(b.name))
 
-    setFilteredSenators(new Collection<Senator>(senators))
-  }, [allSenators, props.faction])
+    // Sort by the selected attribute
+    if (sort !== '') {
+      const isDescending = sort.startsWith('-');
+      const attribute = sort.replace('-', '');
+      senators = senators.sort((a, b) => {
+        if (a[attribute as SortAttribute] > b[attribute as SortAttribute]) return isDescending ? -1 : 1;
+        if (a[attribute as SortAttribute] < b[attribute as SortAttribute]) return isDescending ? 1 : -1;
+        return 0;
+      });
+    }
+
+    // Finally, sort by faction if grouped is true
+    if (grouped) {
+      senators = senators.sort((a, b) => {
+        const factionA = allFactions.asArray.find(f => f.id === a.faction)
+        const factionB = allFactions.asArray.find(f => f.id === b.faction)
+
+        if (factionA === undefined && factionB === undefined) {
+          return 0
+        } else if (factionA === undefined) {
+          return 1
+        } else if (factionB === undefined) {
+          return -1
+        } else {
+          return factionA.position - factionB.position
+        }
+      });
+    }
+
+    setFilteredSortedSenators(new Collection<Senator>(senators))
+  }, [allSenators, sort, grouped, props.faction])
 
   const handleRadioSelectSenator = (senator: Senator) => {
     if (props.setRadioSelectedSenator) props.setRadioSelectedSenator(senator)
   }
 
+  const handleSortClick = (attributeName: string) => {
+    if (sort === attributeName) {
+      setSort('')
+    } else if (sort === `-${attributeName}`) {
+      setSort(attributeName)
+    } else {
+      setSort(`-${attributeName}`)
+    }
+  }
+
+  const handleGroupClick = () => {
+    if (grouped === true) {
+      setGrouped(false)
+    } else {
+      setGrouped(true)
+    }
+  }
+
   // Function to render each row in the list
   const rowRenderer = ({ index, key, style }: ListRowProps) => {
-    const senator: Senator = filteredAndSortedSenators.asArray[index]
+    const senator: Senator = filteredSortedSenators.asArray[index]
   
     return (
       <div key={key} style={style} onClick={() => handleRadioSelectSenator(senator)}>
@@ -76,14 +130,50 @@ const SenatorsTab = (props: SenatorsTabProps) => {
 
   return (
     <div className={styles.listContainer} style={{height: props.height, margin: props.margin ?? 0}}>
-      <div className={`${styles.headers} ${props.setRadioSelectedSenator ? styles.radioHeaderMargin : ''}`}>
-        <div><Image src={MilitaryIcon} height={iconSize} width={iconSize} alt="Military Icon" /></div>
-        <div><Image src={OratoryIcon} height={iconSize} width={iconSize} alt="Oratory Icon" /></div>
-        <div><Image src={LoyaltyIcon} height={iconSize} width={iconSize} alt="Loyalty Icon" /></div>
-        <div><Image src={InfluenceIcon} height={iconSize} width={iconSize} alt="Influence Icon" /></div>
-        <div><Image src={TalentsIcon} height={iconSize} width={iconSize} alt="Talents Icon" /></div>
-        <div><Image src={PopularityIcon} height={iconSize} width={iconSize} alt="Popularity Icon" /></div>
-        <div><Image src={KnightsIcon} height={iconSize} width={iconSize} alt="Knights Icon" /></div>
+      <div className={`${styles.headers} ${props.setRadioSelectedSenator ? styles.radioHeaderMargin : ''}`}
+        style={{height: sort === "" ? 42 : 55}}
+      >
+        <div className={styles.groupButton}>
+          {!props.faction &&
+            <FormControlLabel control={<Checkbox style={{ marginLeft: 0, marginRight: -8 }} checked={grouped} />}
+              label="Group by Faction" onChange={handleGroupClick} style={{marginRight: 0}} />
+          }
+        </div>
+        <div onClick={() => handleSortClick("military")}>
+          <Image src={MilitaryIcon} height={iconSize} width={iconSize} alt="Military Icon" />
+          {sort === "military" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+          {sort === "-military" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+        </div>
+        <div onClick={() => handleSortClick("oratory")}>
+          <Image src={OratoryIcon} height={iconSize} width={iconSize} alt="Oratory Icon" />
+          {sort === "oratory" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+          {sort === "-oratory" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+        </div>
+        <div onClick={() => handleSortClick("loyalty")}>
+          <Image src={LoyaltyIcon} height={iconSize} width={iconSize} alt="Loyalty Icon" />
+          {sort === "loyalty" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+          {sort === "-loyalty" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+        </div>
+        <div onClick={() => handleSortClick("influence")}>
+          <Image src={InfluenceIcon} height={iconSize} width={iconSize} alt="Influence Icon" />
+          {sort === "influence" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+          {sort === "-influence" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+        </div>
+        <div onClick={() => handleSortClick("talents")}>
+          <Image src={TalentsIcon} height={iconSize} width={iconSize} alt="Talents Icon" />
+          {sort === "talents" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+          {sort === "-talents" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+        </div>
+        <div onClick={() => handleSortClick("popularity")}>
+          <Image src={PopularityIcon} height={iconSize} width={iconSize} alt="Popularity Icon" />
+          {sort === "popularity" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+          {sort === "-popularity" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+        </div>
+        <div onClick={() => handleSortClick("knights")}>
+          <Image src={KnightsIcon} height={iconSize} width={iconSize} alt="Knights Icon" />
+          {sort === "knights" && <FontAwesomeIcon icon={faChevronUp} fontSize={18} />}
+          {sort === "-knights" && <FontAwesomeIcon icon={faChevronDown} fontSize={18} />}
+        </div>
       </div>
       <div className={styles.list}>
         <AutoSizer>
@@ -91,7 +181,7 @@ const SenatorsTab = (props: SenatorsTabProps) => {
             <List
               width={width}
               height={height}
-              rowCount={filteredAndSortedSenators.asArray.length}
+              rowCount={filteredSortedSenators.asArray.length}
               rowHeight={104}
               rowRenderer={rowRenderer}
             />

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -32,14 +32,18 @@ interface SenatorsTabProps {
 const SenatorsTab = (props: SenatorsTabProps) => {
   const { allSenators } = useGameContext()
 
-  const [filteredSenators, setFilteredSenators] = useState<Collection<Senator>>(new Collection<Senator>())
+  const [filteredAndSortedSenators, setFilteredSenators] = useState<Collection<Senator>>(new Collection<Senator>())
 
-  // Filter senator list
+  // Filter and sort the senator list
   useEffect(() => {
     let senators = allSenators.asArray
     if (props.faction) {
       senators = senators.filter(s => s.faction === props.faction?.id)
     }
+
+    // Sort by name in alphabetical order
+    senators = senators.sort((a, b) => a.name.localeCompare(b.name))
+
     setFilteredSenators(new Collection<Senator>(senators))
   }, [allSenators, props.faction])
 
@@ -49,7 +53,7 @@ const SenatorsTab = (props: SenatorsTabProps) => {
 
   // Function to render each row in the list
   const rowRenderer = ({ index, key, style }: ListRowProps) => {
-    const senator: Senator = filteredSenators.asArray[index]
+    const senator: Senator = filteredAndSortedSenators.asArray[index]
   
     return (
       <div key={key} style={style} onClick={() => handleRadioSelectSenator(senator)}>
@@ -87,7 +91,7 @@ const SenatorsTab = (props: SenatorsTabProps) => {
             <List
               width={width}
               height={height}
-              rowCount={filteredSenators.asArray.length}
+              rowCount={filteredAndSortedSenators.asArray.length}
               rowHeight={104}
               rowRenderer={rowRenderer}
             />

--- a/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
@@ -38,7 +38,7 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps ) => {
             <small>*Except when executed as a result of a Special Major Prosecution.</small>
           </p>
           {/* 354 pixels is the height required to show 3 senators */}
-          <SenatorsList faction={faction} height={354} radioSelectedSenator={selectedSenator} setRadioSelectedSenator={setSelectedSenator} />
+          <SenatorsList faction={faction} height={356} radioSelectedSenator={selectedSenator} setRadioSelectedSenator={setSelectedSenator} />
         </DialogContent>
         <DialogActions>
           <Button>Select</Button>


### PR DESCRIPTION
Closes #199 by allowing the senators to be sortable. This change also allows senators to be grouped by faction, which is compatible with sorting.

![Recording 2023-08-29 at 21 28 54](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/61d9b866-7a7b-4c27-bf4b-5122903a5427)

This also works on the action dialog's use of the `SenatorList` component:

![Recording 2023-08-29 at 21 33 44](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/5293ea78-b9d9-43c2-86a3-e9915a1248fa)

