### PR TITLE
Fix indefinite loading bug on game pages

### DIFF
--- a/backend/rorapp/consumers/game.py
+++ b/backend/rorapp/consumers/game.py
@@ -11,7 +11,6 @@ class GameConsumer(WebsocketConsumer):
         if user and not isinstance(user, AnonymousUser):
             self.game_id = self.scope["url_route"]["kwargs"]["game_id"]
             self.game_group_name = "game_" + self.game_id
-            print(user)
 
             # Join game group
             async_to_sync(self.channel_layer.group_add)(


### PR DESCRIPTION
Fix an issue where the game lobby and game play pages would continue loading indefinitely if the user's auth JWT tokens have expired. This was happening because the client had no way of knowing that the user's tokens had expired without making a HTTP request. Now there is a `fetchGame` call within in the WebSocket hook's `onClose` event handler that will sign the user out if the call fails due to bad credentials.