### PR TITLE
Force re-render of portrait on senator prop change

### DIFF
--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -15,7 +15,7 @@ import Faction from "@/classes/Faction"
 import Notification from "@/classes/Notification"
 import NotificationContainer from "@/components/notifications/Notification"
 
-const typedActions: ActionsType = Actions;
+const typedActions: ActionsType = Actions
 
 interface ProgressSectionProps {
   allPotentialActions: Collection<PotentialAction>
@@ -46,19 +46,18 @@ const ProgressSection = (props: ProgressSectionProps) => {
   // Scroll to the bottom of the notification list when `scrollToBottom` is true
   useEffect(() => {
     if (scrollToBottom && notificationListRef.current) {
-      const scrollableDiv = notificationListRef.current;
+      const scrollableDiv = notificationListRef.current
       scrollableDiv.scrollTo({
         top: scrollableDiv.scrollHeight,
         behavior: 'smooth', // Enable smooth scrolling
-      });
-      setScrollToBottom(false);
+      })
+      setScrollToBottom(false)
     }
-  }, [scrollToBottom]);
+  }, [scrollToBottom])
 
   // Scroll to the bottom when the notification list is updated
   useEffect(() => {
-    console.log("props.notifications changed")
-    setScrollToBottom(true);
+    setScrollToBottom(true)
   }, [props.notifications.allIds.length])
 
   if (potentialActions) {
@@ -69,7 +68,7 @@ const ProgressSection = (props: ProgressSectionProps) => {
         <div className={styles.notificationArea}>
           <h3 style={{ lineHeight: '40px' }}>Notifications</h3>
           <div ref={notificationListRef} className={styles.notificationList}>
-            { props.notifications && props.notifications.asArray.sort((a, b) => a.index - b.index).map((notification) =>
+            {props.notifications && props.notifications.asArray.sort((a, b) => a.index - b.index).map((notification) =>
               <NotificationContainer key={notification.id} notification={notification} />
             )}
           </div>
@@ -96,7 +95,7 @@ const ProgressSection = (props: ProgressSectionProps) => {
               <ActionDialog potentialActions={potentialActions} open={dialogOpen} setOpen={setDialogOpen} onClose={() => setDialogOpen(false)}/>
             </>
             :
-            <>{ faction && <Button variant="contained" disabled>Waiting for others</Button> }</>
+            <>{faction && <Button variant="contained" disabled>Waiting for others</Button>}</>
           }
         </div>
       </div>

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -74,6 +74,9 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
   const [majorOffice, setMajorOffice] = useState<Title | null>(null)
   const [factionLeader, setFactionLeader] = useState<boolean>(false)
 
+  // Used to force a re-render when senator changes
+  const [key, setKey] = useState(0)
+
   // Update faction
   useEffect(() => {
     setFaction(allFactions.byId[props.senator.faction] ?? null)
@@ -192,6 +195,11 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
     return size
   }
 
+  // Whenever senator changes, update the key to force a re-render
+  useEffect(() => {
+    setKey(key + 1)
+  }, [props.senator])
+
   const handleMouseOver = () => {
     if (props.selectable) setHover(true)
   }
@@ -212,6 +220,7 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
       title={props.senator.name}
       onMouseOver={handleMouseOver} onMouseLeave={handleMouseLeave}
       onClick={handleClick}
+      key={key}
     >
       <figure style={{height: props.size, width: props.size}}>
         <div className={styles.imageContainer} style={getImageContainerStyle()}>
@@ -229,11 +238,14 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
             src={getPicture()}
             alt={"Portrait of " + props.senator.name}
             style={{transform: `translate(-50%, -${50 - getOffset()}%)`}}
+            placeholder='blur'
           />
         </div>
         <div className={styles.bg} style={getBgStyle()}></div>
-        { majorOffice && <TitleIcon title={majorOffice} size={getIconSize()} /> }
-        { props.senator.alive === false && <Image src={DeadIcon} alt="Dead" height={getIconSize()} className={styles.deadIcon} /> }
+        {majorOffice && <TitleIcon title={majorOffice} size={getIconSize()} />}
+        {props.senator.alive === false &&
+          <Image src={DeadIcon} alt="Dead" height={getIconSize()} className={styles.deadIcon} />
+        }
       </figure>
     </PortraitElement>
   )


### PR DESCRIPTION
Closes #190

Use the React `key` prop to force a re-render of the senator portrait component whenever the `senator` prop is changed. Also make the senator's Next.js `Image` component use a blurry placeholder whilst the full image loads. These two changes help improve the look of the senator images when using the app for the first time or with cache disabled.

### Videos
Recorded using Chrome Dev Tools with network throttled to Fast 3G and cache disabled

Before

![Recording 2023-09-19 at 08 15 38](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/7566e02a-812a-4569-a086-97611236ba3c)

After

![Recording 2023-09-19 at 08 12 29](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/63289ca9-2332-4a93-a5e1-014c70b9527a)
