### PR TITLE
Fix CSS width value mismatch

### DIFF
--- a/frontend/components/AttributeGrid.tsx
+++ b/frontend/components/AttributeGrid.tsx
@@ -19,7 +19,7 @@ const AttributeGrid = ({ attributes }: AttributeGridProps) => {
     return (
       <div
         key={index}
-        className={`w-[158px] grid grid-cols-[35px_85px_30px] items-center justify-items-center gap-1`}
+        className={`w-[150px] grid grid-cols-[35px_85px_30px] items-center justify-items-center gap-1`}
       >
         <Image
           src={item.icon}
@@ -37,7 +37,7 @@ const AttributeGrid = ({ attributes }: AttributeGridProps) => {
   if (!attributes) return null
 
   return (
-    <div className={`grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4 justify-items-center content-start`}>
+    <div className={`grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4 justify-items-center content-start box-border`}>
       {attributes.map((attribute: Attribute, index) => getAttributeItem(attribute, index))}
     </div>
   )

--- a/frontend/components/detailSections/DetailSection_Senator.tsx
+++ b/frontend/components/detailSections/DetailSection_Senator.tsx
@@ -400,7 +400,7 @@ const SenatorDetails = (props: SenatorDetailsProps) => {
         {senatorDetailTab === 1 && (
           <div
             ref={scrollableAreaRef}
-            className="h-fill box-border flex flex-col gap-2 overflow-7-auto"
+            className="h-fill box-border flex flex-col gap-2 overflow-y-auto"
           >
             {matchingActionLogs &&
               matchingActionLogs


### PR DESCRIPTION
Closes #373

Fix a mismatch between the attribute item's auto-fill min width (CSS grid columns) and the actual item's fixed width in the `AttributeGrid` component. This removes the pointless horizontal scroll bar that was appearing for smaller displays.

Also fix a typo with `overflow-y-auto`.