### PR TITLE
Make faction color assignments smarter

### DIFF
--- a/backend/rorapp/functions/start_game.py
+++ b/backend/rorapp/functions/start_game.py
@@ -76,10 +76,15 @@ def create_factions(game, players, seed):
     random.seed() if seed is None else random.seed(seed)
     list_of_players = list(players)
     random.shuffle(list_of_players)
+    
+    position_exclusions = [4, 6, 2]
+    positions_to_exclude = position_exclusions[:(6 - len(list_of_players))]
 
     for player in list_of_players:
+        while position in positions_to_exclude:
+            position += 1
         faction = Faction(game=game, position=position, player=player)
-        faction.save()  # Save factions to DB
+        faction.save()
         factions.append(faction)
         position += 1
     return factions

--- a/backend/rorapp/models/faction.py
+++ b/backend/rorapp/models/faction.py
@@ -6,7 +6,7 @@ from rorapp.models.player import Player
 # Model for representing factions
 class Faction(models.Model):
     game = models.ForeignKey(Game, on_delete=models.CASCADE, related_name='factions')
-    position = models.IntegerField()
+    position = models.IntegerField() # 1 is red, 2 is yellow, 3 is green, 4 is cyan, 5 is blue, 6 is purple
     player = models.ForeignKey(Player, blank=True, null=True, on_delete=models.SET_NULL)
     rank = models.IntegerField(blank=True, null=True)
     

--- a/backend/rorapp/tests/start_game_tests.py
+++ b/backend/rorapp/tests/start_game_tests.py
@@ -51,7 +51,7 @@ class StartGameTests(TestCase):
         Player.objects.create(user=self.user3, game=threePlayerGame)
         
         # Define expectations for faction positions
-        allExpectedPositions = [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3]]
+        allExpectedPositions = [[1, 2, 3, 4, 5, 6], [1, 2, 3, 5, 6], [1, 2, 3, 5], [1, 3, 5]]
         
         for game in [sixPlayerGame, fivePlayerGame, fourPlayerGame, threePlayerGame]:
             
@@ -69,7 +69,7 @@ class StartGameTests(TestCase):
             factions = Faction.objects.filter(game=game).order_by('position')
             expectedPositions = [positions for positions in allExpectedPositions if len(positions) == game.players.count()][0]
             for i in range(len(factions)):
-                self.assertEqual(factions[i].position, expectedPositions[i])
+                self.assertEqual(factions[i].position, expectedPositions[i], f'Game {game.id} has incorrect faction positions: item {i} is {factions[i].position} but should be {expectedPositions[i]}')
             
             # Check that a Temporary Rome Consul has been assigned
             temp_rome_consuls = Title.objects.filter(senator__game=game, name='Temporary Rome Consul')


### PR DESCRIPTION
Make faction position/color assignments during game setup smarter. Before this change a 3 player game would have red(1), yellow(2) and green(3) factions.

After the change:
- 6 player games will have red(1), yellow(2), green(3), cyan(4), blue(5) and purple(6).
- 5 player games will have red(1), yellow(2), green(3), blue(5) and purple(6).
- 4 player games will have red(1), yellow(2), green(3) and blue(5).
- 3 player games will have red(1), green(3) and blue(5).