### PR TITLE
Fix JS error for invalid game ID

### DIFF
--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -218,6 +218,7 @@ const GamePage = (props: GamePageProps) => {
       fetchData(
         url,
         (data: any) => {
+          if (data.length === 0) return  // Exit if there is no data
           const deserializedInstance = new EntityType(data.id ? data : data[0])
           setEntity(deserializedInstance)
         },


### PR DESCRIPTION
Closes #396

Stop the frontend from throwing a JS error when the user visits the play page using an invalid game ID.