### PR TITLE
Fix production size issue on term avatars

### DIFF
--- a/frontend/components/TermLink.tsx
+++ b/frontend/components/TermLink.tsx
@@ -21,7 +21,7 @@ interface TermLinkProps {
   displayName?: string
   tooltipTitle?: string
   includeIcon?: boolean
-  selectable?: boolean
+  disabled?: boolean
 }
 
 // Icon link for a game term
@@ -30,7 +30,7 @@ const TermLink = ({
   displayName,
   tooltipTitle,
   includeIcon,
-  selectable,
+  disabled,
 }: TermLinkProps) => {
   const { selectedDetail, setSelectedDetail } = useGameContext()
 
@@ -64,7 +64,7 @@ const TermLink = ({
 
   // Get the JSX for the link
   const getLink = () => {
-    if (!selectable || (selectedDetail?.type === "Term" && selectedDetail.name === name))
+    if (disabled || (selectedDetail?.type === "Term" && selectedDetail.name === name))
       return <span>{getContent()}</span>
 
     return (

--- a/frontend/components/TitleList.tsx
+++ b/frontend/components/TitleList.tsx
@@ -54,7 +54,7 @@ const TitleList = ({ senator, selectable }: TitleListProps) => {
       {titleNames.map((titleName: string, index: number) => (
         <span key={index}>
           {index > 0 && index < titleNames.length - 1 && ", "}
-          {index === titleNames.length - 1 && " and "}
+          {index === titleNames.length - 1 && titleNames.length > 1 && " and "}
           <TermLink
             name={
               titleName == "Temporary Rome Consul" ? "Rome Consul" : titleName

--- a/frontend/components/TitleList.tsx
+++ b/frontend/components/TitleList.tsx
@@ -61,7 +61,7 @@ const TitleList = ({ senator, selectable }: TitleListProps) => {
             }
             displayName={titleName}
             includeIcon
-            selectable={selectable}
+            disabled={!selectable}
           />
         </span>
       ))}

--- a/frontend/components/terms/Term_Hrao.tsx
+++ b/frontend/components/terms/Term_Hrao.tsx
@@ -9,7 +9,7 @@ const HraoTerm = () => {
   return (
     <div className="p-6 flex flex-col gap-4">
       <div className="flex items-center gap-4">
-        <Avatar className="h-14 w-14">
+        <Avatar sx={{height: 56, width: 56}}>
           <Image src={HRAOIcon} height={44} width={44} alt={`HRAO Icon`} />
         </Avatar>
         <h4>

--- a/frontend/components/terms/Term_RomeConsul.tsx
+++ b/frontend/components/terms/Term_RomeConsul.tsx
@@ -8,7 +8,7 @@ const RomeConsulTerm = () => {
   return (
     <div className="p-6 flex flex-col gap-4">
       <div className="flex items-center gap-4">
-        <Avatar className="h-14 w-14">
+        <Avatar sx={{height: 56, width: 56}}>
           <Image
             src={RomeConsulIcon}
             height={40}


### PR DESCRIPTION
Fix a production size issue on the MUI `Avatar`s used in the term components and another UI issue affecting `TermLink`s.

Also close #359 which was a small easy fix.