### PR TITLE
Fix mortality/forum phase indexing issue

### DIFF
--- a/backend/rorapp/functions/face_mortality.py
+++ b/backend/rorapp/functions/face_mortality.py
@@ -65,7 +65,7 @@ def face_mortality(game, faction, potential_action, step):
                         title.end_step = step
                         title.save()
                         
-                        if title.major_office == True:
+                        if title.major_office is True:
                             ended_major_office = title.name
                         
                         # If the title is faction leader, create an heir senator as faction leader
@@ -129,7 +129,7 @@ def face_mortality(game, faction, potential_action, step):
         messages_to_send.extend(rank_senators_and_factions(game.id))
                 
         # Proceed to the forum phase
-        new_phase = Phase(name="Forum", index=1, turn=step.phase.turn)
+        new_phase = Phase(name="Forum", index=step.phase.index + 1, turn=step.phase.turn)
         new_phase.save()
         messages_to_send.append(ws_message_create("phase", PhaseSerializer(new_phase).data))
         new_step = Step(index=step.index + 1, phase=new_phase)
@@ -147,4 +147,4 @@ def face_mortality(game, faction, potential_action, step):
         messages_to_send.append(ws_message_create("potential_action", PotentialActionSerializer(action).data))
         
     send_websocket_messages(game.id, messages_to_send)
-    return Response({"message": f"Ready for mortality"}, status=200)
+    return Response({"message": "Ready for mortality"}, status=200)

--- a/backend/rorapp/functions/select_faction_leader.py
+++ b/backend/rorapp/functions/select_faction_leader.py
@@ -47,7 +47,7 @@ def select_faction_leader(game, faction, potential_action, step, data):
     messages_to_send.extend(proceed_to_next_step_if_forum_phase(game, step, faction))
     send_websocket_messages(game.id, messages_to_send)
     
-    return Response({"message": f"Faction leader selected"}, status=200)
+    return Response({"message": "Faction leader selected"}, status=200)
 
 
 def get_previous_title(faction) -> Optional[Title]:

--- a/backend/rorapp/functions/start_next_turn.py
+++ b/backend/rorapp/functions/start_next_turn.py
@@ -17,7 +17,7 @@ def start_next_turn(game, step) -> [dict]:
     messages_to_send.append(ws_message_create("turn", TurnSerializer(new_turn).data))
     
     # Create the mortality phase
-    new_phase = Phase(name="Mortality", index=1, turn=new_turn)
+    new_phase = Phase(name="Mortality", index=0, turn=new_turn)
     new_phase.save()
     messages_to_send.append(ws_message_create("phase", PhaseSerializer(new_phase).data))
     


### PR DESCRIPTION
Closes #301

Fix a phase indexing issue that was causing a bug where the UI showed the current phase as mortality when it should show faction. This was caused by the index of all phases, except the initial faction phase, being set to 1. This was making it impossible for parts of the system to figure out which phase is the "latest".