### PR TITLE
Fix the `get_latest_phase` function

### DIFF
--- a/backend/rorapp/functions/forum_phase_helper.py
+++ b/backend/rorapp/functions/forum_phase_helper.py
@@ -12,7 +12,6 @@ from rorapp.functions.websocket_message_helper import (
 from rorapp.models import (
     Action,
     Faction,
-    Phase,
     Senator,
     Situation,
     Step,

--- a/backend/rorapp/functions/progress_helper.py
+++ b/backend/rorapp/functions/progress_helper.py
@@ -11,9 +11,10 @@ def get_latest_step(game_id: int, reverse_index: int = 0) -> Step:
 
 
 def get_latest_phase(game_id: int, reverse_index: int = 0) -> Phase:
+    latest_step = get_latest_step(game_id)
     if reverse_index == 0:
-        return Phase.objects.filter(turn__game=game_id).order_by("-index").first()
+        return Phase.objects.filter(turn=latest_step.phase.turn).order_by("-index").first()
     else:
-        return Phase.objects.filter(turn__game=game_id).order_by("-index")[
+        return Phase.objects.filter(turn=latest_step.phase.turn).order_by("-index")[
             reverse_index
         ]


### PR DESCRIPTION
Fix a bug where the `get_latest_phase` function was pretty much broken, causing the game to never progress beyond the second turn.

This was a regression introduced in #404.