### PR TITLE
Move the Amplify config into version control

### DIFF
--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: '18'
+        node-version: '18.17.1'
 
     - name: Cache dependencies
       uses: actions/cache@v2

--- a/amplify.yml
+++ b/amplify.yml
@@ -15,3 +15,4 @@ applications:
       cache:
         paths:
           - node_modules/**/*
+    appRoot: frontend

--- a/amplify.yml
+++ b/amplify.yml
@@ -15,4 +15,4 @@ applications:
       cache:
         paths:
           - node_modules/**/*
-    appRoot: frontend
+    appRoot: frontend 

--- a/frontend/amplify.yml
+++ b/frontend/amplify.yml
@@ -1,0 +1,17 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        preBuild:
+          commands:
+            - npm ci
+        build:
+          commands:
+            - npm run build
+      artifacts:
+        baseDirectory: .next
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*


### PR DESCRIPTION
Move the Amplify configuration file into version control, rather than having it only in the AWS management console. For now it doesn't use node 18.17.1, but rather the default version, so it will fail to build - but it's still progress.