### PR TITLE
Add a new backend cleanup cron job (builder prune)

### DIFF
--- a/backend/.ebextensions/cronjob.config
+++ b/backend/.ebextensions/cronjob.config
@@ -5,3 +5,4 @@ files:
     group: root
     content: |
       0 6 * * * root sudo docker system prune -a >> /var/log/docker_prune.log 2>&1
+      0 0,3,9,12,15,18,21 * * * root sudo docker builder prune -a >> /var/log/docker_builder_prune.log 2>&1


### PR DESCRIPTION
Update the backend cron configuration to include a new cron job that runs a docker builder prune command every 3 hours, except 6am because that's when the existing system prune cron job runs. The builder prune removes unused build caches, which is a subset of what system prune removes. This new job will prevent accumulation of cached builds if several commits are being pushed to `main` in a single day.