### PR TITLE
Add the senate tab and diagram

### DIFF
--- a/backend/rorapp/functions/__init__.py
+++ b/backend/rorapp/functions/__init__.py
@@ -1,8 +1,8 @@
 # The functions module provides a collection of public functions that are intended to be used by other parts of the application.
 from .enemy_leader_helper import create_new_enemy_leader  # noqa: F401
 from .faction_leader_helper import (
-    select_faction_leader_from_action,
-    select_faction_leader,
+    select_faction_leader_from_action,  # noqa: F401
+    select_faction_leader,  # noqa: F401
 )  # noqa: F401
 from .forum_phase_helper import initiate_situation  # noqa: F401
 from .forum_phase_starter import start_forum_phase  # noqa: F401
@@ -15,6 +15,7 @@ from .mortality_phase_helper import (
 )
 from .mortality_phase_starter import setup_mortality_phase  # noqa: F401
 from .progress_helper import get_latest_phase, get_latest_step  # noqa: F401
+from .rank_helper import rank_senators_and_factions  # noqa: F401
 from .user_helper import find_or_create_test_user  # noqa: F401
 from .war_helper import create_new_war  # noqa: F401
 from .websocket_message_helper import (

--- a/frontend/components/FactionIcon.tsx
+++ b/frontend/components/FactionIcon.tsx
@@ -29,7 +29,9 @@ const FactionIcon = ({
   const svg = (
     <svg
       className={`overflow-visible mx-px my-[-2px] ${
-        muted ? "text-neutral-500 dark:text-neutral-700" : "text-neutral-700 dark:text-black"
+        muted
+          ? "text-neutral-500 dark:text-neutral-700"
+          : "text-neutral-700 dark:text-black"
       }`}
       height={size}
       viewBox="0 0 0.9 1"

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -43,6 +43,7 @@ import Secret from "@/classes/Secret"
 import War from "@/classes/War"
 import WarfareTab from "@/components/WarfareTab"
 import EnemyLeader from "@/classes/EnemyLeader"
+import SenateTab from "@/components/SenateTab"
 
 const webSocketURL: string = process.env.NEXT_PUBLIC_WS_URL ?? ""
 
@@ -216,7 +217,7 @@ const GamePage = (props: GamePageProps) => {
       fetchData(
         url,
         (data: any) => {
-          if (data.length === 0) return  // Exit if there is no data
+          if (data.length === 0) return // Exit if there is no data
           const deserializedInstance = new EntityType(data.id ? data : data[0])
           setEntity(deserializedInstance)
         },
@@ -696,6 +697,7 @@ const GamePage = (props: GamePageProps) => {
                   >
                     <Tab label="Factions" />
                     <Tab label="Senators" />
+                    <Tab label="Senate" />
                     <Tab label="Warfare" />
                   </Tabs>
                 </div>
@@ -720,7 +722,8 @@ const GamePage = (props: GamePageProps) => {
                     />
                   </div>
                 )}
-                {mainTab === 2 && <WarfareTab />}
+                {mainTab === 2 && <SenateTab />}
+                {mainTab === 3 && <WarfareTab />}
               </section>
             </div>
             <div className="xl:flex-1 xl:max-w-[540px] bg-neutral-50 dark:bg-neutral-700 rounded shadow">

--- a/frontend/components/SenateSeat.tsx
+++ b/frontend/components/SenateSeat.tsx
@@ -1,0 +1,41 @@
+import Senator from "@/classes/Senator"
+import SenatorPortrait from "@/components/SenatorPortrait"
+import { getXOffset, getYOffset } from "@/functions/trigonometry"
+
+interface SenateSeatProps {
+  angle: number
+  radius: number
+  size: number
+  senator: Senator
+}
+
+const SenateSeat = ({ angle, radius, size, senator }: SenateSeatProps) => {
+  const xOffset = getXOffset(angle, radius)
+  const yOffset = getYOffset(angle, radius)
+
+  return (
+    <div
+      className="absolute left-1/2 top-1/2 z-10"
+      style={{
+        transform: `translate(${xOffset}px, ${yOffset}px)`,
+        marginLeft: -size / 2,
+        marginTop: -size / 2,
+      }}
+    >
+      <div
+        className="h-[80px] w-[80px] rounded-full bg-black"
+        style={{ width: size, height: size }}
+      >
+        <SenatorPortrait
+          senator={senator}
+          size={size}
+          selectable
+          round
+          nameTooltip
+        />
+      </div>
+    </div>
+  )
+}
+
+export default SenateSeat

--- a/frontend/components/SenateSector.tsx
+++ b/frontend/components/SenateSector.tsx
@@ -97,7 +97,9 @@ const SenateSector = ({
         style={{
           width: outerRadius * 2,
           height: outerRadius * 2,
-          backgroundColor: (darkMode ? faction?.getColor(600) : faction?.getColor(300)) ?? (darkMode ? "var(--neutral-500)" : "var(--neutral-200)"),
+          backgroundColor:
+            (darkMode ? faction?.getColor(600) : faction?.getColor(300)) ??
+            (darkMode ? "var(--neutral-550)" : "var(--neutral-200)"),
           clipPath: `path('\
             M ${outerRadius + getXOffset(startAngle, innerRadius)} ${
             outerRadius + getYOffset(startAngle, innerRadius)

--- a/frontend/components/SenateSector.tsx
+++ b/frontend/components/SenateSector.tsx
@@ -131,16 +131,18 @@ const SenateSector = ({
           </div>
         </div>
       )}
-      {innerSeatData.map((seatData) => (
+      {innerSeatData.map((seatData, index) => (
         <SenateSeat
+          key={index}
           angle={seatData.angle}
           radius={innerRowRadius}
           size={seatSize}
           senator={seatData.senator}
         />
       ))}
-      {outerSeatData.map((seatData) => (
+      {outerSeatData.map((seatData, index) => (
         <SenateSeat
+          key={index}
           angle={seatData.angle}
           radius={outerRowRadius}
           size={seatSize}

--- a/frontend/components/SenateSector.tsx
+++ b/frontend/components/SenateSector.tsx
@@ -1,0 +1,154 @@
+import Faction from "@/classes/Faction"
+import Senator from "@/classes/Senator"
+import FactionIcon from "@/components/FactionIcon"
+import { getXOffset, getYOffset } from "@/functions/trigonometry"
+import SenateSeat from "@/components/SenateSeat"
+import { useCookieContext } from "@/contexts/CookieContext"
+
+const SECTOR_GAP_ANGLE = 2
+const SEAT_GAP = 5
+
+interface SeatData {
+  senator: Senator
+  angle: number
+}
+
+interface SenateSectorProps {
+  outerRadius: number
+  startAngle: number
+  endAngle: number
+  senators: Senator[]
+  seatSize: number
+  faction?: Faction
+}
+
+const SenateSector = ({
+  outerRadius,
+  startAngle,
+  endAngle,
+  senators,
+  seatSize,
+  faction,
+}: SenateSectorProps) => {
+  const { darkMode } = useCookieContext()
+
+  const innerRadius = outerRadius - seatSize * 2 - SEAT_GAP * 3
+
+  startAngle += SECTOR_GAP_ANGLE / 2
+  endAngle -= SECTOR_GAP_ANGLE / 2
+  const meanAngle = (startAngle + endAngle) / 2
+
+  const pathArc = endAngle - startAngle > 180 ? 1 : 0
+
+  const innerRowRadius = outerRadius - seatSize * 1.5 - SEAT_GAP * 2
+  const outerRowRadius = outerRadius - seatSize * 0.5 - SEAT_GAP
+  const innerRowArcLength =
+    innerRowRadius * (endAngle - startAngle) * (Math.PI / 180)
+
+  const centerAngle = (startAngle + endAngle) / 2
+
+  const innerCapacity = Math.floor(innerRowArcLength / (seatSize + SEAT_GAP))
+
+  let innerSeatsCount = Math.min(
+    innerCapacity,
+    senators.length,
+    Math.floor(senators.length / 2 + 1)
+  )
+  if (innerSeatsCount == 0 && senators.length > 1) {
+    innerSeatsCount = 1
+  }
+  const outerSeatsCount = senators.length - innerSeatsCount
+
+  let senatorIndex = 0
+  const innerSeatsArcLength =
+    innerSeatsCount * seatSize - seatSize + (innerSeatsCount - 1) * SEAT_GAP
+  const innerSeatsArcAngle =
+    (innerSeatsArcLength / innerRowRadius) * (180 / Math.PI)
+  const innerSeatData: SeatData[] = []
+  let currentAngle = centerAngle - innerSeatsArcAngle / 2
+  for (let i = 0; i < innerSeatsCount; i++) {
+    innerSeatData.push({
+      senator: senators[senatorIndex],
+      angle: currentAngle,
+    })
+    currentAngle += innerSeatsArcAngle / (innerSeatsCount - 1)
+    senatorIndex++
+  }
+
+  const outerSeatsArcLength =
+    outerSeatsCount * seatSize - seatSize + (outerSeatsCount - 1) * SEAT_GAP
+  const outerSeatsArcAngle =
+    (outerSeatsArcLength / outerRowRadius) * (180 / Math.PI)
+  const outerSeatData: SeatData[] = []
+  currentAngle = centerAngle - outerSeatsArcAngle / 2
+  for (let i = 0; i < outerSeatsCount; i++) {
+    outerSeatData.push({
+      senator: senators[senatorIndex],
+      angle: currentAngle,
+    })
+    currentAngle += outerSeatsArcAngle / (outerSeatsCount - 1)
+    senatorIndex++
+  }
+
+  return (
+    <>
+      <div
+        className="absolute right-1/2 bottom-1/2 translate-x-1/2 translate-y-1/2 bg-neutral-200"
+        style={{
+          width: outerRadius * 2,
+          height: outerRadius * 2,
+          backgroundColor: (darkMode ? faction?.getColor(600) : faction?.getColor(300)) ?? (darkMode ? "var(--neutral-500)" : "var(--neutral-200)"),
+          clipPath: `path('\
+            M ${outerRadius + getXOffset(startAngle, innerRadius)} ${
+            outerRadius + getYOffset(startAngle, innerRadius)
+          } \
+            L ${outerRadius + getXOffset(startAngle, outerRadius)} ${
+            outerRadius + getYOffset(startAngle, outerRadius)
+          } \
+            A ${outerRadius} ${outerRadius} 0 ${pathArc} 1 ${
+            outerRadius + getXOffset(endAngle, outerRadius)
+          } ${outerRadius + getYOffset(endAngle, outerRadius)} \
+            L ${outerRadius + getXOffset(endAngle, innerRadius)} ${
+            outerRadius + getYOffset(endAngle, innerRadius)
+          } \
+            A ${innerRadius} ${innerRadius} 0 ${pathArc} 0 ${
+            outerRadius + getXOffset(startAngle, innerRadius)
+          } ${outerRadius + getYOffset(startAngle, innerRadius)} \
+            ')`,
+        }}
+      ></div>
+      {faction && (
+        <div className="absolute right-1/2 bottom-1/2 translate-x-1/2 translate-y-1/2">
+          <div
+            style={{
+              transform: `translate(${getXOffset(
+                meanAngle,
+                innerRadius - 25
+              )}px, ${getYOffset(meanAngle, innerRadius - 25)}px)`,
+            }}
+          >
+            <FactionIcon faction={faction} size={30} selectable />
+          </div>
+        </div>
+      )}
+      {innerSeatData.map((seatData) => (
+        <SenateSeat
+          angle={seatData.angle}
+          radius={innerRowRadius}
+          size={seatSize}
+          senator={seatData.senator}
+        />
+      ))}
+      {outerSeatData.map((seatData) => (
+        <SenateSeat
+          angle={seatData.angle}
+          radius={outerRowRadius}
+          size={seatSize}
+          senator={seatData.senator}
+        />
+      ))}
+    </>
+  )
+}
+
+export default SenateSector

--- a/frontend/components/SenateTab.tsx
+++ b/frontend/components/SenateTab.tsx
@@ -3,20 +3,7 @@ import Senator from "@/classes/Senator"
 import { useGameContext } from "@/contexts/GameContext"
 import SenatorPortrait from "@/components/SenatorPortrait"
 import FactionIcon from "@/components/FactionIcon"
-
-const getOpposite = (hypotenuse: number, angle: number) => {
-  return Math.sin((-angle * Math.PI) / 180) * hypotenuse
-}
-const getXOffset = (angle: number, radius: number) => {
-  return getOpposite(radius, angle + 180)
-}
-
-const getAdjacent = (hypotenuse: number, angle: number) => {
-  return Math.cos((-angle * Math.PI) / 180) * hypotenuse
-}
-const getYOffset = (angle: number, radius: number) => {
-  return getAdjacent(radius, angle + 180)
-}
+import { getXOffset, getYOffset } from "@/functions/trigonometry"
 
 interface SeatProps {
   angle: number

--- a/frontend/components/SenateTab.tsx
+++ b/frontend/components/SenateTab.tsx
@@ -1,0 +1,277 @@
+import Faction from "@/classes/Faction"
+import Senator from "@/classes/Senator"
+import { useGameContext } from "@/contexts/GameContext"
+import SenatorPortrait from "./SenatorPortrait"
+
+const getOpposite = (hypotenuse: number, angle: number) => {
+  return Math.sin((-angle * Math.PI) / 180) * hypotenuse
+}
+const getXOffset = (angle: number, radius: number) => {
+  return getOpposite(radius, angle + 180)
+}
+
+const getAdjacent = (hypotenuse: number, angle: number) => {
+  return Math.cos((-angle * Math.PI) / 180) * hypotenuse
+}
+const getYOffset = (angle: number, radius: number) => {
+  return getAdjacent(radius, angle + 180)
+}
+
+interface SeatProps {
+  angle: number
+  radius: number
+  seatSize: number
+  senator: Senator
+}
+
+const Seat = ({ angle, radius, seatSize, senator }: SeatProps) => {
+  const xOffset = getXOffset(angle, radius)
+  const yOffset = getYOffset(angle, radius)
+
+  return (
+    <div
+      className="absolute left-1/2 top-1/2 z-10"
+      style={{
+        transform: `translate(${xOffset}px, ${yOffset}px)`,
+        marginLeft: -seatSize / 2,
+        marginTop: -seatSize / 2,
+      }}
+    >
+      <div
+        className="h-[80px] w-[80px] rounded-full bg-black"
+        style={{ width: seatSize, height: seatSize }}
+      >
+        <SenatorPortrait
+          senator={senator}
+          size={seatSize}
+          selectable
+          round
+          nameTooltip
+        />
+      </div>
+    </div>
+  )
+}
+
+interface SeatData {
+  senator: Senator
+  angle: number
+}
+
+interface SectorProps {
+  startAngle: number
+  endAngle: number
+  faction: Faction | null
+  senators: Senator[]
+  seatSize: number
+}
+
+const Sector = ({
+  startAngle,
+  endAngle,
+  faction,
+  senators,
+  seatSize,
+}: SectorProps) => {
+  const SECTOR_GAP_ANGLE = 2
+  const OUTER_RADIUS = 340
+  const SEAT_GAP = 5
+
+  const innerRadius = OUTER_RADIUS - seatSize * 2 - SEAT_GAP * 3
+
+  startAngle += SECTOR_GAP_ANGLE / 2
+  endAngle -= SECTOR_GAP_ANGLE / 2
+
+  const pathArc = endAngle - startAngle > 180 ? 1 : 0
+
+  const innerRowRadius = OUTER_RADIUS - seatSize * 1.5 - SEAT_GAP * 2
+  const outerRowRadius = OUTER_RADIUS - seatSize * 0.5 - SEAT_GAP
+  const innerRowArcLength =
+    innerRowRadius * (endAngle - startAngle) * (Math.PI / 180)
+
+  const centerAngle = (startAngle + endAngle) / 2
+
+  const innerCapacity = Math.floor(innerRowArcLength / (seatSize + SEAT_GAP))
+
+  let innerSeatsCount = Math.min(
+    innerCapacity,
+    senators.length,
+    Math.floor(senators.length / 2 + 1)
+  )
+  if (innerSeatsCount == 0 && senators.length > 1) {
+    innerSeatsCount = 1
+  }
+  const outerSeatsCount = senators.length - innerSeatsCount
+
+  let senatorIndex = 0
+  const innerSeatsArcLength =
+    innerSeatsCount * seatSize - seatSize + (innerSeatsCount - 1) * SEAT_GAP
+  const innerSeatsArcAngle =
+    (innerSeatsArcLength / innerRowRadius) * (180 / Math.PI)
+  const innerSeatData: SeatData[] = []
+  let currentAngle = centerAngle - innerSeatsArcAngle / 2
+  for (let i = 0; i < innerSeatsCount; i++) {
+    innerSeatData.push({
+      senator: senators[senatorIndex],
+      angle: currentAngle,
+    })
+    currentAngle += innerSeatsArcAngle / (innerSeatsCount - 1)
+    senatorIndex++
+  }
+
+  const outerSeatsArcLength =
+    outerSeatsCount * seatSize - seatSize + (outerSeatsCount - 1) * SEAT_GAP
+  const outerSeatsArcAngle =
+    (outerSeatsArcLength / outerRowRadius) * (180 / Math.PI)
+  const outerSeatData: SeatData[] = []
+  currentAngle = centerAngle - outerSeatsArcAngle / 2
+  for (let i = 0; i < outerSeatsCount; i++) {
+    outerSeatData.push({
+      senator: senators[senatorIndex],
+      angle: currentAngle,
+    })
+    currentAngle += outerSeatsArcAngle / (outerSeatsCount - 1)
+    senatorIndex++
+  }
+
+  return (
+    <>
+      <div
+        className="absolute right-1/2 bottom-1/2 translate-x-1/2 translate-y-1/2 bg-neutral-200"
+        style={{
+          width: OUTER_RADIUS * 2,
+          height: OUTER_RADIUS * 2,
+          backgroundColor: faction?.getColor(300) ?? "var(--neutral-300)",
+          clipPath: `path('\
+            M ${OUTER_RADIUS + getXOffset(startAngle, innerRadius)} ${
+            OUTER_RADIUS + getYOffset(startAngle, innerRadius)
+          } \
+            L ${OUTER_RADIUS + getXOffset(startAngle, OUTER_RADIUS)} ${
+            OUTER_RADIUS + getYOffset(startAngle, OUTER_RADIUS)
+          } \
+            A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 ${pathArc} 1 ${
+            OUTER_RADIUS + getXOffset(endAngle, OUTER_RADIUS)
+          } ${OUTER_RADIUS + getYOffset(endAngle, OUTER_RADIUS)} \
+            L ${OUTER_RADIUS + getXOffset(endAngle, innerRadius)} ${
+            OUTER_RADIUS + getYOffset(endAngle, innerRadius)
+          } \
+            A ${innerRadius} ${innerRadius} 0 ${pathArc} 0 ${
+            OUTER_RADIUS + getXOffset(startAngle, innerRadius)
+          } ${OUTER_RADIUS + getYOffset(startAngle, innerRadius)} \
+            ')`,
+        }}
+      ></div>
+      {innerSeatData.map((seatData) => (
+        <Seat
+          angle={seatData.angle}
+          radius={innerRowRadius}
+          seatSize={seatSize}
+          senator={seatData.senator}
+        />
+      ))}
+      {outerSeatData.map((seatData) => (
+        <Seat
+          angle={seatData.angle}
+          radius={outerRowRadius}
+          seatSize={seatSize}
+          senator={seatData.senator}
+        />
+      ))}
+    </>
+  )
+}
+
+interface SectorData {
+  faction: Faction | null
+  senators: Senator[]
+  space: number
+  startAngle: number
+  endAngle: number
+}
+
+const SenateTab = () => {
+  const EMPTY_SPACE_ANGLE = 50
+
+  const { allFactions, allSenators } = useGameContext()
+
+  let sectors: SectorData[] = []
+  allFactions.asArray.forEach((faction) => {
+    const senators = allSenators.asArray
+      .filter((senator) => senator.alive && senator.faction === faction.id)
+      .sort((a, b) => a.rank! - b.rank!)
+    sectors.push({
+      faction: faction,
+      senators: senators,
+      space: 0,
+      startAngle: 0,
+      endAngle: 0,
+    })
+  })
+
+  const unalignedSenators = allSenators.asArray
+    .filter((senator) => senator.alive && senator.faction === null)
+    .sort((a, b) => a.influence - b.influence)
+
+  sectors.push({
+    faction: null,
+    senators: unalignedSenators,
+    space: 0,
+    startAngle: 0,
+    endAngle: 0,
+  })
+
+  sectors = sectors.sort((a, b) => a.senators.length - b.senators.length)
+  sectors = sectors.filter((sector) => sector.senators.length > 0)
+
+  const totalMembers = sectors.reduce(
+    (acc, sector) => acc + sector.senators.length,
+    0
+  )
+  const seatSize = Math.max(40, Math.min(80, 110 - totalMembers * 1.5))
+
+  const minimumSpace = (0.055 * seatSize) / 80
+
+  let remainingSpace = 1
+  let remainingMembers = totalMembers
+  sectors.forEach((sector) => {
+    const representativeSpace =
+      (sector.senators.length * remainingSpace) / remainingMembers
+    let actualSpace = Math.max(minimumSpace, representativeSpace)
+    sector.space = actualSpace
+    remainingSpace -= actualSpace
+    remainingMembers -= sector.senators.length
+  })
+
+  sectors.sort((a, b) =>
+    a.faction && b.faction
+      ? a.faction.rank - b.faction.rank
+      : a.faction
+      ? -1
+      : 1
+  )
+
+  let currentAngle = EMPTY_SPACE_ANGLE / 2
+  const totalAngle = 360 - EMPTY_SPACE_ANGLE
+  sectors.forEach((sector) => {
+    sector.startAngle = currentAngle
+    sector.endAngle = currentAngle + totalAngle * sector.space
+    currentAngle += totalAngle * sector.space
+  })
+
+  return (
+    <div className="h-full w-full relative">
+      {sectors.map((sector) => (
+        <Sector
+          key={sector.faction?.id ?? -1}
+          startAngle={sector.startAngle}
+          endAngle={sector.endAngle}
+          faction={sector.faction}
+          senators={sector.senators}
+          seatSize={seatSize}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default SenateTab

--- a/frontend/components/SenateTab.tsx
+++ b/frontend/components/SenateTab.tsx
@@ -1,206 +1,24 @@
 import Faction from "@/classes/Faction"
 import Senator from "@/classes/Senator"
 import { useGameContext } from "@/contexts/GameContext"
-import SenatorPortrait from "@/components/SenatorPortrait"
-import FactionIcon from "@/components/FactionIcon"
-import { getXOffset, getYOffset } from "@/functions/trigonometry"
+import SenateSector from "@/components/SenateSector"
 
-interface SeatProps {
-  angle: number
-  radius: number
-  seatSize: number
-  senator: Senator
-}
-
-const Seat = ({ angle, radius, seatSize, senator }: SeatProps) => {
-  const xOffset = getXOffset(angle, radius)
-  const yOffset = getYOffset(angle, radius)
-
-  return (
-    <div
-      className="absolute left-1/2 top-1/2 z-10"
-      style={{
-        transform: `translate(${xOffset}px, ${yOffset}px)`,
-        marginLeft: -seatSize / 2,
-        marginTop: -seatSize / 2,
-      }}
-    >
-      <div
-        className="h-[80px] w-[80px] rounded-full bg-black"
-        style={{ width: seatSize, height: seatSize }}
-      >
-        <SenatorPortrait
-          senator={senator}
-          size={seatSize}
-          selectable
-          round
-          nameTooltip
-        />
-      </div>
-    </div>
-  )
-}
-
-interface SeatData {
-  senator: Senator
-  angle: number
-}
-
-interface SectorProps {
-  outerRadius: number
-  startAngle: number
-  endAngle: number
-  faction: Faction | null
-  senators: Senator[]
-  seatSize: number
-}
-
-const Sector = ({
-  outerRadius,
-  startAngle,
-  endAngle,
-  faction,
-  senators,
-  seatSize,
-}: SectorProps) => {
-  const SECTOR_GAP_ANGLE = 2
-
-  const SEAT_GAP = 5
-
-  const innerRadius = outerRadius - seatSize * 2 - SEAT_GAP * 3
-
-  startAngle += SECTOR_GAP_ANGLE / 2
-  endAngle -= SECTOR_GAP_ANGLE / 2
-  const meanAngle = (startAngle + endAngle) / 2
-
-  const pathArc = endAngle - startAngle > 180 ? 1 : 0
-
-  const innerRowRadius = outerRadius - seatSize * 1.5 - SEAT_GAP * 2
-  const outerRowRadius = outerRadius - seatSize * 0.5 - SEAT_GAP
-  const innerRowArcLength =
-    innerRowRadius * (endAngle - startAngle) * (Math.PI / 180)
-
-  const centerAngle = (startAngle + endAngle) / 2
-
-  const innerCapacity = Math.floor(innerRowArcLength / (seatSize + SEAT_GAP))
-
-  let innerSeatsCount = Math.min(
-    innerCapacity,
-    senators.length,
-    Math.floor(senators.length / 2 + 1)
-  )
-  if (innerSeatsCount == 0 && senators.length > 1) {
-    innerSeatsCount = 1
-  }
-  const outerSeatsCount = senators.length - innerSeatsCount
-
-  let senatorIndex = 0
-  const innerSeatsArcLength =
-    innerSeatsCount * seatSize - seatSize + (innerSeatsCount - 1) * SEAT_GAP
-  const innerSeatsArcAngle =
-    (innerSeatsArcLength / innerRowRadius) * (180 / Math.PI)
-  const innerSeatData: SeatData[] = []
-  let currentAngle = centerAngle - innerSeatsArcAngle / 2
-  for (let i = 0; i < innerSeatsCount; i++) {
-    innerSeatData.push({
-      senator: senators[senatorIndex],
-      angle: currentAngle,
-    })
-    currentAngle += innerSeatsArcAngle / (innerSeatsCount - 1)
-    senatorIndex++
-  }
-
-  const outerSeatsArcLength =
-    outerSeatsCount * seatSize - seatSize + (outerSeatsCount - 1) * SEAT_GAP
-  const outerSeatsArcAngle =
-    (outerSeatsArcLength / outerRowRadius) * (180 / Math.PI)
-  const outerSeatData: SeatData[] = []
-  currentAngle = centerAngle - outerSeatsArcAngle / 2
-  for (let i = 0; i < outerSeatsCount; i++) {
-    outerSeatData.push({
-      senator: senators[senatorIndex],
-      angle: currentAngle,
-    })
-    currentAngle += outerSeatsArcAngle / (outerSeatsCount - 1)
-    senatorIndex++
-  }
-
-  return (
-    <>
-      <div
-        className="absolute right-1/2 bottom-1/2 translate-x-1/2 translate-y-1/2 bg-neutral-200"
-        style={{
-          width: outerRadius * 2,
-          height: outerRadius * 2,
-          backgroundColor: faction?.getColor(300) ?? "var(--neutral-300)",
-          clipPath: `path('\
-            M ${outerRadius + getXOffset(startAngle, innerRadius)} ${
-            outerRadius + getYOffset(startAngle, innerRadius)
-          } \
-            L ${outerRadius + getXOffset(startAngle, outerRadius)} ${
-            outerRadius + getYOffset(startAngle, outerRadius)
-          } \
-            A ${outerRadius} ${outerRadius} 0 ${pathArc} 1 ${
-            outerRadius + getXOffset(endAngle, outerRadius)
-          } ${outerRadius + getYOffset(endAngle, outerRadius)} \
-            L ${outerRadius + getXOffset(endAngle, innerRadius)} ${
-            outerRadius + getYOffset(endAngle, innerRadius)
-          } \
-            A ${innerRadius} ${innerRadius} 0 ${pathArc} 0 ${
-            outerRadius + getXOffset(startAngle, innerRadius)
-          } ${outerRadius + getYOffset(startAngle, innerRadius)} \
-            ')`,
-        }}
-      ></div>
-      {faction && (
-        <div className="absolute right-1/2 bottom-1/2 translate-x-1/2 translate-y-1/2">
-          <div
-            style={{
-              transform: `translate(${getXOffset(
-                meanAngle,
-                innerRadius - 25
-              )}px, ${getYOffset(meanAngle, innerRadius - 25)}px)`,
-            }}
-          >
-            <FactionIcon faction={faction} size={30} selectable />
-          </div>
-        </div>
-      )}
-      {innerSeatData.map((seatData) => (
-        <Seat
-          angle={seatData.angle}
-          radius={innerRowRadius}
-          seatSize={seatSize}
-          senator={seatData.senator}
-        />
-      ))}
-      {outerSeatData.map((seatData) => (
-        <Seat
-          angle={seatData.angle}
-          radius={outerRowRadius}
-          seatSize={seatSize}
-          senator={seatData.senator}
-        />
-      ))}
-    </>
-  )
-}
+const EMPTY_SPACE_ANGLE = 50 // Angular distance between sectors
+const SIZE = 720 // Width of the Senate diagram
+const MARGIN = 10 // Margin around the diagram
 
 interface SectorData {
-  faction: Faction | null
   senators: Senator[]
   space: number
   startAngle: number
   endAngle: number
+  faction?: Faction
 }
 
 const SenateTab = () => {
-  const EMPTY_SPACE_ANGLE = 50
-  const SIZE = 720
-  const MARGIN = 10
-  const outerRadius = SIZE / 2 - MARGIN
-
   const { allFactions, allSenators } = useGameContext()
+
+  const outerRadius = SIZE / 2 - MARGIN
 
   let sectors: SectorData[] = []
   allFactions.asArray.forEach((faction) => {
@@ -208,11 +26,11 @@ const SenateTab = () => {
       .filter((senator) => senator.alive && senator.faction === faction.id)
       .sort((a, b) => a.rank! - b.rank!)
     sectors.push({
-      faction: faction,
       senators: senators,
       space: 0,
       startAngle: 0,
       endAngle: 0,
+      faction: faction,
     })
   })
 
@@ -221,7 +39,6 @@ const SenateTab = () => {
     .sort((a, b) => a.influence - b.influence)
 
   sectors.push({
-    faction: null,
     senators: unalignedSenators,
     space: 0,
     startAngle: 0,
@@ -244,7 +61,7 @@ const SenateTab = () => {
   sectors.forEach((sector) => {
     const representativeSpace =
       (sector.senators.length * remainingSpace) / remainingMembers
-    let actualSpace = Math.max(minimumSpace, representativeSpace)
+    const actualSpace = Math.max(minimumSpace, representativeSpace)
     sector.space = actualSpace
     remainingSpace -= actualSpace
     remainingMembers -= sector.senators.length
@@ -274,7 +91,7 @@ const SenateTab = () => {
       >
         <div className="relative mt-[-35px]">
           {sectors.map((sector) => (
-            <Sector
+            <SenateSector
               key={sector.faction?.id ?? -1}
               outerRadius={outerRadius}
               startAngle={sector.startAngle}

--- a/frontend/components/SenateTab.tsx
+++ b/frontend/components/SenateTab.tsx
@@ -283,9 +283,9 @@ const SenateTab = () => {
     <div className="h-full w-full overflow-auto box-border">
       <div
         className="h-full w-full flex justify-center items-center"
-        style={{ minWidth: SIZE, minHeight: SIZE }}
+        style={{ minWidth: SIZE, minHeight: SIZE - 35 }}
       >
-        <div className="relative" style={{ width: SIZE, height: SIZE }}>
+        <div className="relative mt-[-35px]">
           {sectors.map((sector) => (
             <Sector
               key={sector.faction?.id ?? -1}

--- a/frontend/components/SenatorPortrait.module.css
+++ b/frontend/components/SenatorPortrait.module.css
@@ -4,16 +4,15 @@
 
 .senatorPortrait.selectable {
   cursor: pointer;
-  
+
   /* Remove default button styles */
   border: none;
   padding: 0;
   background-color: transparent;
 }
 
-.senatorPortrait>figure {
+.senatorPortrait > figure {
   box-sizing: border-box;
-  border-radius: 4px;
 
   position: relative;
   display: flex;
@@ -50,7 +49,6 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  border-radius: 2px;
 }
 
 .imageContainer img.picture {

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -65,6 +65,7 @@ interface SenatorPortraitProps {
   selectable?: boolean
   nameTooltip?: boolean
   blurryPlaceholder?: boolean
+  round?: boolean
 }
 
 // The senator portrait is a visual representation of the senator,
@@ -75,6 +76,7 @@ const SenatorPortrait = ({
   selectable,
   nameTooltip,
   blurryPlaceholder,
+  round,
 }: SenatorPortraitProps) => {
   const {
     allFactions,
@@ -113,6 +115,7 @@ const SenatorPortrait = ({
       border: "2px solid " + bgColor,
       height: size - 8,
       width: size - 8,
+      borderRadius: round ? "50%" : "2px",
     }
   }
 
@@ -162,6 +165,7 @@ const SenatorPortrait = ({
       background: "radial-gradient(" + innerBgColor + ", " + outerBgColor + ")",
       height: size - 6,
       width: size - 6,
+      borderRadius: round ? "50%" : "4px",
     }
   }
 
@@ -222,7 +226,11 @@ const SenatorPortrait = ({
       onClick={handleClick}
     >
       <figure
-        style={{ height: size, width: size }}
+        style={{
+          height: size,
+          width: size,
+          borderRadius: round ? "50%" : "4px",
+        }}
         className="shadow bg-neutral-700 dark:bg-black"
       >
         <div
@@ -234,6 +242,7 @@ const SenatorPortrait = ({
             selectedDetail?.id === senator.id && (
               <div
                 className={`absolute w-full h-full z-[2] shadow-[inset_0_0_6px_4px_white]`}
+                style={{ borderRadius: round ? "50%" : 0 }}
               ></div>
             )}
           {factionLeader && (
@@ -257,31 +266,35 @@ const SenatorPortrait = ({
           />
         </div>
         <div className={styles.bg} style={getBgStyle()}></div>
-        {size > 120 && (
-          <Tooltip title="Senator ID" arrow>
-            <div className={styles.code}># {senator.code}</div>
-          </Tooltip>
-        )}
-        {majorOffice && (
-          <TitleIcon
-            title={majorOffice}
-            size={getIconSize()}
-            dead={!senator.alive}
-          />
-        )}
-        {senator.alive === false && (
-          <Image
-            src={DeadIcon}
-            alt="Skull and crossbones icon"
-            height={getIconSize()}
-            width={getIconSize()}
-            className={styles.deadIcon}
-          />
-        )}
-        {debugShowEntityIds && (
-          <div className="z-[1000] absolute top-1 px-1 text-lg text-white bg-black/60 ">
-            {senator.id}
-          </div>
+        {!round && (
+          <>
+            {size > 120 && (
+              <Tooltip title="Senator ID" arrow>
+                <div className={styles.code}># {senator.code}</div>
+              </Tooltip>
+            )}
+            {majorOffice && (
+              <TitleIcon
+                title={majorOffice}
+                size={getIconSize()}
+                dead={!senator.alive}
+              />
+            )}
+            {senator.alive === false && (
+              <Image
+                src={DeadIcon}
+                alt="Skull and crossbones icon"
+                height={getIconSize()}
+                width={getIconSize()}
+                className={styles.deadIcon}
+              />
+            )}
+            {debugShowEntityIds && (
+              <div className="z-[1000] absolute top-1 px-1 text-lg text-white bg-black/60 ">
+                {senator.id}
+              </div>
+            )}
+          </>
         )}
       </figure>
     </PortraitElement>
@@ -289,10 +302,7 @@ const SenatorPortrait = ({
 
   if (nameTooltip) {
     return (
-      <Tooltip
-        title={senator.displayName}
-        arrow
-      >
+      <Tooltip title={senator.displayName} arrow>
         {getPortrait()}
       </Tooltip>
     )

--- a/frontend/functions/trigonometry.ts
+++ b/frontend/functions/trigonometry.ts
@@ -1,0 +1,7 @@
+export const getXOffset = (angle: number, radius: number) => {
+  return Math.sin((-(angle + 180) * Math.PI) / 180) * radius
+}
+
+export const getYOffset = (angle: number, radius: number) => {
+  return Math.cos((-(angle + 180) * Math.PI) / 180) * radius
+}


### PR DESCRIPTION
Closes #435 by adding the senate tab with this initial version of the senate diagram:

![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/589c06d0-c117-4e7a-a55a-2e59ed454093)
