### PR TITLE
Make sorting and grouping persistent

### DIFF
--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -20,7 +20,7 @@ import { useAuthContext } from '@/contexts/AuthContext'
 import { deserializeToInstance, deserializeToInstances } from '@/functions/serialize'
 import Collection from '@/classes/Collection'
 import styles from "./GamePage.module.css"
-import SenatorsTab from '@/components/SenatorList'
+import SenatorList from '@/components/SenatorList'
 import FactionsTab from '@/components/MainSection_FactionsTab'
 import DetailSection from '@/components/DetailSection'
 import Turn from '@/classes/Turn'
@@ -48,7 +48,7 @@ const GamePage = (props: GamePageProps) => {
   const [syncingGameData, setSyncingGameData] = useState<boolean>(true)
 
   // Game-specific state
-  const { game, setGame, latestStep, setLatestStep, setAllPlayers, setAllFactions, setAllSenators, setAllTitles } = useGameContext()
+  const { game, setGame, setLatestStep, setAllPlayers, setAllFactions, setAllSenators, setAllTitles } = useGameContext()
   const [latestTurn, setLatestTurn] = useState<Turn | null>(null)
   const [latestPhase, setLatestPhase] = useState<Phase | null>(null)
   const [potentialActions, setPotentialActions] = useState<Collection<PotentialAction>>(new Collection<PotentialAction>())
@@ -62,7 +62,9 @@ const GamePage = (props: GamePageProps) => {
   }, [props.initialLatestSteps, setLatestStep])
 
   // UI selections
-  const [mainTab, setMainTab] = useState(0);
+  const [mainTab, setMainTab] = useState(0)
+  const [mainSenatorListSort, setMainSenatorListSort] = useState<string>('')
+  const [mainSenatorListGrouped, setMainSenatorListGrouped] = useState<boolean>(false)
 
   // Establish a WebSocket connection and provide a state containing the last message
   const { lastMessage } = useWebSocket(webSocketURL + `games/${props.gameId}/`, {
@@ -347,11 +349,16 @@ const GamePage = (props: GamePageProps) => {
                   <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
                     <Tabs value={mainTab} onChange={handleMainTabChange} className={styles.tabs}>
                       <Tab label="Factions" />
-                      <Tab label="Senators" />
+                      <Tab label="Senators"/>
                     </Tabs>
                   </Box>
                   {mainTab === 0 && <FactionsTab />}
-                  {mainTab === 1 && <SenatorsTab margin={8} selectable />}
+                  {mainTab === 1 &&
+                    <SenatorList margin={8} selectable
+                      mainSenatorListSortState={[mainSenatorListSort, setMainSenatorListSort]}
+                      mainSenatorListGroupedState={[mainSenatorListGrouped, setMainSenatorListGrouped]}
+                    />
+                  }
                 </section>
               </Card>
               <Card variant="outlined" className={styles.normalSection}>

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -30,14 +30,17 @@ interface SenatorListProps {
   faction?: Faction
   radioSelectedSenator?: Senator | null
   setRadioSelectedSenator?: (senator: Senator | null) => void
+  mainSenatorListSortState?: [string, (sort: string) => void]
+  mainSenatorListGroupedState?: [boolean, (grouped: boolean) => void]
 }
 
 // List of senators
 const SenatorList = (props: SenatorListProps) => {
   const { allFactions, allSenators } = useGameContext()
 
-  const [sort, setSort] = useState<string>('')  // Attribute to sort by, prefixed with '-' for descending order
-  const [grouped, setGrouped] = useState<boolean>(false)  // Whether to group senators by faction
+  // State for sorting and grouping. Optionally passed in from parent component
+  const [sort, setSort] = props.mainSenatorListSortState ?? useState<string>('')  // Attribute to sort by, prefixed with '-' for descending order
+  const [grouped, setGrouped] = props.mainSenatorListGroupedState ?? useState<boolean>(false)  // Whether to group senators by faction
 
   const [filteredSortedSenators, setFilteredSortedSenators] = useState<Collection<Senator>>(new Collection<Senator>())
 

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -39,8 +39,12 @@ const SenatorList = (props: SenatorListProps) => {
   const { allFactions, allSenators } = useGameContext()
 
   // State for sorting and grouping. Optionally passed in from parent component
-  const [sort, setSort] = props.mainSenatorListSortState ?? useState<string>('')  // Attribute to sort by, prefixed with '-' for descending order
-  const [grouped, setGrouped] = props.mainSenatorListGroupedState ?? useState<boolean>(false)  // Whether to group senators by faction
+  const [localSort, setLocalSort] = useState<string>('')  // Attribute to sort by, prefixed with '-' for descending order
+  const [localGrouped, setLocalGrouped] = useState<boolean>(false)  // Whether to group senators by faction
+  const sort = props.mainSenatorListSortState ? props.mainSenatorListSortState[0] : localSort
+  const setSort = props.mainSenatorListSortState ? props.mainSenatorListSortState[1] : setLocalSort
+  const grouped = props.mainSenatorListGroupedState ? props.mainSenatorListGroupedState[0] : localGrouped
+  const setGrouped = props.mainSenatorListGroupedState ? props.mainSenatorListGroupedState[1] : setLocalGrouped
 
   const [filteredSortedSenators, setFilteredSortedSenators] = useState<Collection<Senator>>(new Collection<Senator>())
 


### PR DESCRIPTION
Closes #208 by making sorting and grouping persistent by storing the relevant state on the game page. This is optional though - other instances of the `SenatorList` component default to storing this state themselves (in which case the sorting is not persistent).