### PR TITLE
Stop unauthenticated users from using WebSockets

### DIFF
--- a/backend/rorsite/asgi.py
+++ b/backend/rorsite/asgi.py
@@ -8,11 +8,10 @@ https://docs.djangoproject.com/en/4.1/howto/deployment/asgi/
 """
 
 import os
-
-from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
+from rorapp.middleware.jwt_auth_middleware import JwtAuthMiddleware
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rorsite.settings')
 # Initialize Django ASGI application early to ensure the AppRegistry
@@ -25,7 +24,7 @@ application = ProtocolTypeRouter(
     {
         "http": get_asgi_application(),
         "websocket": AllowedHostsOriginValidator(
-            AuthMiddlewareStack(URLRouter(rorapp.routing.websocket_urlpatterns))
+            JwtAuthMiddleware(URLRouter(rorapp.routing.websocket_urlpatterns))
         ),
     }
 )

--- a/backend/rorsite/settings.py
+++ b/backend/rorsite/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     'rorapp.apps.RorappConfig',
     'rest_framework',
     'corsheaders',
+    'channels',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -69,7 +69,7 @@ const GamePage = (props: GamePageProps) => {
   const [mainSenatorListGrouped, setMainSenatorListGrouped] = useState<boolean>(false)
 
   // Establish a WebSocket connection and provide a state containing the last message
-  const { lastMessage } = useWebSocket(webSocketURL + `games/${props.gameId}/`, {
+  const { lastMessage } = useWebSocket(webSocketURL + `games/${props.gameId}/?token=${accessToken}`, {
 
     // On connection open, if this isn't the first render then perform a full sync
     onOpen: () => {

--- a/frontend/pages/games/[id]/index.tsx
+++ b/frontend/pages/games/[id]/index.tsx
@@ -65,8 +65,8 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
   const [latestStep, setLatestStep] = useState<Step | null>(null)
 
   // Establish a WebSocket connection and provide a state containing the last message
-  const { lastMessage } = useWebSocket(webSocketURL + `games/${props.gameId}/`, {
-
+  const { lastMessage } = useWebSocket(webSocketURL + `games/${props.gameId}/?token=${accessToken}`, {
+    
     // On connection open, if this isn't the first render then perform a full sync
     onOpen: () => {
       console.log('WebSocket connection opened')


### PR DESCRIPTION
Closes #241 by adding an authentication middleware for Channels, so only authenticated users can connect to WebSocket channels. Unauthenticated users are rejected when they attempt to establish a connection.