### PR TITLE
Award 5 influence to the Temporary Rome Consul

### DIFF
--- a/backend/rorapp/functions/start_game.py
+++ b/backend/rorapp/functions/start_game.py
@@ -194,13 +194,16 @@ def assign_temp_rome_consul(senators, step, seed) -> Title:
     random.seed() if seed is None else random.seed(seed)
     random.shuffle(senators)
 
+    rome_consul = senators[0]
     temp_rome_consul_title = Title(
         name="Temporary Rome Consul",
-        senator=senators[0],
+        senator=rome_consul,
         start_step=step,
         major_office=True,
     )
     temp_rome_consul_title.save()
+    rome_consul.influence += 5
+    rome_consul.save()
     return temp_rome_consul_title
 
 

--- a/backend/rorapp/migrations/0040_temp_rome_consul_influence.py
+++ b/backend/rorapp/migrations/0040_temp_rome_consul_influence.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+    
+def increase_influence(apps, schema_editor):
+    Title = apps.get_model("rorapp", "Title")
+    Senator = apps.get_model("rorapp", "Senator")
+    for title in Title.objects.filter(name="Temporary Rome Consul"):
+        senator = Senator.objects.get(id=title.senator.id)
+        senator.influence += 5
+        senator.save()
+
+
+def decrease_influence(apps, schema_editor):
+    Title = apps.get_model("rorapp", "Title")
+    Senator = apps.get_model("rorapp", "Senator")
+    for title in Title.objects.filter(name="Temporary Rome Consul"):
+        senator = Senator.objects.get(id=title.senator.id)
+        senator.influence -= 5
+        senator.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rorapp", "0039_rename_potentialaction_action_delete_completedaction"),
+    ]
+
+    operations = [
+        migrations.RunPython(increase_influence, decrease_influence),
+    ]

--- a/backend/rorapp/tests/start_game_tests.py
+++ b/backend/rorapp/tests/start_game_tests.py
@@ -116,6 +116,7 @@ class StartGameTests(TestCase):
         # Check that the Temporary Rome Consul is the highest ranked senator
         temp_rome_consul = Title.objects.get(senator__game=game)
         self.assertEqual(temp_rome_consul.senator.name, "Papirius")
+        self.assertEqual(temp_rome_consul.senator.influence, 8)  # 3 base + 5 consulship
 
         # Check that the factions have been ranked correctly
         factions = Faction.objects.filter(game=game).order_by("rank")

--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -20,7 +20,7 @@ import FactionLink from "@/components/FactionLink"
 
 const typedActions: ActionsType = Actions
 
-const SEQUENTIAL_PHASES = ["Faction", "Forum"]
+const SEQUENTIAL_PHASES = ["Forum"]
 
 interface ProgressSectionProps {
   allPotentialActions: Collection<Action>


### PR DESCRIPTION
Closes #327.

Edit the game setup script and add a migration script for awarding 5 influence to new and existing Temporary Rome Consuls.