### PR TITLE
Fix React console error on games page

### DIFF
--- a/frontend/pages/games/index.tsx
+++ b/frontend/pages/games/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -135,11 +135,13 @@ const BrowseGamesPage = (props: BrowseGamesPageProps) => {
   }
 
   // Sign out if authentication failed on the server
-  if (props.authFailure) {
-    setAccessToken('')
-    setRefreshToken('')
-    setUser(null)
-  }
+  useEffect(() => {
+    if (props.authFailure) {
+      setAccessToken('')
+      setRefreshToken('')
+      setUser(null)
+    }
+  }, [props.authFailure, setAccessToken, setRefreshToken, setUser])
 
   // Render page error if user is not signed in
   if (user === null || props.authFailure) {


### PR DESCRIPTION
Closes #243 by fixing an issue where a set state was being called within the `BrowseGamesPage` component, without being wrapped inside a `useEffect`. By moving the code into a `useEffect`, the console error on this page has been removed.