### PR TITLE
Move "Group by faction" state into cookie context

### DIFF
--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -113,8 +113,6 @@ const GamePage = (props: GamePageProps) => {
   // UI selections
   const [mainTab, setMainTab] = useState(0)
   const [mainSenatorListSort, setMainSenatorListSort] = useState<string>("")
-  const [mainSenatorListGrouped, setMainSenatorListGrouped] =
-    useState<boolean>(false)
   const [mainSenatorListFilterAlive, setMainSenatorListFilterAlive] =
     useState<boolean>(true)
   const [mainSenatorListFilterDead, setMainSenatorListFilterDead] =
@@ -710,10 +708,6 @@ const GamePage = (props: GamePageProps) => {
                       mainSenatorListSortState={[
                         mainSenatorListSort,
                         setMainSenatorListSort,
-                      ]}
-                      mainSenatorListGroupedState={[
-                        mainSenatorListGrouped,
-                        setMainSenatorListGrouped,
                       ]}
                       mainSenatorListFilterAliveState={[
                         mainSenatorListFilterAlive,

--- a/frontend/components/SenatorList.tsx
+++ b/frontend/components/SenatorList.tsx
@@ -55,7 +55,7 @@ interface SenatorListProps {
   border?: boolean
   radioSelectedSenator?: Senator | null
   setRadioSelectedSenator?: (senator: Senator | null) => void
-  mainSenatorListGroupedState?: [boolean, (grouped: boolean) => void]
+  mainSenatorListGroupedState?: [boolean, (groupedSenators: boolean) => void]
   mainSenatorListSortState?: [string, (sort: string) => void]
   mainSenatorListFilterAliveState?: [boolean, (sort: boolean) => void]
   mainSenatorListFilterDeadState?: [boolean, (sort: boolean) => void]
@@ -70,22 +70,12 @@ const SenatorList = ({
   senators,
   radioSelectedSenator,
   setRadioSelectedSenator,
-  mainSenatorListGroupedState,
   mainSenatorListSortState,
   mainSenatorListFilterAliveState,
   mainSenatorListFilterDeadState,
 }: SenatorListProps) => {
-  const { darkMode } = useCookieContext()
+  const { darkMode, groupedSenators, setGroupedSenators} = useCookieContext()
   const { allFactions, allSenators, selectedDetail } = useGameContext()
-
-  // State for grouped, optionally passed in from the parent component
-  const [localGrouped, setLocalGrouped] = useState<boolean>(false) // Whether to group senators by faction
-  const grouped = mainSenatorListGroupedState
-    ? mainSenatorListGroupedState[0]
-    : localGrouped
-  const setGrouped = mainSenatorListGroupedState
-    ? mainSenatorListGroupedState[1]
-    : setLocalGrouped
 
   // State for sort, optionally passed in from the parent component
   const [localSort, setLocalSort] = useState<string>("") // Attribute to sort by, prefixed with '-' for descending order
@@ -164,8 +154,8 @@ const SenatorList = ({
       })
     }
 
-    // Finally, sort by faction if grouped is true
-    if (grouped) {
+    // Finally, sort by faction if groupedSenators is true
+    if (groupedSenators) {
       filteredSortedSenators = filteredSortedSenators.sort((a, b) => {
         const factionARank = allFactions.byId[a.faction]?.rank ?? null
         const factionBRank = allFactions.byId[b.faction]?.rank ?? null
@@ -187,7 +177,7 @@ const SenatorList = ({
     senators,
     allSenators,
     sort,
-    grouped,
+    groupedSenators,
     allFactions,
     filterAlive,
     filterDead,
@@ -246,7 +236,7 @@ const SenatorList = ({
 
   // Handle clicking the group button to toggle grouping
   const handleGroupClick = () =>
-    grouped ? setGrouped(false) : setGrouped(true)
+    groupedSenators ? setGroupedSenators(false) : setGroupedSenators(true)
 
   // Handle clicking the alive filter button to toggle showing alive senators
   const handleFilterAliveClick = () =>
@@ -418,7 +408,7 @@ const SenatorList = ({
                 <div className="w-full h-px bg-neutral-200 dark:bg-neutral-700 my-1"></div>
                 {!faction && (
                   <FormControlLabel
-                    control={<Checkbox checked={grouped} />}
+                    control={<Checkbox checked={groupedSenators} />}
                     label="Group by faction"
                     onChange={handleGroupClick}
                     className="px-4"

--- a/frontend/contexts/CookieContext.tsx
+++ b/frontend/contexts/CookieContext.tsx
@@ -12,6 +12,8 @@ interface CookieContextType {
   setUser: (value: User | null) => void
   darkMode: boolean
   setDarkMode: (value: boolean) => void
+  groupedSenators: boolean
+  setGroupedSenators: (value: boolean) => void
 }
 
 const CookieContext = createContext<CookieContextType | null>(null)
@@ -55,14 +57,15 @@ export const CookieProvider = (props: CookieProviderProps) => {
   const storeUser = (user: User | null) => setUser(JSON.stringify(user))
 
   const [darkMode, setDarkMode] = useCookies<boolean>("darkMode", false)
-  let parsedDarkMode: boolean
-  if (darkMode) {
-    parsedDarkMode = JSON.parse(darkMode)
-  } else {
-    parsedDarkMode = false
-  }
+  const parsedDarkMode = darkMode ? JSON.parse(darkMode) : false
   const storeDarkMode = (darkMode: boolean) =>
-    setDarkMode(JSON.stringify(darkMode))
+  setDarkMode(JSON.stringify(darkMode))
+
+  // Whether to group senators by faction in the senator list
+  const [groupedSenators, setGroupedSenators] = useCookies<boolean>("groupedSenators", false)
+  const parsedGroupedSenators = groupedSenators ? JSON.parse(groupedSenators) : false
+  const storeGroupedSenators = (groupedSenators: boolean) =>
+    setGroupedSenators(JSON.stringify(groupedSenators))
 
   return (
     <CookieContext.Provider
@@ -75,6 +78,8 @@ export const CookieProvider = (props: CookieProviderProps) => {
         setUser: storeUser,
         darkMode: parsedDarkMode,
         setDarkMode: storeDarkMode,
+        groupedSenators: parsedGroupedSenators,
+        setGroupedSenators: storeGroupedSenators,
       }}
     >
       {props.children}


### PR DESCRIPTION
Closes #425 by bringing the "Group by faction" option state into cookie context so that it persists after the user refreshes or leaves the site.