### PR TITLE
Add senator links

### DIFF
--- a/frontend/classes/Senator.ts
+++ b/frontend/classes/Senator.ts
@@ -1,3 +1,5 @@
+import numberToRoman from "@/functions/romanNumerals"
+
 interface SenatorData {
   id: number,
   name: string,
@@ -49,6 +51,10 @@ class Senator {
     this.knights = data.knights
     this.talents = data.talents
     this.votes = data.votes
+  }
+
+  get displayName() {
+    return this.name + (this.generation > 1 ? " " + numberToRoman(this.generation) : "")
   }
 }
 

--- a/frontend/components/SenatorLink.tsx
+++ b/frontend/components/SenatorLink.tsx
@@ -1,0 +1,23 @@
+import { Link } from "@mui/material"
+
+import { useGameContext } from '@/contexts/GameContext'
+import Senator from "@/classes/Senator"
+import SelectedEntity from "@/types/selectedEntity"
+
+interface SenatorLinkProps {
+  senator: Senator
+}
+
+const SenatorLink = (props: SenatorLinkProps) => {
+  const { setSelectedEntity } = useGameContext()
+
+  const handleClick = () => {
+    if (props.senator) setSelectedEntity({className: "Senator", id: props.senator.id} as SelectedEntity)
+  }
+
+  return (
+    <Link component="button" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>{props.senator.displayName}</Link>
+  )
+}
+
+export default SenatorLink

--- a/frontend/components/SenatorListItem.tsx
+++ b/frontend/components/SenatorListItem.tsx
@@ -8,6 +8,7 @@ import styles from './SenatorListItem.module.css'
 import FactionIcon from './FactionIcon'
 import { useGameContext } from '@/contexts/GameContext'
 import skillsJSON from "@/data/skills.json"
+import SenatorLink from '@/components/SenatorLink'
 
 interface SenatorListItemProps {
   senator: Senator
@@ -36,10 +37,8 @@ const SenatorListItem = (props: SenatorListItemProps) => {
     <div key={props.senator.id} className={`${styles.senatorListItem} ${props.radioSelected ? styles.radioSelected : ''}`}>
       <SenatorPortrait senator={props.senator} size={80} selectable={props.selectableSenators} />
       <div className={styles.primaryArea}>
-        <p>
-          <b>{props.senator.name}</b>
-          {props.senator.generation > 1 && <span> ({props.senator.generation})</span>}
-        </p>
+        <p><b><SenatorLink senator={props.senator} /></b></p>
+        
         <p>
           {faction && player ?
             <span>

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -217,7 +217,7 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
   return (
     <PortraitElement
       className={`${styles.senatorPortrait} ${props.selectable ? styles.selectable : ''}`}
-      title={props.senator.name}
+      title={props.senator.displayName}
       onMouseOver={handleMouseOver} onMouseLeave={handleMouseLeave}
       onClick={handleClick}
       key={key}
@@ -236,7 +236,7 @@ const SenatorPortrait = (props: SenatorPortraitProps) => {
             width={props.size + getZoom()}
             height={props.size + getZoom()}
             src={getPicture()}
-            alt={"Portrait of " + props.senator.name}
+            alt={"Portrait of " + props.senator.displayName}
             style={{transform: `translate(-50%, -${50 - getOffset()}%)`}}
             placeholder='blur'
           />

--- a/frontend/components/detailSections/DetailSection_Senator.module.css
+++ b/frontend/components/detailSections/DetailSection_Senator.module.css
@@ -4,13 +4,10 @@
   gap: 8px;
 }
 
-.primaryArea {
-  gap: 8px;
-}
-
 .portraitContainer {
   float: left;
   margin-right: 8px;
+  margin-bottom: 8px;
 }
 
 .textContainer>p:not(:last-child) {

--- a/frontend/components/detailSections/DetailSection_Senator.tsx
+++ b/frontend/components/detailSections/DetailSection_Senator.tsx
@@ -93,10 +93,7 @@ const SenatorDetails = (props: SenatorDetailsProps) => {
         <div className={styles.primaryArea}>
           <div className={styles.portraitContainer}><SenatorPortrait senator={senator} size={getPortraitSize()} /></div>
           <div className={styles.textContainer}>
-            <p>
-              <b>{senator.name}</b>
-              {senator.generation > 1 && <span> ({senator.generation})</span>}
-            </p>
+            <p><b>{senator.displayName}</b></p>
             <p>
               {factionNameAndUser ?
                 <span>

--- a/frontend/components/notifications/Notification_FaceMortality.tsx
+++ b/frontend/components/notifications/Notification_FaceMortality.tsx
@@ -8,6 +8,7 @@ import Faction from "@/classes/Faction"
 import DeadIcon from "@/images/icons/dead.svg"
 import styles from "./Notification.module.css"
 import Senator from '@/classes/Senator'
+import SenatorLink from "@/components/SenatorLink"
 
 interface FaceMortalityNotificationProps {
   notification: Notification
@@ -52,8 +53,8 @@ const FaceMortalityNotification = (props: FaceMortalityNotificationProps) => {
               {majorOffice && <span> {majorOffice} and</span>}
               {heir && <span> {faction?.getName()} Faction Leader</span>}
               {majorOffice || heir ? <span>, </span> : null}
-              <span> {senator.name}{senator.generation > 1 && <span> ({senator.generation})</span>} has passed away.</span>
-              {heir && <span> His heir {heir.name}{heir.generation > 1 && <span> ({heir.generation})</span>} has replaced him as Faction Leader.</span>}
+              <span><SenatorLink senator={senator} /> has passed away.</span>
+              {heir && <span> His heir <SenatorLink senator={heir} /> has replaced him as Faction Leader.</span>}
             </>
           </p>
         </Alert>

--- a/frontend/components/notifications/Notification_SelectFactionLeader.tsx
+++ b/frontend/components/notifications/Notification_SelectFactionLeader.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react"
 import Faction from "@/classes/Faction"
 import Senator from "@/classes/Senator"
 import styles from "./Notification.module.css"
+import SenatorLink from "@/components/SenatorLink"
 
 interface SelectFactionLeaderNotificationProps {
   notification: Notification
@@ -49,8 +50,8 @@ const SelectFactionLeaderNotification = (props: SelectFactionLeaderNotificationP
       <Alert icon={getIcon()} style={{backgroundColor: faction.getColor("textBg")}}>
         <b>New Faction Leader</b>
         <p>
-          {newFactionLeader.name} now holds the position of {faction?.getName()} Faction Leader
-          {oldFactionLeader ? `, taking over from ${oldFactionLeader.name}.` : '.'}
+          <SenatorLink senator={newFactionLeader} /> now holds the position of {faction?.getName()} Faction Leader
+          {oldFactionLeader ? ', taking over from ' + <SenatorLink senator={oldFactionLeader} /> + '.' : '.'}
         </p>
       </Alert>
     )

--- a/frontend/functions/romanNumerals.ts
+++ b/frontend/functions/romanNumerals.ts
@@ -1,0 +1,30 @@
+const numberToRoman = (num: number) => {
+  const romanNumerals = [
+    { value: 1000, numeral: 'M' },
+    { value: 900, numeral: 'CM' },
+    { value: 500, numeral: 'D' },
+    { value: 400, numeral: 'CD' },
+    { value: 100, numeral: 'C' },
+    { value: 90, numeral: 'XC' },
+    { value: 50, numeral: 'L' },
+    { value: 40, numeral: 'XL' },
+    { value: 10, numeral: 'X' },
+    { value: 9, numeral: 'IX' },
+    { value: 5, numeral: 'V' },
+    { value: 4, numeral: 'IV' },
+    { value: 1, numeral: 'I' }
+  ]
+
+  let result = ''
+
+  for (const { value, numeral } of romanNumerals) {
+    while (num >= value) {
+      result += numeral
+      num -= value
+    }
+  }
+
+  return result
+}
+
+export default numberToRoman


### PR DESCRIPTION
Closes #226

Add senator links, which are buttons styled like links (for good semantics/accessibility), that open the senator details when clicked. Also change the senator generation to display the number in Roman format instead of Arabic.