### PR TITLE
Fix relevant title API bug

### DIFF
--- a/backend/rorapp/views/title.py
+++ b/backend/rorapp/views/title.py
@@ -1,4 +1,4 @@
-from django.db.models import Q, F
+from django.db.models import Q
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rorapp.models import Title
@@ -25,6 +25,6 @@ class TitleViewSet(viewsets.ReadOnlyModelViewSet):
         # Active means that the title's end step is null or the senator is dead
         active = self.request.query_params.get('relevant', None)
         if active is not None:
-            queryset = queryset.filter(Q(end_step__isnull=True) | Q(senator__alive=True))
+            queryset = queryset.filter(Q(end_step__isnull=True) | Q(senator__alive=False))
             
         return queryset


### PR DESCRIPTION
Fix a bug where all titles associated with living senators, including expired titles, were being sent to the frontend even when the frontend specifically requested "relevant" titles only.

This was a regression introduced in #405.