### PR TITLE
Fix progress section faction order bug

### DIFF
--- a/frontend/classes/Faction.ts
+++ b/frontend/classes/Faction.ts
@@ -17,14 +17,14 @@ class Faction {
   game: number
   position: FactionPosition
   player: number
-  rank: number | null
+  rank: number
 
   constructor(data: FactionData) {
     this.id = data.id
     this.game = data.game
     this.position = data.position
     this.player = data.player
-    this.rank = data.rank
+    this.rank = data.rank ?? 0
   }
 
   // Get the faction's color hex code

--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -50,6 +50,8 @@ const ProgressSection = ({ latestActions }: ProgressSectionProps) => {
     )
   }, [latestActions, faction, setThisFactionsPendingActions])
 
+  const rankedFactions = allFactions.asArray.sort((a: Faction, b: Faction) => a.rank - b.rank)
+
   if (thisFactionsPendingActions) {
     const requiredAction = thisFactionsPendingActions.asArray.find(
       (a) => a.required === true
@@ -95,7 +97,7 @@ const ProgressSection = ({ latestActions }: ProgressSectionProps) => {
           <div className="p-2 bg-white dark:bg-neutral-600 border border-solid border-neutral-200 dark:border-neutral-750 rounded shadow-inner flex flex-col gap-3 items-center">
             <p className="text-center">{waitingForDesc}</p>
             <div className="h-full flex gap-3 justify-center">
-              {allFactions.asArray.map((faction, index) => {
+              {rankedFactions.map((faction, index) => {
                 const potential = latestActions.asArray.some(
                   (a) => a.faction === faction.id && a.completed === false
                 )


### PR DESCRIPTION
Fix a bug where the progress section didn't show factions in rank order. It only ever showed them in order of when the instances were updated in the backend, which happens to be rank order most of the time.