### PR TITLE
Fix senator a list auto scroll bug

### DIFF
--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -193,16 +193,15 @@ const SenatorList = ({
   useEffect(() => {
     if (selectedDetail?.type !== "Senator") return
 
-    let selectedSenatorIndex = 0
+    let selectedSenatorIndex = null
     for (let i = 0; i < filteredSortedSenatorsRef.current.length; i++) {
       if (filteredSortedSenatorsRef.current[i].id === selectedDetail.id) {
         selectedSenatorIndex = i
         break
       }
     }
-    console.log(selectedSenatorIndex)
 
-    setAutoScrollTargetIndex(selectedSenatorIndex)
+    if (selectedSenatorIndex) setAutoScrollTargetIndex(selectedSenatorIndex)
     setTimeout(() => setAutoScrollTargetIndex(null), 100)
   }, [selectedDetail])
 


### PR DESCRIPTION
Fix a bug where the senator list would auto scroll to the top of the list when a senator that is not currently present in the list is selected.