### PR TITLE
Rename `AuthContext` to `CookieContext`

### DIFF
--- a/frontend/components/EnemyLeaderPortrait.tsx
+++ b/frontend/components/EnemyLeaderPortrait.tsx
@@ -1,6 +1,6 @@
 import EnemyLeader from "@/classes/EnemyLeader"
 import Image from "next/image"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 import AntiochusIII from "@/images/enemyLeaders/antiochusIII.png"
 import Hamilcar from "@/images/enemyLeaders/hamilcar.png"
@@ -19,7 +19,7 @@ const EnemyLeaderPortrait = ({
   size,
   nameTooltip,
 }: EnemyLeaderPortraitProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
 
   // Get number of pixels by which to increase image size, beyond container size
   const getZoom = () => {

--- a/frontend/components/FactionListItem.tsx
+++ b/frontend/components/FactionListItem.tsx
@@ -9,7 +9,7 @@ import TalentsIcon from "@/images/icons/talents.svg"
 import VotesIcon from "@/images/icons/votes.svg"
 import SecretsIcon from "@/images/icons/secrets.svg"
 import AttributeFlex, { Attribute } from "@/components/AttributeFlex"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 interface FactionListItemProps {
   faction: Faction
@@ -17,7 +17,7 @@ interface FactionListItemProps {
 
 // Item in the faction list
 const FactionListItem = (props: FactionListItemProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const { allPlayers, allSenators, allSecrets } = useGameContext()
 
   // Get faction-specific data

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -21,7 +21,7 @@ import Senator from "@/classes/Senator"
 import Title from "@/classes/Title"
 import PageError from "@/components/PageError"
 import request from "@/functions/request"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import {
   deserializeToInstance,
   deserializeToInstances,
@@ -65,7 +65,7 @@ const GamePage = (props: GamePageProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const [syncingGameData, setSyncingGameData] = useState<boolean>(true)
   const [latestTokenRefreshDate, setLatestTokenRefreshDate] =
     useState<Date | null>(null)

--- a/frontend/components/MetaSection.tsx
+++ b/frontend/components/MetaSection.tsx
@@ -8,7 +8,7 @@ import { faRightFromBracket } from "@fortawesome/free-solid-svg-icons"
 import VisibilityIcon from "@mui/icons-material/Visibility"
 
 import { useGameContext } from "@/contexts/GameContext"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import Player from "@/classes/Player"
 import Faction from "@/classes/Faction"
 import Senator from "@/classes/Senator"
@@ -25,7 +25,7 @@ import SelectedDetail from "@/types/SelectedDetail"
 
 // Section showing meta info about the game
 const MetaSection = () => {
-  const { user, darkMode } = useAuthContext()
+  const { user, darkMode } = useCookieContext()
   const {
     game,
     latestTurn,

--- a/frontend/components/PageError.tsx
+++ b/frontend/components/PageError.tsx
@@ -1,4 +1,4 @@
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 interface PageErrorProps {
   statusCode: number
@@ -6,7 +6,7 @@ interface PageErrorProps {
 
 // This component is designed to replace the entire `<main>` element of a page with an error message
 const PageError = (props: PageErrorProps) => {
-  const { user } = useAuthContext()
+  const { user } = useCookieContext()
 
   let message = ""
   switch (props.statusCode) {

--- a/frontend/components/PageWrapper.tsx
+++ b/frontend/components/PageWrapper.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useState } from "react"
 import Cookies from "js-cookie"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 interface PageWrapperProps {
   children: ReactNode
@@ -9,7 +9,7 @@ interface PageWrapperProps {
 
 // Wraps the top bar, page content and footer
 const PageWrapper = (props: PageWrapperProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const [isReady, setIsReady] = useState(false)
 
   useEffect(() => {

--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -7,7 +7,7 @@ import Action from "@/classes/Action"
 import ActionDataCollection from "@/data/actions.json"
 import FactionIcon from "@/components/FactionIcon"
 import { useGameContext } from "@/contexts/GameContext"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import ActionDialog from "@/components/ActionDialog"
 import ActionDataCollectionType from "@/types/Action"
 import Faction from "@/classes/Faction"
@@ -24,7 +24,7 @@ interface ProgressSectionProps {
 
 // Progress section showing who players are waiting for
 const ProgressSection = ({ latestActions }: ProgressSectionProps) => {
-  const { user } = useAuthContext()
+  const { user } = useCookieContext()
   const { game, latestPhase, allPlayers, allFactions } = useGameContext()
   const [thisFactionsPendingActions, setThisFactionsPendingActions] = useState<
     Collection<Action>

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -30,7 +30,7 @@ import KnightsIcon from "@/images/icons/knights.svg"
 import VotesIcon from "@/images/icons/votes.svg"
 import Faction from "@/classes/Faction"
 import Collection from "@/classes/Collection"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 type SortAttribute =
   | "military"
@@ -75,7 +75,7 @@ const SenatorList = ({
   mainSenatorListFilterAliveState,
   mainSenatorListFilterDeadState,
 }: SenatorListProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const { allFactions, allSenators, selectedDetail } = useGameContext()
 
   // State for grouped, optionally passed in from the parent component

--- a/frontend/components/SenatorListItem.tsx
+++ b/frontend/components/SenatorListItem.tsx
@@ -8,7 +8,7 @@ import skillsJSON from "@/data/skills.json"
 import SenatorLink from "@/components/SenatorLink"
 import FactionLink from "@/components/FactionLink"
 import SenatorFactList from "@/components/SenatorFactList"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 type FixedAttribute = "military" | "oratory" | "loyalty"
 
@@ -27,7 +27,7 @@ interface SenatorListItemProps {
 
 // Item in the senator list
 const SenatorListItem = ({ senator, ...props }: SenatorListItemProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const { allFactions, allTitles, selectedDetail } = useGameContext()
 
   // Get senator-specific data

--- a/frontend/components/ThemeWrapper.tsx
+++ b/frontend/components/ThemeWrapper.tsx
@@ -1,4 +1,4 @@
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import { ThemeProvider } from "@emotion/react"
 import { ReactNode } from "react"
 import darkTheme from "@/themes/darkTheme"
@@ -9,7 +9,7 @@ interface ThemeWrapperProps {
 }
 
 const ThemeWrapper = (props: ThemeWrapperProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
 
   return <ThemeProvider theme={darkMode ? darkTheme : rootTheme}>{props.children}</ThemeProvider>
 }

--- a/frontend/components/TopBar.tsx
+++ b/frontend/components/TopBar.tsx
@@ -14,7 +14,7 @@ import PersonIcon from "@mui/icons-material/Person"
 import LightModeIcon from "@mui/icons-material/LightMode"
 import DarkModeIcon from "@mui/icons-material/DarkMode"
 
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import SiteLogo from "@/images/siteLogo.png"
 import { ThemeProvider } from "@emotion/react"
 import darkTheme from "@/themes/darkTheme"
@@ -33,7 +33,7 @@ const TopBar = (props: TopBarProps) => {
     setUser,
     darkMode,
     setDarkMode,
-  } = useAuthContext()
+  } = useCookieContext()
   const router = useRouter()
 
   const [dialogOpen, setDialogOpen] = useState(false)

--- a/frontend/components/actionDialogs/ActionDialog_FaceMortality.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_FaceMortality.tsx
@@ -13,7 +13,7 @@ import Action from "@/classes/Action"
 import Collection from "@/classes/Collection"
 import DeadIcon from "@/images/icons/dead.svg"
 import request from "@/functions/request"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import { useGameContext } from "@/contexts/GameContext"
 
 interface FaceMortalityDialogProps {
@@ -29,7 +29,7 @@ const FaceMortalityDialog = (props: FaceMortalityDialogProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const { game } = useGameContext()
 
   const [requiredAction, setRequiredAction] = useState<Action | null>(null)

--- a/frontend/components/actionDialogs/ActionDialog_InitiateSituation.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_InitiateSituation.tsx
@@ -13,7 +13,7 @@ import Action from "@/classes/Action"
 import Collection from "@/classes/Collection"
 import DeadIcon from "@/images/icons/dead.svg"
 import request from "@/functions/request"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import { useGameContext } from "@/contexts/GameContext"
 
 interface InitiateSituationDialogProps {
@@ -29,7 +29,7 @@ const InitiateSituationDialog = (props: InitiateSituationDialogProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const { game } = useGameContext()
 
   const [requiredAction, setRequiredAction] = useState<Action | null>(null)

--- a/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
@@ -13,7 +13,7 @@ import { useGameContext } from "@/contexts/GameContext"
 import Action from "@/classes/Action"
 import Collection from "@/classes/Collection"
 import Senator from "@/classes/Senator"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import request from "@/functions/request"
 
 interface SelectFactionLeaderDialogProps {
@@ -29,7 +29,7 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const { game, allSenators, allFactions, allTitles } = useGameContext()
 
   const requiredAction =

--- a/frontend/components/actionLogs/ActionLog_FaceMortality.tsx
+++ b/frontend/components/actionLogs/ActionLog_FaceMortality.tsx
@@ -8,7 +8,7 @@ import Senator from "@/classes/Senator"
 import SenatorLink from "@/components/SenatorLink"
 import FactionLink from "@/components/FactionLink"
 import TermLink from "@/components/TermLink"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 interface NotificationProps {
   notification: ActionLog
@@ -20,7 +20,7 @@ const FaceMortalityNotification = ({
   notification,
   senatorDetails,
 }: NotificationProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const { allFactions, allSenators } = useGameContext()
 
   // Get notification-specific data

--- a/frontend/components/actionLogs/ActionLog_NewSecret.tsx
+++ b/frontend/components/actionLogs/ActionLog_NewSecret.tsx
@@ -6,7 +6,7 @@ import { useGameContext } from "@/contexts/GameContext"
 import TermLink from "@/components/TermLink"
 import FactionLink from "../FactionLink"
 import Faction from "@/classes/Faction"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 interface NotificationProps {
   notification: ActionLog
@@ -15,7 +15,7 @@ interface NotificationProps {
 
 // Notification for when a senator dies during the mortality phase
 const NewSecretNotification = ({ notification }: NotificationProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const { allFactions } = useGameContext()
 
   // Get notification-specific data

--- a/frontend/components/actionLogs/ActionLog_SelectFactionLeader.tsx
+++ b/frontend/components/actionLogs/ActionLog_SelectFactionLeader.tsx
@@ -6,7 +6,7 @@ import Faction from "@/classes/Faction"
 import Senator from "@/classes/Senator"
 import SenatorLink from "@/components/SenatorLink"
 import FactionLink from "@/components/FactionLink"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 interface NotificationProps {
   notification: ActionLog
@@ -18,7 +18,7 @@ const SelectFactionLeaderNotification = ({
   notification,
   senatorDetails,
 }: NotificationProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const { allFactions, allSenators } = useGameContext()
 
   // Get notification-specific data

--- a/frontend/components/actionLogs/ActionLog_TemporaryRomeConsul.tsx
+++ b/frontend/components/actionLogs/ActionLog_TemporaryRomeConsul.tsx
@@ -8,7 +8,7 @@ import Faction from "@/classes/Faction"
 import Senator from "@/classes/Senator"
 import { useGameContext } from "@/contexts/GameContext"
 import TermLink from "@/components/TermLink"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 interface NotificationProps {
   notification: ActionLog
@@ -19,7 +19,7 @@ const TemporaryRomeConsulNotification = ({
   notification,
   senatorDetails,
 }: NotificationProps) => {
-  const { darkMode } = useAuthContext()
+  const { darkMode } = useCookieContext()
   const { allFactions, allSenators } = useGameContext()
 
   // Get notification-specific data

--- a/frontend/components/entityDetails/EntityDetail_Faction.tsx
+++ b/frontend/components/entityDetails/EntityDetail_Faction.tsx
@@ -17,11 +17,11 @@ import Title from "@/classes/Title"
 import SenatorLink from "@/components/SenatorLink"
 import TermLink from "@/components/TermLink"
 import SecretList from "@/components/SecretList"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 
 // Detail section content for a faction
 const FactionDetails = () => {
-  const { user } = useAuthContext()
+  const { user } = useCookieContext()
   const {
     allPlayers,
     allFactions,

--- a/frontend/components/entityDetails/EntityDetail_Senator.tsx
+++ b/frontend/components/entityDetails/EntityDetail_Senator.tsx
@@ -20,7 +20,7 @@ import Title from "@/classes/Title"
 import { Tab, Tabs } from "@mui/material"
 import ActionLog from "@/classes/ActionLog"
 import request from "@/functions/request"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import { deserializeToInstances } from "@/functions/serialize"
 import Collection from "@/classes/Collection"
 import SenatorActionLog from "@/classes/SenatorActionLog"
@@ -52,7 +52,7 @@ const SenatorDetails = (props: SenatorDetailsProps) => {
     setRefreshToken,
     setUser,
     darkMode,
-  } = useAuthContext()
+  } = useCookieContext()
   const {
     allPlayers,
     allFactions,

--- a/frontend/contexts/CookieContext.tsx
+++ b/frontend/contexts/CookieContext.tsx
@@ -19,7 +19,7 @@ const CookieContext = createContext<CookieContextType | null>(null)
 export const useCookieContext = (): CookieContextType => {
   const context = useContext(CookieContext)
   if (!context) {
-    throw new Error("useCookieContext must be used within an CookieProvider")
+    throw new Error("useCookieContext must be used within a CookieProvider")
   }
   return context
 }

--- a/frontend/contexts/CookieContext.tsx
+++ b/frontend/contexts/CookieContext.tsx
@@ -3,7 +3,7 @@ import useCookies from "../hooks/useCookies"
 import User from "@/classes/User"
 import { deserializeToInstance } from "@/functions/serialize"
 
-interface AuthContextType {
+interface CookieContextType {
   accessToken: string
   setAccessToken: (value: string) => void
   refreshToken: string
@@ -14,22 +14,22 @@ interface AuthContextType {
   setDarkMode: (value: boolean) => void
 }
 
-const AuthContext = createContext<AuthContextType | null>(null)
+const CookieContext = createContext<CookieContextType | null>(null)
 
-export const useAuthContext = (): AuthContextType => {
-  const context = useContext(AuthContext)
+export const useCookieContext = (): CookieContextType => {
+  const context = useContext(CookieContext)
   if (!context) {
-    throw new Error("useAuthContext must be used within an AuthProvider")
+    throw new Error("useCookieContext must be used within an CookieProvider")
   }
   return context
 }
 
-interface AuthProviderProps {
+interface CookieProviderProps {
   children: ReactNode
   pageProps: any
 }
 
-export const AuthProvider = (props: AuthProviderProps) => {
+export const CookieProvider = (props: CookieProviderProps) => {
   const clientAccessToken = props.pageProps.clientAccessToken ?? ""
   const clientRefreshToken = props.pageProps.clientRefreshToken ?? ""
   const clientUserJSON = props.pageProps.clientUser ?? ""
@@ -65,7 +65,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
     setDarkMode(JSON.stringify(darkMode))
 
   return (
-    <AuthContext.Provider
+    <CookieContext.Provider
       value={{
         accessToken,
         setAccessToken,
@@ -78,6 +78,6 @@ export const AuthProvider = (props: AuthProviderProps) => {
       }}
     >
       {props.children}
-    </AuthContext.Provider>
+    </CookieContext.Provider>
   )
 }

--- a/frontend/contexts/RootContext.tsx
+++ b/frontend/contexts/RootContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from "react"
 import { ThemeProvider } from "@mui/material/styles"
 
 import rootTheme from "@/themes/rootTheme"
-import { AuthProvider } from "./AuthContext"
+import { CookieProvider } from "./CookieContext"
 
 const RootContext = createContext({})
 
@@ -18,9 +18,9 @@ interface RootProviderProps {
 export const RootProvider = (props: RootProviderProps) => {
   return (
     <RootContext.Provider value={{}}>
-      <AuthProvider pageProps={props.pageProps}>
+      <CookieProvider pageProps={props.pageProps}>
         <ThemeProvider theme={rootTheme}>{props.children}</ThemeProvider>
-      </AuthProvider>
+      </CookieProvider>
     </RootContext.Provider>
   )
 }

--- a/frontend/pages/account.tsx
+++ b/frontend/pages/account.tsx
@@ -2,7 +2,7 @@ import { GetServerSidePropsContext } from "next"
 import Head from "next/head"
 import Card from "@mui/material/Card"
 
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import getInitialCookieData from "@/functions/cookies"
 import PageError from "@/components/PageError"
 import Breadcrumb from "@/components/Breadcrumb"
@@ -13,7 +13,7 @@ import Box from "@mui/material/Box"
  * The component for the account page
  */
 const AccountPage = () => {
-  const { user } = useAuthContext()
+  const { user } = useCookieContext()
 
   // Render page error if user is not signed in
   if (user === null) {

--- a/frontend/pages/games/[id]/edit.tsx
+++ b/frontend/pages/games/[id]/edit.tsx
@@ -11,7 +11,7 @@ import TextField from "@mui/material/TextField"
 import Game from "@/classes/Game"
 import Breadcrumb from "@/components/Breadcrumb"
 import PageError from "@/components/PageError"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import getInitialCookieData from "@/functions/cookies"
 import request, { ResponseType } from "@/functions/request"
 import Step from "@/classes/Step"
@@ -31,7 +31,7 @@ const EditGamePage = (props: GamePageProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const [game, setGame] = useState<Game | null>(() => {
     if (props.initialGame) {
       const gameObject = JSON.parse(props.initialGame)

--- a/frontend/pages/games/[id]/index.tsx
+++ b/frontend/pages/games/[id]/index.tsx
@@ -30,7 +30,7 @@ import {
 import Game from "@/classes/Game"
 import Breadcrumb from "@/components/Breadcrumb"
 import PageError from "@/components/PageError"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import getInitialCookieData from "@/functions/cookies"
 import formatDate from "@/functions/date"
 import request from "@/functions/request"
@@ -66,7 +66,7 @@ const GameLobbyPage = (props: GameLobbyPageProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const [loading, setLoading] = useState<boolean>(true)
   const [latestTokenRefreshDate, setLatestTokenRefreshDate] =
     useState<Date | null>(null)

--- a/frontend/pages/games/index.tsx
+++ b/frontend/pages/games/index.tsx
@@ -14,7 +14,7 @@ import {
 import Box from "@mui/material/Box"
 import Card from "@mui/material/Card"
 
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import request from "@/functions/request"
 import Game from "@/classes/Game"
 import getInitialCookieData from "@/functions/cookies"
@@ -41,7 +41,7 @@ const BrowseGamesPage = (props: BrowseGamesPageProps) => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const [refreshPending, setRefreshPending] = useState<boolean>(false)
   const [games, setGames] = useState<Game[]>(() => {
     if (props.initialGames) {

--- a/frontend/pages/games/new.tsx
+++ b/frontend/pages/games/new.tsx
@@ -5,7 +5,7 @@ import Head from "next/head"
 import TextField from "@mui/material/TextField"
 import Button from "@mui/material/Button"
 
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import request from "@/functions/request"
 import getInitialCookieData from "@/functions/cookies"
 import PageError from "@/components/PageError"
@@ -22,7 +22,7 @@ const NewGamePage = () => {
     setAccessToken,
     setRefreshToken,
     setUser,
-  } = useAuthContext()
+  } = useCookieContext()
   const [name, setName] = useState<string>("")
   const [nameFeedback, setNameFeedback] = useState<string>("")
   const [description, setDescription] = useState<string>("")

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -7,7 +7,7 @@ import Head from "next/head"
 import Image, { StaticImageData } from "next/image"
 
 import { requestWithoutAuthentication } from "@/functions/request"
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import getInitialCookieData from "@/functions/cookies"
 import ExternalLink from "@/components/ExternalLink"
 
@@ -25,7 +25,7 @@ const HomePage = () => {
   const [email, setEmail] = useState("")
   const [emailFeedback, setEmailFeedback] = useState("")
   const [open, setOpen] = useState(false)
-  const { user } = useAuthContext()
+  const { user } = useCookieContext()
 
   const getFixedSizeImage = (imageSource: StaticImageData) => (
     <div className="overflow-auto">

--- a/frontend/pages/sign-in.tsx
+++ b/frontend/pages/sign-in.tsx
@@ -6,14 +6,14 @@ import Head from "next/head"
 import { Button, Stack, TextField } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
 
-import { useAuthContext } from "@/contexts/AuthContext"
+import { useCookieContext } from "@/contexts/CookieContext"
 import Breadcrumb from "@/components/Breadcrumb"
 import request from "@/functions/request"
 import { deserializeToInstance } from "@/functions/serialize"
 import User from "@/classes/User"
 
 const SignInPage = () => {
-  const { setAccessToken, setRefreshToken, setUser } = useAuthContext()
+  const { setAccessToken, setRefreshToken, setUser } = useCookieContext()
   const [identity, setIdentity] = useState<string>("")
   const [password, setPassword] = useState<string>("")
   const [feedback, setFeedback] = useState<string>("")


### PR DESCRIPTION
Rename `AuthContext` to `CookieContext` to improve semantics, since this context has been extended to provide more than just authentication data.