### PR TITLE
Delay import of `JwtAuthMiddleware` in ASGI config

### DIFF
--- a/backend/rorsite/asgi.py
+++ b/backend/rorsite/asgi.py
@@ -11,20 +11,21 @@ import os
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
-from rorapp.middleware.jwt_auth_middleware import JwtAuthMiddleware
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rorsite.settings')
 # Initialize Django ASGI application early to ensure the AppRegistry
 # is populated before importing code that may import ORM models.
 django_asgi_app = get_asgi_application()
-
 import rorapp.routing
 
 application = ProtocolTypeRouter(
     {
         "http": get_asgi_application(),
         "websocket": AllowedHostsOriginValidator(
-            JwtAuthMiddleware(URLRouter(rorapp.routing.websocket_urlpatterns))
+            # Import JwtAuthMiddleware here, after Django settings have been configured.
+            URLRouter(rorapp.routing.websocket_urlpatterns, middleware=[
+                'rorapp.middleware.jwt_auth_middleware.JwtAuthMiddleware'
+            ])
         ),
     }
 )


### PR DESCRIPTION
In the ASGI configuration, delay import of `JwtAuthMiddleware` until after Django settings have been configured. This should fix a build failure in production that brought the API down a couple of days ago.