### PR TITLE
Improve WebSocket connection handling

### DIFF
--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -48,6 +48,8 @@ export interface GamePageProps {
 const GamePage = (props: GamePageProps) => {
   const { accessToken, refreshToken, user, setAccessToken, setRefreshToken, setUser } = useAuthContext()
   const [syncingGameData, setSyncingGameData] = useState<boolean>(true)
+  const [latestTokenRefreshDate, setLatestTokenRefreshDate] = useState<Date | null>(null)
+  const [refreshingToken, setRefreshingToken] = useState<boolean>(false)
 
   // Game-specific state
   const { game, setGame, setLatestStep, setAllPlayers, setAllFactions, setAllSenators, setAllTitles } = useGameContext()
@@ -76,13 +78,23 @@ const GamePage = (props: GamePageProps) => {
     onOpen: () => {
       console.log('WebSocket connection opened')
       fullSync()
+      setLatestTokenRefreshDate(new Date())
     },
 
-    // On connection close validate authentication credentials,
-    // preventing the client from repeatedly trying to connect to the WebSocket
-    onClose: () => {
+    // On connection close refresh the access token in case their access token has expired
+    onClose: async () => {
       console.log('WebSocket connection closed')
-      refreshAccessToken(refreshToken, setAccessToken, setRefreshToken, setUser)
+
+      if (refreshingToken) return  // Don't refresh access token if already being refreshed
+
+      // Refresh the access token if it hasn't been refreshed yet or is 1 hour old
+      if (latestTokenRefreshDate === null || (latestTokenRefreshDate && latestTokenRefreshDate.getTime() < Date.now() - 1000 * 60 * 59)) {
+        console.log('Refreshing access token')
+        setRefreshingToken(true)
+        await refreshAccessToken(refreshToken, setAccessToken, setRefreshToken, setUser)
+        setLatestTokenRefreshDate(new Date())
+        setRefreshingToken(false)
+      }
     },
 
     // Don't attempt to reconnect
@@ -209,6 +221,7 @@ const GamePage = (props: GamePageProps) => {
   // Fully synchronize all game data
   const fullSync = useCallback(async () => {
     if (user === null) return  // Don't attempt to sync if user is not signed in
+    if (refreshingToken) return  // Don't attempt to sync if access token is being refreshed
 
     console.log("[Full Sync] started")
     const startTime = performance.now()

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -83,7 +83,7 @@ const GamePage = (props: GamePageProps) => {
 
     // On connection close refresh the access token in case their access token has expired
     onClose: async () => {
-      console.log('WebSocket connection closed')
+      console.log('WebSocket connection closed (or failed to connect)')
 
       if (refreshingToken) return  // Don't refresh access token if already being refreshed
 

--- a/frontend/pages/games/[id]/index.tsx
+++ b/frontend/pages/games/[id]/index.tsx
@@ -73,7 +73,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
 
     // On connection close refresh the access token in case their access token has expired
     onClose: async () => {
-      console.log('WebSocket connection closed')
+      console.log('WebSocket connection closed (or failed to connect)')
 
       if (refreshingToken) return  // Don't refresh access token if already being refreshed
 


### PR DESCRIPTION
Fix a bug where the game play page repeatedly connects and disconnects from the WebSocket connection, endlessly "loading". Also improve WebSocket connection handling to prevent multiple game synchronizations from happening in parallel.

The frontend's WebSocket handling logic is still not completely bullet proof, but it's one step closer.