### PR TITLE
Fix senator death and leader assignment bugs

### DIFF
--- a/backend/rorapp/functions/face_mortality.py
+++ b/backend/rorapp/functions/face_mortality.py
@@ -2,16 +2,14 @@ import os
 import json
 from django.conf import settings
 from rest_framework.response import Response
-from channels.layers import get_channel_layer
-from asgiref.sync import async_to_sync
 from rorapp.functions.draw_mortality_chits import draw_mortality_chits
 from rorapp.functions.rank_senators_and_factions import rank_senators_and_factions
 from rorapp.functions.send_websocket_messages import send_websocket_messages
 from rorapp.functions.ws_message_create import ws_message_create
 from rorapp.functions.ws_message_destroy import ws_message_destroy
 from rorapp.functions.ws_message_update import ws_message_update
-from rorapp.models import Faction, PotentialAction, CompletedAction, Step, Senator, Title, Phase, Turn, ActionLog, SenatorActionLog
-from rorapp.serializers import ActionLogSerializer, PotentialActionSerializer, StepSerializer, TitleSerializer, PhaseSerializer, TurnSerializer, SenatorSerializer, SenatorActionLogSerializer
+from rorapp.models import Faction, PotentialAction, CompletedAction, Step, Senator, Title, Phase, ActionLog, SenatorActionLog
+from rorapp.serializers import ActionLogSerializer, PotentialActionSerializer, StepSerializer, TitleSerializer, PhaseSerializer, SenatorSerializer, SenatorActionLogSerializer
 
 
 def face_mortality(game, faction, potential_action, step):
@@ -53,7 +51,6 @@ def face_mortality(game, faction, potential_action, step):
                 
                 # Kill the senator
                 senator.death_step = step
-                senator.faction = None
                 senator.save()
                 killed_senator_count += 1
                 

--- a/backend/rorapp/functions/select_faction_leader.py
+++ b/backend/rorapp/functions/select_faction_leader.py
@@ -27,7 +27,7 @@ def select_faction_leader(game, faction, potential_action, step, data):
     '''
 
     try:
-        senator = Senator.objects.filter(faction=faction).get(id=data.get("leader_id"))
+        senator = Senator.objects.filter(faction=faction, death_step__isnull=True).get(id=data.get("leader_id"))
     except Senator.DoesNotExist:
         return Response({"message": "Selected faction leader (senator) was not found"}, status=404)
 

--- a/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
@@ -47,8 +47,8 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps) => {
       (t) => t.name === "Faction Leader"
     )
     const factionLeader = factionLeaderTitles
-      ? senators.find((s) =>
-          factionLeaderTitles.some((t) => t.senator === s.id)
+      ? senators.find(
+          (s) => factionLeaderTitles.some((t) => t.senator === s.id) && s.alive
         )
       : null
     if (factionLeader) setSelectedSenator(factionLeader)


### PR DESCRIPTION
Fix bug where upon senator death their faction was still being set to none. Fix a bug in the backend where a dead senator could be assigned faction leader. Fix an issue where a dead faction leader was invisibly selected by default in the faction leader selection action dialog.

These bugs were introduced in #294