### PR TITLE
Emphasize selected senators 

### DIFF
--- a/frontend/components/FactionIcon.tsx
+++ b/frontend/components/FactionIcon.tsx
@@ -24,7 +24,7 @@ const FactionIcon = (props: FactionIconProps) => {
   if (props.faction && props.faction) {
     const svg = (
       <svg
-        className={styles.factionIcon}
+        className={`${styles.factionIcon} text-stone-700`}
         height={props.size}
         viewBox="0 0 0.9 1"
         xmlns="http://www.w3.org/2000/svg"
@@ -32,7 +32,7 @@ const FactionIcon = (props: FactionIconProps) => {
         <path
           d="M0,0 H0.9 V1 L0.45,0.75 L0,1 Z"
           fill={props.faction.getColor(500)}
-          stroke="var(--foreground-color)"
+          stroke="currentColor"
           strokeWidth="2"
           vectorEffect="non-scaling-stroke"
         />

--- a/frontend/components/SenatorListItem.tsx
+++ b/frontend/components/SenatorListItem.tsx
@@ -26,7 +26,7 @@ interface SenatorListItemProps {
 
 // Item in the senator list
 const SenatorListItem = ({ senator, ...props }: SenatorListItemProps) => {
-  const { allFactions, allTitles } = useGameContext()
+  const { allFactions, allTitles, selectedDetail } = useGameContext()
 
   // Get senator-specific data
   const faction: Faction | null = senator.faction
@@ -79,17 +79,23 @@ const SenatorListItem = ({ senator, ...props }: SenatorListItemProps) => {
     )
   }
 
+  // Get style for selected item
+  const getSelectedStyle = () => ({
+    boxShadow: "inset 0 0 0 1px hsl(325, 40%, 50%)", // tyrian-500
+    borderColor: "hsl(325, 40%, 50%)", // tyrian-500
+    backgroundColor: "hsl(310, 100%, 97%)", // tyrian-50
+  })
+
   return (
     <div
       key={senator.id}
       className="flex-1 h-[98px] mt-2 mx-2 mb-0 box-border bg-stone-100 p-2 rounded flex gap-2 border border-solid border-stone-300"
       style={
-        props.radioSelected
-          ? {
-              boxShadow: "inset 0 0 0 1px hsl(325, 40%, 50%)", // tyrian-500
-              borderColor: "hsl(325, 40%, 50%)", // tyrian-500
-              backgroundColor: "hsl(310, 100%, 97%)", // tyrian-50
-            }
+        props.radioSelected ||
+        (selectedDetail?.type === "Senator" &&
+          selectedDetail?.id === senator.id &&
+          props.selectableSenators)
+          ? getSelectedStyle()
           : {}
       }
       aria-selected={props.radioSelected}

--- a/frontend/components/SenatorPortrait.module.css
+++ b/frontend/components/SenatorPortrait.module.css
@@ -13,7 +13,6 @@
 
 .senatorPortrait>figure {
   box-sizing: border-box;
-  background-color: var(--foreground-color);
   border-radius: 4px;
 
   position: relative;

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -68,8 +68,14 @@ interface SenatorPortraitProps {
 
 // The senator portrait is a visual representation of the senator,
 // containing an image of their face, faction color background, and other status icons
-const SenatorPortrait = ({ senator, size, ...props }: SenatorPortraitProps) => {
-  const { allFactions, allTitles, setSelectedDetail } = useGameContext()
+const SenatorPortrait = ({
+  senator,
+  size,
+  selectable,
+  nameTooltip,
+}: SenatorPortraitProps) => {
+  const { allFactions, allTitles, selectedDetail, setSelectedDetail } =
+    useGameContext()
 
   // Used to force a re-render when senator changes
   const [key, setKey] = useState(0)
@@ -193,34 +199,42 @@ const SenatorPortrait = ({ senator, size, ...props }: SenatorPortraitProps) => {
 
   // Handle mouse interactions
   const handleMouseOver = () => {
-    if (props.selectable) setHover(true)
+    if (selectable) setHover(true)
   }
   const handleMouseLeave = () => {
     setHover(false)
   }
   const handleClick = () => {
-    if (props.selectable)
+    if (selectable)
       setSelectedDetail({ type: "Senator", id: senator.id } as SelectedDetail)
   }
 
   // Get JSX for the portrait
-  const PortraitElement = props.selectable ? "button" : "div"
+  const PortraitElement = selectable ? "button" : "div"
   const getPortrait = () => {
     return (
       <PortraitElement
         className={`${styles.senatorPortrait} ${
-          props.selectable ? styles.selectable : ""
+          selectable ? styles.selectable : ""
         }`}
         onMouseOver={handleMouseOver}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
         key={key}
       >
-        <figure style={{ height: size, width: size }} className="shadow">
+        <figure style={{ height: size, width: size }} className="shadow bg-stone-700">
           <div
-            className={styles.imageContainer}
+            className={`${styles.imageContainer}`}
             style={getImageContainerStyle()}
           >
+            {selectable &&
+              selectedDetail?.type === "Senator" &&
+              selectedDetail?.id === senator.id && (
+                <div
+                  className={`absolute w-full h-full z-[2] shadow-[inset_0_0_6px_4px_white]`}
+                ></div>
+              )}
+
             {factionLeader && (
               <Image
                 src={FactionLeaderPattern}
@@ -267,7 +281,7 @@ const SenatorPortrait = ({ senator, size, ...props }: SenatorPortraitProps) => {
     )
   }
 
-  if (props.nameTooltip) {
+  if (nameTooltip) {
     return (
       <Tooltip
         key={key}


### PR DESCRIPTION
Closes #274

Selected senator portraits in the faction and senator lists now have a inset white glow in the portrait. The senator list also highlights the selected senator list item using the same style that was previously only used for radio selected senator items in the select faction leader dialog box.

![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/5c76a304-8051-4beb-b80f-e8bae3fa6920)
