### PR TITLE
Sort the faction detail overview senators

### DIFF
--- a/frontend/components/detailSections/DetailSection_Faction.tsx
+++ b/frontend/components/detailSections/DetailSection_Faction.tsx
@@ -37,9 +37,10 @@ const FactionDetails = () => {
   let senators: Collection<Senator> = new Collection<Senator>([])
   if (selectedDetail && selectedDetail.type == "Faction") {
     senators = new Collection<Senator>(
-      allSenators.asArray.filter(
-        (s) => s.faction === selectedDetail.id && s.alive === true
-      )
+      // Filter by faction and alive, then sort by name
+      allSenators.asArray
+        .filter((s) => s.faction === selectedDetail.id && s.alive === true)
+        .sort((a, b) => a.name.localeCompare(b.name))
     )
   }
   const faction: Faction | null = selectedDetail?.id


### PR DESCRIPTION
Closes #376

Sort the faction detail overview senators using the same order as the senator list - alphabetic order on the name field. Generation doesn't matter here because the faction detail overview doesn't show dead senators.