### PR TITLE
Add a cron job config file to the EB extensions

### DIFF
--- a/backend/.ebextensions/cronjob.config
+++ b/backend/.ebextensions/cronjob.config
@@ -1,0 +1,7 @@
+files:
+  "/etc/cron.d/docker_prune":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      0 6 * * * root sudo docker system prune -a >> /var/log/docker_prune.log 2>&1


### PR DESCRIPTION
Closes #196

Add a cron job config file to the EB extensions folder for running the `docker system prune -a` command once per day.