### PR TITLE
Fix a bug where games got stuck in faction phase

### DIFF
--- a/backend/rorapp/functions/select_faction_leader.py
+++ b/backend/rorapp/functions/select_faction_leader.py
@@ -119,7 +119,7 @@ def create_completed_action(step, faction) -> None:
 
 def proceed_to_next_step_if_faction_phase(step, game) -> [dict]:
     messages_to_send = []
-    if step.phase.name == "Faction" and Action.objects.filter(step__id=step.id, completed=True).count() == 0:
+    if step.phase.name == "Faction" and Action.objects.filter(step__id=step.id, completed=False).count() == 0:
         turn = Turn.objects.get(id=step.phase.turn.id)
         new_phase = Phase(name="Mortality", index=1, turn=turn)
         new_phase.save()


### PR DESCRIPTION
Fix a mistake in one of the python functions that was causing games to get stuck in the initial faction phase. This was a regression introduced by #336 and wasn't caught until now due to poor test coverage of the faction phase and related functions.