### PR TITLE
Fix jumpiness on game page load

### DIFF
--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -606,10 +606,10 @@ const GamePage = (props: GamePageProps) => {
         <Head>
           <title>Loading... | Republic of Rome Online</title>
         </Head>
-        <main className="p-2">
-          <div className="px-0 py-2 flex flex-col gap-4 items-center">
+        <main className="h-full p-2">
+          <div className="h-full flex flex-col justify-center gap-6 items-center text-lg">
             <span>Synchronizing{game && `: ${game.name}`}</span>
-            <CircularProgress />
+            <CircularProgress size={60} />
           </div>
         </main>
       </>

--- a/frontend/components/MetaSection.tsx
+++ b/frontend/components/MetaSection.tsx
@@ -85,7 +85,7 @@ const MetaSection = () => {
     ]
   }
 
-  if (game && latestStep && latestTurn && latestPhase) {
+  if (game) {
     return (
       <section className="flex flex-col-reverse lg:flex-row gap-2 align-center justify-between rounded bg-stone-200 dark:bg-stone-750">
         <div className="flex-1 flex flex-col lg:flex-row gap-3 items-center justify-start">
@@ -140,7 +140,7 @@ const MetaSection = () => {
                 height={20}
                 className="align-middle mt-[-4px] mb-[-2px] mr-1"
               />
-              Turn {latestTurn.index}, {latestPhase.name} Phase
+              Turn {latestTurn?.index}, {latestPhase?.name} Phase
             </span>
           </div>
           <div className="flex flex-col justify-center">


### PR DESCRIPTION
Fix an issue where the meta section would render after the other sections, causing the other content to jump down slightly once the meta section loads.

This PR also repositions the loading spinner and makes it and the related text larger.