### PR TITLE
Improve senator portrait image load time

### DIFF
--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -251,6 +251,7 @@ const SenatorPortrait = ({
               alt={"Portrait of " + senator.displayName}
               style={{ transform: `translate(-50%, -${50 - getOffset()}%)` }}
               placeholder="blur"
+              priority
             />
           </div>
           <div className={styles.bg} style={getBgStyle()}></div>


### PR DESCRIPTION
Attempt to improve senator portrait image load time by setting the images to `priority`.