### PR TITLE
Replace uses of `Collection.asArray`

### DIFF
--- a/frontend/classes/Collection.ts
+++ b/frontend/classes/Collection.ts
@@ -1,38 +1,37 @@
 interface Identifiable {
-  id: number;
-  [key: string]: any;
+  id: number
+  [key: string]: any
 }
 
 class Collection<T extends Identifiable> {
-  byId: { [key: number]: T };
-  allIds: number[];
+  byId: { [key: number]: T }
+  allIds: number[]
 
   constructor(instances: T[] = []) {
-    this.byId = {};
-    this.allIds = [];
+    this.byId = {}
+    this.allIds = []
 
     for (let instance of instances) {
-      this.add(instance);
+      this.add(instance)
     }
   }
 
   add(instance: T) {
-    this.byId[instance.id] = instance;
-    this.allIds.push(instance.id);
+    this.byId[instance.id] = instance
+    this.allIds.push(instance.id)
+    return this
   }
 
   remove(id: number) {
-    delete this.byId[id];
-    this.allIds = this.allIds.filter(instanceId => instanceId !== id);
-  }
-
-  update(instance: T) {
-    this.byId[instance.id] = instance;
+    delete this.byId[id]
+    this.allIds = this.allIds.filter(instanceId => instanceId !== id)
+    const newInstances = this.allIds.map(instanceId => this.byId[instanceId])
+    return new Collection(newInstances)
   }
 
   get asArray(): T[] {
-    return this.allIds.map(id => this.byId[id]);
+    return this.allIds.map(id => this.byId[id])
   }
 }
 
-export default Collection;
+export default Collection

--- a/frontend/components/DetailSection_Faction.tsx
+++ b/frontend/components/DetailSection_Faction.tsx
@@ -27,9 +27,8 @@ const FactionDetails = (props: FactionDetailsProps) => {
   // Get faction related data
   useEffect(() => {
     if (selectedEntity && selectedEntity.className === "Faction") {
-      setSenators(new Collection<Senator>(allSenators.asArray.filter(s => s.faction === selectedEntity?.id)))
-      setFaction(allFactions.asArray.find(f => f.id === selectedEntity?.id) ?? null)
-      
+      setSenators(new Collection<Senator>(allSenators.asArray.filter(s => s.faction === selectedEntity.id)))
+      setFaction(allFactions.byId[selectedEntity.id] ?? null)
     } else {
       setSenators(new Collection<Senator>())
       setFaction(null)
@@ -38,8 +37,8 @@ const FactionDetails = (props: FactionDetailsProps) => {
   }, [selectedEntity, allFactions, allSenators, allTitles, faction])
 
   useEffect(() => {
-    if (selectedEntity && selectedEntity.className === "Faction") {
-      setPlayer(allPlayers.asArray.find(p => p.id === faction?.player) ?? null)
+    if (faction && selectedEntity && selectedEntity.className === "Faction") {
+      setPlayer(allPlayers.byId[faction.player] ?? null)
     }
   }, [selectedEntity, allPlayers, faction])
 

--- a/frontend/components/DetailSection_Senator.tsx
+++ b/frontend/components/DetailSection_Senator.tsx
@@ -40,19 +40,19 @@ const SenatorDetails = (props: SenatorDetailsProps) => {
   // Selected senator
   const [senator, setSenator] = useState<Senator | null>(null)
   useEffect(() => {
-    if (selectedEntity) setSenator(allSenators.asArray.find(f => f.id === selectedEntity.id) ?? null)
+    if (selectedEntity) setSenator(allSenators.byId[selectedEntity.id] ?? null)
   }, [allFactions, selectedEntity, allSenators, setSenator])
   
   // Faction that this senator is aligned to
   const [faction, setFaction] = useState<Faction | null>(null)
   useEffect(() => {
-    if (senator) setFaction(allFactions.asArray.find(f => f.id === senator.faction) ?? null)
+    if (senator) setFaction(allFactions.byId[senator.faction] ?? null)
   }, [allFactions, senator, setFaction])
   
   // Player that controls this senator
   const [player, setPlayer] = useState<Player | null>(null)
   useEffect(() => {
-    if (faction) setPlayer(allPlayers.asArray.find(p => p.id === faction.player) ?? null)
+    if (faction) setPlayer(allPlayers.byId[faction.player] ?? null)
   }, [allPlayers, faction, setPlayer])
 
   // Calculate senator portrait size.

--- a/frontend/components/FactionListItem.tsx
+++ b/frontend/components/FactionListItem.tsx
@@ -21,7 +21,7 @@ const FactionListItem = (props: FactionListItemProps) => {
   // Player that controls this faction
   const [player, setPlayer] = useState<Player | null>(null)
   useEffect(() => {
-    setPlayer(allPlayers.asArray.find(p => p.id === props.faction.player) ?? null)
+    setPlayer(allPlayers.byId[props.faction.player] ?? null)
   }, [allPlayers, props.faction, setPlayer])
 
   // Senators in this faction
@@ -31,7 +31,7 @@ const FactionListItem = (props: FactionListItemProps) => {
     setSenators(new Collection<Senator>(senators))
   }, [allSenators, props.faction, setSenators])
 
-  if (player && player.user && senators.asArray.length > 0) {
+  if (player && player.user && senators.allIds.length > 0) {
     return (
       <div className={styles.factionListItem}>
         <p>

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -225,7 +225,7 @@ const GamePage = (props: GamePageProps) => {
                   if (existingInstances.allIds.includes(newInstance.id)) {
                     return existingInstances
                   } else {
-                    return new Collection<PotentialAction>([...existingInstances.asArray, newInstance])
+                    return existingInstances.add(newInstance)
                   }
                 }
               )
@@ -235,7 +235,7 @@ const GamePage = (props: GamePageProps) => {
           // Remove a potential action
           if (message?.operation === "destroy") {
             const idToRemove = message.instance.id
-            setPotentialActions((potentialActions) => new Collection<PotentialAction>(potentialActions.asArray.filter(p => p.id !== idToRemove)))
+            setPotentialActions((potentialActions) => potentialActions.remove(idToRemove))
           }
         }
 
@@ -252,7 +252,7 @@ const GamePage = (props: GamePageProps) => {
                   if (existingInstances.allIds.includes(newInstance.id)) {
                     return existingInstances
                   } else {
-                    return new Collection<Title>([...existingInstances.asArray, newInstance])
+                    return existingInstances.add(newInstance)
                   }
                 }
               )
@@ -262,7 +262,7 @@ const GamePage = (props: GamePageProps) => {
           // Remove an active title
           if (message?.operation === "destroy") {
             const idToRemove = message.instance.id
-            setAllTitles((titles) => new Collection<Title>(titles.asArray.filter(t => t.id !== idToRemove)))
+            setAllTitles((titles) => titles.remove(idToRemove))
           }
         }
       }

--- a/frontend/components/MainSection_FactionsTab.tsx
+++ b/frontend/components/MainSection_FactionsTab.tsx
@@ -29,7 +29,7 @@ const FactionsTab = () => {
             <List
               width={width}
               height={height}
-              rowCount={allFactions.asArray.length}
+              rowCount={allFactions.allIds.length}
               rowHeight={170}
               rowRenderer={rowRenderer}
             />

--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -38,7 +38,7 @@ const ProgressSection = (props: ProgressSectionProps) => {
       <section className={styles.progressSection}>
         <div className={styles.actionItems}>
           {props.allPotentialActions.asArray.map((potentialAction) => {
-            const faction = allFactions.asArray.find(f => f.id === potentialAction.faction) ?? null
+            const faction = allFactions.byId[potentialAction.faction] ?? null
 
             return (
               <div key={potentialAction.id}>

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -65,8 +65,8 @@ const SenatorList = (props: SenatorListProps) => {
     // Finally, sort by faction if grouped is true
     if (grouped) {
       senators = senators.sort((a, b) => {
-        const factionA = allFactions.asArray.find(f => f.id === a.faction)
-        const factionB = allFactions.asArray.find(f => f.id === b.faction)
+        const factionA = allFactions.byId[a.faction] ?? null
+        const factionB = allFactions.byId[b.faction] ?? null
 
         if (factionA === undefined && factionB === undefined) {
           return 0
@@ -164,7 +164,7 @@ const SenatorList = (props: SenatorListProps) => {
             <List
               width={width}
               height={height}
-              rowCount={filteredSortedSenators.asArray.length}
+              rowCount={filteredSortedSenators.allIds.length}
               rowHeight={104}
               rowRenderer={rowRenderer}
             />

--- a/frontend/components/SenatorListItem.tsx
+++ b/frontend/components/SenatorListItem.tsx
@@ -22,13 +22,13 @@ const SenatorListItem = (props: SenatorListItemProps) => {
   // Faction that this senator is aligned to
   const [faction, setFaction] = useState<Faction | null>(null)
   useEffect(() => {
-    setFaction(allFactions.asArray.find(f => f.id === props.senator.faction) ?? null)
+    setFaction(allFactions.byId[props.senator.faction] ?? null)
   }, [allFactions, props.senator, setFaction])
 
   // Player that controls this senator
   const [player, setPlayer] = useState<Player | null>(null)
   useEffect(() => {
-    if (faction) setPlayer(allPlayers.asArray.find(p => p.id === faction.player) ?? null)
+    if (faction) setPlayer(allPlayers.byId[faction.player] ?? null)
   }, [allPlayers, faction, setFaction])
 
   return (

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -73,7 +73,7 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
 
   // Update faction
   useEffect(() => {
-    setFaction(allFactions.asArray.find(f => f.id === props.senator.faction) ?? null)
+    setFaction(allFactions.byId[props.senator.faction] ?? null)
   }, [allFactions, props.senator, setFaction])
 
   // Update titles

--- a/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
@@ -55,7 +55,7 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps ) => {
   }
 
   if (requiredAction) {
-    const faction = allFactions.asArray.find(f => f.id === requiredAction?.faction)
+    const faction = allFactions.byId[requiredAction.faction] ?? null
     return (
       <>
         <DialogTitle>Select your Faction Leader</DialogTitle>


### PR DESCRIPTION
Closes #202 by replacing uses of `asArray` with `byId` or `allIds` because these members are more convenient, standardized and a little more performant.