### PR TITLE
Always show Faction Leader on senator list item

### DIFF
--- a/frontend/components/SenatorListItem.tsx
+++ b/frontend/components/SenatorListItem.tsx
@@ -117,12 +117,12 @@ const SenatorListItem = ({ senator, ...props }: SenatorListItemProps) => {
         </p>
         <p>
           {faction
-            ? props.selectableFactions && (
+            ? (props.selectableFactions ? (
                 <span>
                   <FactionLink faction={faction} includeIcon />{" "}
-                  {factionLeader ? "Leader" : "Member"}
+                  {factionLeader && "Leader"}
                 </span>
-              )
+              ) : (factionLeader && <span>Faction Leader</span>))
             : senator.alive
             ? "Unaligned"
             : "Dead"}


### PR DESCRIPTION
Change the senator list item component so that for a faction leader, the title of "Faction Leader" is always present. This change was made because of the importance of the title. The word "Member" has been omitted from this same component because it's not important.