### PR TITLE
Allow notification auto scroll to be switched off

### DIFF
--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -76,12 +76,11 @@ const GamePage = (props: GamePageProps) => {
     setAllTitles,
     setActionLogs,
     setSenatorActionLogs,
+    notifications,
+    setNotifications,
   } = useGameContext()
   const [latestActions, setLatestActions] = useState<Collection<Action>>(
     new Collection<Action>()
-  )
-  const [notifications, setNotifications] = useState<Collection<ActionLog>>(
-    new Collection<ActionLog>()
   )
 
   // Set game-specific state using initial data
@@ -860,7 +859,6 @@ const GamePage = (props: GamePageProps) => {
               <section className="flex flex-col h-[75vh] xl:h-full">
                 <ProgressSection
                   latestActions={latestActions}
-                  notifications={notifications}
                 />
               </section>
             </div>

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -457,6 +457,7 @@ const GamePage = (props: GamePageProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
+    setNotifications
   ])
 
   // Fully synchronize all game data

--- a/frontend/components/NotificationList.tsx
+++ b/frontend/components/NotificationList.tsx
@@ -1,0 +1,76 @@
+import { useGameContext } from "@/contexts/GameContext"
+import { ExpandCircleDown } from "@mui/icons-material"
+import { IconButton } from "@mui/material"
+import { useEffect, useRef, useState } from "react"
+import ActionLog from "@/components/actionLogs/ActionLog"
+
+const NotificationList = () => {
+  const { notifications } = useGameContext()
+  const notificationListRef = useRef<HTMLDivElement>(null)
+  const [initiateScrollDown, setInitiateScrollDown] = useState(false)
+  const [isNearBottom, setIsNearBottom] = useState(true)
+
+  useEffect(() => {
+    const scrollableDiv = notificationListRef.current
+    if (scrollableDiv === null) return
+
+    const handleScroll = () => {
+      const isNearBottom =
+        scrollableDiv.scrollHeight -
+          scrollableDiv.scrollTop -
+          scrollableDiv.clientHeight <
+        3
+      setIsNearBottom(isNearBottom)
+    }
+
+    scrollableDiv.addEventListener("scroll", handleScroll)
+    return () => scrollableDiv.removeEventListener("scroll", handleScroll)
+  }, [])
+
+  useEffect(() => {
+    if (isNearBottom) setInitiateScrollDown(true)
+  }, [notifications.allIds.length, isNearBottom])
+
+  const scrollToBottom = (element: HTMLDivElement) => {
+    element.scrollTo({
+      top: element.scrollHeight,
+      behavior: "smooth",
+    })
+  }
+
+  useEffect(() => {
+    const scrollableDiv = notificationListRef.current
+    if (scrollableDiv === null || !initiateScrollDown) return
+
+    scrollToBottom(scrollableDiv)
+    setInitiateScrollDown(false)
+  }, [initiateScrollDown])
+
+  return (
+    <div className="flex-1 flex flex-col overflow-y-auto relative">
+      <h3 className="leading-lg m-2 ml-2 text-base text-stone-600">
+        Notifications
+      </h3>
+      {!isNearBottom && (
+        <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2">
+          <IconButton onClick={() => setInitiateScrollDown(true)} size="large">
+            <ExpandCircleDown fontSize="inherit" />
+          </IconButton>
+        </div>
+      )}
+      <div
+        ref={notificationListRef}
+        className="h-full overflow-y-auto p-2 bg-white border border-solid border-stone-200 rounded shadow-inner flex flex-col gap-2 scroll-smooth"
+      >
+        {notifications &&
+          notifications.asArray
+            .sort((a, b) => a.index - b.index)
+            .map((notification) => (
+              <ActionLog key={notification.id} notification={notification} />
+            ))}
+      </div>
+    </div>
+  )
+}
+
+export default NotificationList

--- a/frontend/components/NotificationList.tsx
+++ b/frontend/components/NotificationList.tsx
@@ -27,11 +27,21 @@ const NotificationList = () => {
     return () => scrollableDiv.removeEventListener("scroll", handleScroll)
   }, [])
 
+  const [hideButton, setHideButton] = useState(false)
+  const timeoutId = useRef<number | null>(null)
+
   useEffect(() => {
     if (isNearBottom) setInitiateScrollDown(true)
   }, [notifications.allIds.length, isNearBottom])
 
   const scrollToBottom = (element: HTMLDivElement) => {
+    if (timeoutId.current !== null) {
+      window.clearTimeout(timeoutId.current)
+    }
+    setHideButton(true)
+    timeoutId.current = window.setTimeout(() => {
+      setHideButton(false)
+    }, Math.abs(element.scrollHeight - element.scrollTop) / 2)
     element.scrollTo({
       top: element.scrollHeight,
       behavior: "smooth",
@@ -51,7 +61,7 @@ const NotificationList = () => {
       <h3 className="leading-lg m-2 ml-2 text-base text-stone-600">
         Notifications
       </h3>
-      {!isNearBottom && (
+      {!isNearBottom && !hideButton && (
         <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2">
           <IconButton onClick={() => setInitiateScrollDown(true)} size="large">
             <ExpandCircleDown fontSize="inherit" />

--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -11,7 +11,6 @@ import { useAuthContext } from "@/contexts/AuthContext"
 import ActionDialog from "@/components/actionDialogs/ActionDialog"
 import ActionsType from "@/types/actions"
 import Faction from "@/classes/Faction"
-import ActionLog from "@/classes/ActionLog"
 import FactionLink from "@/components/FactionLink"
 import NotificationList from "@/components/NotificationList"
 
@@ -21,13 +20,12 @@ const SEQUENTIAL_PHASES = ["Forum"]
 
 interface ProgressSectionProps {
   latestActions: Collection<Action>
-  notifications: Collection<ActionLog>
 }
 
 // Progress section showing who players are waiting for
 const ProgressSection = ({ latestActions }: ProgressSectionProps) => {
   const { user } = useAuthContext()
-  const { latestPhase, allPlayers, allFactions, notifications } =
+  const { latestPhase, allPlayers, allFactions } =
     useGameContext()
   const [thisFactionsPendingActions, setThisFactionsPendingActions] = useState<
     Collection<Action>

--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from "react"
-import debounce from "lodash/debounce"
-import { Button, IconButton } from "@mui/material"
+import { useEffect, useState } from "react"
+import { Button } from "@mui/material"
 import EastIcon from "@mui/icons-material/East"
 
 import Collection from "@/classes/Collection"
@@ -13,9 +12,8 @@ import ActionDialog from "@/components/actionDialogs/ActionDialog"
 import ActionsType from "@/types/actions"
 import Faction from "@/classes/Faction"
 import ActionLog from "@/classes/ActionLog"
-import Notification from "@/components/actionLogs/ActionLog"
 import FactionLink from "@/components/FactionLink"
-import { ExpandCircleDown } from "@mui/icons-material"
+import NotificationList from "@/components/NotificationList"
 
 const typedActions: ActionsType = Actions
 
@@ -27,20 +25,15 @@ interface ProgressSectionProps {
 }
 
 // Progress section showing who players are waiting for
-const ProgressSection = ({
-  latestActions,
-  notifications,
-}: ProgressSectionProps) => {
+const ProgressSection = ({ latestActions }: ProgressSectionProps) => {
   const { user } = useAuthContext()
-  const { latestPhase, allPlayers, allFactions } = useGameContext()
+  const { latestPhase, allPlayers, allFactions, notifications } =
+    useGameContext()
   const [thisFactionsPendingActions, setThisFactionsPendingActions] = useState<
     Collection<Action>
   >(new Collection<Action>())
   const [dialogOpen, setDialogOpen] = useState<boolean>(false)
   const [faction, setFaction] = useState<Faction | null>(null)
-  const notificationListRef = useRef<HTMLDivElement>(null)
-  const [initiateScrollDown, setInitiateScrollDown] = useState(false)
-  const [isNearBottom, setIsNearBottom] = useState(true)
 
   // Update faction
   useEffect(() => {
@@ -58,42 +51,6 @@ const ProgressSection = ({
       )
     )
   }, [latestActions, faction, setThisFactionsPendingActions])
-
-  useEffect(() => {
-    const scrollableDiv = notificationListRef.current
-    if (scrollableDiv === null) return
-
-    const handleScroll = () => {
-      const isNearBottom =
-        scrollableDiv.scrollHeight -
-          scrollableDiv.scrollTop -
-          scrollableDiv.clientHeight <
-        3
-      setIsNearBottom(isNearBottom)
-    }
-
-    scrollableDiv.addEventListener("scroll", handleScroll)
-    return () => scrollableDiv.removeEventListener("scroll", handleScroll)
-  }, [])
-
-  useEffect(() => {
-    if (isNearBottom) setInitiateScrollDown(true)
-  }, [notifications.allIds.length, isNearBottom])
-
-  const scrollToBottom = (element: HTMLDivElement) => {
-    element.scrollTo({
-      top: element.scrollHeight,
-      behavior: "smooth",
-    })
-  }
-
-  useEffect(() => {
-    const scrollableDiv = notificationListRef.current
-    if (scrollableDiv === null || !initiateScrollDown) return
-
-    scrollToBottom(scrollableDiv)
-    setInitiateScrollDown(false)
-  }, [initiateScrollDown])
 
   if (thisFactionsPendingActions) {
     const requiredAction = thisFactionsPendingActions.asArray.find(
@@ -132,35 +89,7 @@ const ProgressSection = ({
 
     return (
       <div className="box-border h-full px-4 py-2 flex flex-col gap-4">
-        <div className="flex-1 flex flex-col overflow-y-auto relative">
-          <h3 className="leading-lg m-2 ml-2 text-base text-stone-600">
-            Notifications
-          </h3>
-          {!isNearBottom && (
-            <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2">
-              <IconButton
-                onClick={() => setInitiateScrollDown(true)}
-                size="large"
-              >
-                <ExpandCircleDown fontSize="inherit" />
-              </IconButton>
-            </div>
-          )}
-          <div
-            ref={notificationListRef}
-            className="h-full overflow-y-auto p-2 bg-white border border-solid border-stone-200 rounded shadow-inner flex flex-col gap-2 scroll-smooth"
-          >
-            {notifications &&
-              notifications.asArray
-                .sort((a, b) => a.index - b.index)
-                .map((notification) => (
-                  <Notification
-                    key={notification.id}
-                    notification={notification}
-                  />
-                ))}
-          </div>
-        </div>
+        <NotificationList />
         <div className="flex flex-col gap-2">
           <h3 className="leading-none m-0 ml-2 text-base text-stone-600">
             Actions

--- a/frontend/contexts/GameContext.tsx
+++ b/frontend/contexts/GameContext.tsx
@@ -48,6 +48,8 @@ interface GameContextType {
   setFactionDetailTab: Dispatch<SetStateAction<number>>
   debugShowEntityIds: boolean
   setDebugShowEntityIds: Dispatch<SetStateAction<boolean>>
+  notifications: Collection<ActionLog>
+  setNotifications: Dispatch<SetStateAction<Collection<ActionLog>>>
 }
 
 const GameContext = createContext<GameContextType | null>(null)
@@ -94,6 +96,9 @@ export const GameProvider = (props: GameProviderProps): JSX.Element => {
   const [senatorDetailTab, setSenatorDetailTab] = useState<number>(0)
   const [factionDetailTab, setFactionDetailTab] = useState<number>(0)
   const [debugShowEntityIds, setDebugShowEntityIds] = useState<boolean>(false)
+  const [notifications, setNotifications] = useState<Collection<ActionLog>>(
+    new Collection<ActionLog>()
+  )
 
   return (
     <GameContext.Provider
@@ -126,6 +131,8 @@ export const GameProvider = (props: GameProviderProps): JSX.Element => {
         setFactionDetailTab,
         debugShowEntityIds,
         setDebugShowEntityIds,
+        notifications,
+        setNotifications,
       }}
     >
       {props.children}


### PR DESCRIPTION
Closes #237 by allowing the notification auto-scroll feature to temporarily switch off when the user is not already at the bottom of the list. In this case, there is now a button that can be clicked to scroll back to the bottom. The button is hidden when the user is at the bottom of the list.

![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/c9dab95b-028d-49d3-8b7f-3297b456dcfc)
