### PR TITLE
Improve the mortality message

### DIFF
--- a/frontend/components/notifications/Notification_FaceMortality.tsx
+++ b/frontend/components/notifications/Notification_FaceMortality.tsx
@@ -55,7 +55,9 @@ const FaceMortalityNotification = (props: FaceMortalityNotificationProps) => {
               {majorOffice && heir ? <span> and</span> : null}
               {heir && <span> <FactionLink faction={faction} /> Leader</span>}
               {majorOffice || heir ? <span>, </span> : null}
-              <span><SenatorLink senator={senator} /> has passed away.</span>
+              <SenatorLink senator={senator} />
+              {!heir && <span> of the <FactionLink faction={faction} /></span>}
+              <span> has passed away.</span>
               {heir && <span> His heir <SenatorLink senator={heir} /> has replaced him as Faction Leader.</span>}
             </>
           </p>


### PR DESCRIPTION
Improve the mortality message by making mention of the faction that victim was in, which is pretty useful to know.

![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/eb62ba5f-9df4-4b9c-b3f1-2d68490eeb94)
