### PR TITLE
Fix edit game page style and breadcrumb

### DIFF
--- a/frontend/components/Breadcrumb.tsx
+++ b/frontend/components/Breadcrumb.tsx
@@ -13,12 +13,23 @@ export interface CustomItem {
 const Breadcrumb = ({ customItems }: { customItems?: CustomItem[] }) => {
   const router = useRouter()
 
-  const path: string = router.pathname
-  let routes = [""]
+  const path: string = router.asPath
+  const pathName: string = router.pathname
+  const routes = ["home"]
   if (path != "/") {
-    routes = path.split("/")
+    const splitPath = path.split("/")
+    const splitPathName = pathName.split("/")
+
+    for (let i = 1; i < splitPath.length; i++) {
+      const routeFromPath = splitPath[i]
+      const routeFromPathName = splitPathName[i]
+      if (routeFromPath.startsWith("[") && routeFromPath.endsWith("]")) {
+        routes.push(routeFromPathName)
+      } else {
+        routes.push(routeFromPath)
+      }
+    }
   }
-  routes[0] = "home"
 
   return (
     <nav className={styles.breadcrumb}>

--- a/frontend/pages/games/[id]/edit.tsx
+++ b/frontend/pages/games/[id]/edit.tsx
@@ -141,10 +141,17 @@ const EditGamePage = (props: GamePageProps) => {
             : "Loading... | Republic of Rome Online"}
         </title>
       </Head>
-      <main className="standard-page">
-        <Breadcrumb customItems={[{ index: 2, text: game.name }]} />
+      <main className="standard-page px-8 pb-8">
+        <Breadcrumb
+          customItems={[{ index: 2, text: game.name + " (Lobby)" }]}
+        />
 
-        <h2 id="page-title">Edit Game - {game.name}</h2>
+        <h2
+          id="page-title"
+          className="font-semibold text-xl tracking-tight mb-4"
+        >
+          Edit Game - {game.name}
+        </h2>
         <section>
           <form onSubmit={handleSubmit}>
             <Stack alignItems={"start"} spacing={2}>

--- a/frontend/pages/games/[id]/index.tsx
+++ b/frontend/pages/games/[id]/index.tsx
@@ -552,7 +552,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
         <h3 className="font-semibold text-lg text-stone-400 tracking-tight mb-4">
           Game Lobby
         </h3>
-        {game.description && <p>{game.description}</p>}
+        {game.description && <p className="pb-4">{game.description}</p>}
 
         <Stack direction={{ xs: "column" }} gap={2}>
           <Stack direction={{ xs: "column", sm: "row" }} gap={{ xs: 2 }}>


### PR DESCRIPTION
Fix style issues with the edit game page. Also fix a bug with the Breadcrumb component, which was generating an invalid `href` for the edit game page's parent path (the game lobby page). This was caused by a regression introduced by #258.