### PR TITLE
Add an HRAO tooltip

### DIFF
--- a/frontend/components/MetaSection.tsx
+++ b/frontend/components/MetaSection.tsx
@@ -16,6 +16,7 @@ import Faction from '@/classes/Faction'
 import Senator from '@/classes/Senator'
 import FactionLink from '@/components/FactionLink'
 import SenatorLink from '@/components/SenatorLink'
+import { Tooltip } from '@mui/material'
 
 
 interface MetaSectionProps {
@@ -54,7 +55,7 @@ const MetaSection = (props: MetaSectionProps) => {
           {hrao &&
             <div>
               <span>
-                The HRAO is <SenatorLink senator={hrao} />
+                The <Tooltip title="Highest Ranking Available Officer" enterDelay={500} arrow><span>HRAO</span></Tooltip> is <SenatorLink senator={hrao} />
                 {hraoFaction && <span> of <FactionLink faction={hraoFaction} includeIcon /></span>}
               </span>
             </div>


### PR DESCRIPTION
Add an HRAO tooltip because it's otherwise difficult to figure out what "HRAO" means.

![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/d1c22d7e-e88c-458b-a189-c9c471979729)
