### PR TITLE
Remove paths from CI workflows

### DIFF
--- a/.github/workflows/build_and_test_backend.yml
+++ b/.github/workflows/build_and_test_backend.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - 'backend/**'
     
   workflow_dispatch:
 

--- a/.github/workflows/build_frontend.yml
+++ b/.github/workflows/build_frontend.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - 'frontend/**'
     
   workflow_dispatch:
 


### PR DESCRIPTION
Remove paths from CI workflows so that the frontend and backend both get checked for every PR, which supports a change to make both checks required for PRs targeting `main`.