### PR TITLE
Fix 401 game play page loading issue

### DIFF
--- a/frontend/components/GamePage.module.css
+++ b/frontend/components/GamePage.module.css
@@ -6,7 +6,7 @@
 }
 
 .loading {
-  padding: 18px 0;
+  padding: 8px 0;
   display: flex;
   flex-direction: column;
   gap: 18px;

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -87,6 +87,8 @@ const GamePage = (props: GamePageProps) => {
 
       if (refreshingToken) return  // Don't refresh access token if already being refreshed
 
+      if (user === null) setSyncingGameData(false)
+
       // Refresh the access token if it hasn't been refreshed yet or is 1 hour old
       if (latestTokenRefreshDate === null || (latestTokenRefreshDate && latestTokenRefreshDate.getTime() < Date.now() - 1000 * 60 * 59)) {
         console.log('Refreshing access token')


### PR DESCRIPTION
Fix an issue where, for non-authenticated users, the play page loaded indefinitely instead of showing the 401 error.