### PR TITLE
Make links into normal text when already selected

### DIFF
--- a/frontend/components/FactionLink.tsx
+++ b/frontend/components/FactionLink.tsx
@@ -10,28 +10,37 @@ interface FactionLinkProps {
   includeIcon?: boolean
 }
 
-const FactionLink = (props: FactionLinkProps) => {
-  const { setSelectedDetail } = useGameContext()
+const FactionLink = ({ faction, includeIcon }: FactionLinkProps) => {
+  const { selectedDetail, setSelectedDetail } = useGameContext()
 
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) => {
     event.preventDefault()
-    if (props.faction)
+    if (faction)
       setSelectedDetail({
         type: "Faction",
-        id: props.faction.id,
+        id: faction.id,
       } as SelectedDetail)
   }
 
-  return (
-    <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
-      {props.includeIcon && (
+  const getContent = () => (
+    <>
+      {includeIcon && (
         <span style={{ marginRight: 4 }}>
-          <FactionIcon faction={props.faction} size={17} />
+          <FactionIcon faction={faction} size={17} />
         </span>
       )}
-      {props.faction.getName()} Faction
+      {faction.getName()} Faction
+    </>
+  )
+
+  if (selectedDetail?.type === "Faction" && selectedDetail.id === faction.id)
+    return <span>{getContent()}</span>
+
+  return (
+    <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
+      {getContent()}
     </Link>
   )
 }

--- a/frontend/components/SenatorLink.tsx
+++ b/frontend/components/SenatorLink.tsx
@@ -8,23 +8,26 @@ interface SenatorLinkProps {
   senator: Senator
 }
 
-const SenatorLink = (props: SenatorLinkProps) => {
-  const { setSelectedDetail } = useGameContext()
+const SenatorLink = ({ senator }: SenatorLinkProps) => {
+  const { setSelectedDetail, selectedDetail } = useGameContext()
 
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) => {
     event.preventDefault()
-    if (props.senator)
+    if (senator)
       setSelectedDetail({
         type: "Senator",
-        id: props.senator.id,
+        id: senator.id,
       } as SelectedDetail)
   }
 
+  if (selectedDetail?.type === "Senator" && selectedDetail.id === senator.id)
+    return <span>{senator.displayName}</span>
+
   return (
     <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
-      {props.senator.displayName}
+      {senator.displayName}
     </Link>
   )
 }

--- a/frontend/components/TermLink.tsx
+++ b/frontend/components/TermLink.tsx
@@ -28,7 +28,7 @@ const TermLink = ({
   tooltipTitle,
   includeIcon,
 }: TermLinkProps) => {
-  const { setSelectedDetail } = useGameContext()
+  const { selectedDetail, setSelectedDetail } = useGameContext()
 
   // Use the name to get the correct image
   const getIcon = (): StaticImageData | string => {
@@ -43,9 +43,8 @@ const TermLink = ({
     setSelectedDetail({ type: "Term", name: name } as SelectedDetail)
   }
 
-  // Get the JSX for the link
-  const getLink = () => (
-    <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
+  const getContent = () => (
+    <>
       {includeIcon && (
         <Image
           src={getIcon()}
@@ -56,8 +55,20 @@ const TermLink = ({
         />
       )}
       {displayName ?? name}
-    </Link>
+    </>
   )
+
+  // Get the JSX for the link
+  const getLink = () => {
+    if (selectedDetail?.type === "Term" && selectedDetail.name === name)
+      return <span>{getContent()}</span>
+
+    return (
+      <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
+        {getContent()}
+      </Link>
+    )
+  }
 
   if (tooltipTitle) {
     return (


### PR DESCRIPTION
Closes #283

Make links turn into normal text when the linked entity or term is currently selected (i.e. showing in the detail section).