### PR TITLE
Improve the progress section (mostly refactoring)

### DIFF
--- a/frontend/components/ActionLog.tsx
+++ b/frontend/components/ActionLog.tsx
@@ -1,35 +1,35 @@
 import ActionLog from "@/classes/ActionLog"
-import SelectFactionLeaderNotification from "./actionLogs/ActionLog_SelectFactionLeader"
-import FaceMortalityNotification from "./actionLogs/ActionLog_FaceMortality"
-import TemporaryRomeConsulNotification from "./actionLogs/ActionLog_TemporaryRomeConsul"
-import NewTurnNotification from "./actionLogs/ActionLog_NewTurn"
-import NewFamilyNotification from "./actionLogs/ActionLog_NewFamily"
-import NewWarNotification from "./actionLogs/ActionLog_NewWar"
-import MatchedWarNotification from "./actionLogs/ActionLog_MatchedWar"
-import NewEnemyLeaderNotification from "./actionLogs/ActionLog_NewEnemyLeader"
-import MatchedEnemyLeaderNotification from "./actionLogs/ActionLog_MatchedEnemyLeader"
-import NewSecretNotification from "./actionLogs/ActionLog_NewSecret"
+import SelectFactionLeaderActionLog from "./actionLogs/ActionLog_SelectFactionLeader"
+import FaceMortalityActionLog from "./actionLogs/ActionLog_FaceMortality"
+import TemporaryRomeConsulActionLog from "./actionLogs/ActionLog_TemporaryRomeConsul"
+import NewTurnActionLog from "./actionLogs/ActionLog_NewTurn"
+import NewFamilyActionLog from "./actionLogs/ActionLog_NewFamily"
+import NewWarActionLog from "./actionLogs/ActionLog_NewWar"
+import MatchedWarActionLog from "./actionLogs/ActionLog_MatchedWar"
+import NewEnemyLeaderActionLog from "./actionLogs/ActionLog_NewEnemyLeader"
+import MatchedEnemyLeaderActionLog from "./actionLogs/ActionLog_MatchedEnemyLeader"
+import NewSecretActionLog from "./actionLogs/ActionLog_NewSecret"
 
-interface NotificationItemProps {
+interface ActionLogItemProps {
   notification: ActionLog
   senatorDetails?: boolean
 }
 
 const notifications: { [key: string]: React.ComponentType<any> } = {
-  face_mortality: FaceMortalityNotification,
-  matched_enemy_leader: MatchedEnemyLeaderNotification,
-  matched_war: MatchedWarNotification,
-  new_enemy_leader: NewEnemyLeaderNotification,
-  new_family: NewFamilyNotification,
-  new_secret: NewSecretNotification,
-  new_turn: NewTurnNotification,
-  new_war: NewWarNotification,
-  select_faction_leader: SelectFactionLeaderNotification,
-  temporary_rome_consul: TemporaryRomeConsulNotification,
+  face_mortality: FaceMortalityActionLog,
+  matched_enemy_leader: MatchedEnemyLeaderActionLog,
+  matched_war: MatchedWarActionLog,
+  new_enemy_leader: NewEnemyLeaderActionLog,
+  new_family: NewFamilyActionLog,
+  new_secret: NewSecretActionLog,
+  new_turn: NewTurnActionLog,
+  new_war: NewWarActionLog,
+  select_faction_leader: SelectFactionLeaderActionLog,
+  temporary_rome_consul: TemporaryRomeConsulActionLog,
 }
 
 // Container for a notification, which determines the type of notification to render
-const NotificationContainer = (props: NotificationItemProps) => {
+const ActionLogContainer = (props: ActionLogItemProps) => {
   const ContentComponent = notifications[props.notification.type]
   return (
     <ContentComponent
@@ -39,4 +39,4 @@ const NotificationContainer = (props: NotificationItemProps) => {
   )
 }
 
-export default NotificationContainer
+export default ActionLogContainer

--- a/frontend/components/ActionsArea.tsx
+++ b/frontend/components/ActionsArea.tsx
@@ -89,9 +89,9 @@ const ActionsArea = () => {
         <h3 className="leading-none m-0 ml-2 text-base text-neutral-600 dark:text-neutral-100">
           Actions
         </h3>
-        <div className="p-2 bg-white dark:bg-neutral-600 border border-solid border-neutral-200 dark:border-neutral-750 rounded shadow-inner flex flex-col gap-3 items-center">
+        <div className="p-2 h-[80px] bg-white dark:bg-neutral-600 border border-solid border-neutral-200 dark:border-neutral-750 rounded shadow-inner flex flex-col justify-center gap-3 items-center">
           <p className="text-center">{waitingForDesc}</p>
-          <div className="h-full flex gap-3 justify-center">
+          <div className="flex gap-3 justify-center">
             {rankedFactions.map((faction, index) => {
               const potential = latestActions.asArray.some(
                 (a) => a.faction === faction.id && a.completed === false

--- a/frontend/components/ActionsArea.tsx
+++ b/frontend/components/ActionsArea.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react"
+import { Button } from "@mui/material"
+import EastIcon from "@mui/icons-material/East"
+
+import Collection from "@/classes/Collection"
+import Action from "@/classes/Action"
+import ActionDataCollection from "@/data/actions.json"
+import FactionIcon from "@/components/FactionIcon"
+import { useGameContext } from "@/contexts/GameContext"
+import { useCookieContext } from "@/contexts/CookieContext"
+import ActionDialog from "@/components/ActionDialog"
+import ActionDataCollectionType from "@/types/Action"
+import Faction from "@/classes/Faction"
+import FactionLink from "@/components/FactionLink"
+
+const typedActionDataCollection: ActionDataCollectionType = ActionDataCollection
+
+const SEQUENTIAL_PHASES = ["Forum", "Last Forum"]
+
+const ActionsArea = () => {
+  const { user } = useCookieContext()
+  const { latestPhase, allPlayers, allFactions, latestActions } =
+    useGameContext()
+  const [thisFactionsPendingActions, setThisFactionsPendingActions] = useState<
+    Collection<Action>
+  >(new Collection<Action>())
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false)
+  const [faction, setFaction] = useState<Faction | null>(null)
+
+  // Update faction
+  useEffect(() => {
+    const player = allPlayers.asArray.find((p) => p.user?.id === user?.id)
+    setFaction(allFactions.asArray.find((f) => f.player === player?.id) ?? null)
+  }, [user, allPlayers, allFactions, setFaction])
+
+  // Update actions
+  useEffect(() => {
+    setThisFactionsPendingActions(
+      new Collection<Action>(
+        latestActions?.asArray.filter(
+          (a) => a.faction === faction?.id && a.completed === false
+        ) ?? []
+      )
+    )
+  }, [latestActions, faction, setThisFactionsPendingActions])
+
+  const rankedFactions = allFactions.asArray.sort(
+    (a: Faction, b: Faction) => a.rank - b.rank
+  )
+
+  if (thisFactionsPendingActions) {
+    const requiredAction = thisFactionsPendingActions.asArray.find(
+      (a) => a.required === true
+    )
+
+    let waitingForDesc = <span></span>
+    const pendingActions = latestActions.asArray.filter(
+      (a) => a.completed === false
+    )
+    const firstPotentialAction = pendingActions[0]
+    if (pendingActions.length > 1) {
+      waitingForDesc = (
+        <span>
+          Waiting for {pendingActions.length} factions to{" "}
+          {typedActionDataCollection[firstPotentialAction.type]["sentence"]}
+        </span>
+      )
+    } else if (pendingActions.length === 1) {
+      const onlyPendingFaction = allFactions.asArray.find(
+        (f) => f.id === firstPotentialAction.faction
+      )
+      if (onlyPendingFaction)
+        waitingForDesc = (
+          <span>
+            Waiting for{" "}
+            {faction === onlyPendingFaction ? (
+              <span>you</span>
+            ) : (
+              <FactionLink faction={onlyPendingFaction} />
+            )}{" "}
+            to{" "}
+            {typedActionDataCollection[firstPotentialAction.type]["sentence"]}
+          </span>
+        )
+    }
+
+    return (
+      <div className="flex flex-col gap-2">
+        <h3 className="leading-none m-0 ml-2 text-base text-neutral-600 dark:text-neutral-100">
+          Actions
+        </h3>
+        <div className="p-2 bg-white dark:bg-neutral-600 border border-solid border-neutral-200 dark:border-neutral-750 rounded shadow-inner flex flex-col gap-3 items-center">
+          <p className="text-center">{waitingForDesc}</p>
+          <div className="h-full flex gap-3 justify-center">
+            {rankedFactions.map((faction, index) => {
+              const potential = latestActions.asArray.some(
+                (a) => a.faction === faction.id && a.completed === false
+              )
+              return (
+                <div
+                  key={index}
+                  className="mt-1 flex items-start justify-center gap-3"
+                >
+                  {index !== 0 &&
+                    SEQUENTIAL_PHASES.some(
+                      (name) => name === latestPhase?.name
+                    ) && (
+                      <div className="self-start w-1 h-6 relative">
+                        <div className="absolute bottom-1/2 right-1/2 translate-x-1/2 translate-y-1/2">
+                          <EastIcon fontSize="small" />
+                        </div>
+                      </div>
+                    )}
+                  <div className="w-6 h-6 flex items-start justify-center">
+                    <FactionIcon
+                      faction={faction}
+                      size={!potential ? 18 : 24}
+                      muted={!potential}
+                      selectable
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+        <div className="my-0">
+          {thisFactionsPendingActions.allIds.length > 0 && requiredAction ? (
+            <div className="flex flex-col">
+              <Button variant="contained" onClick={() => setDialogOpen(true)}>
+                {typedActionDataCollection[requiredAction.type]["title"]}
+              </Button>
+              <ActionDialog
+                actions={thisFactionsPendingActions}
+                open={dialogOpen}
+                setOpen={setDialogOpen}
+                onClose={() => setDialogOpen(false)}
+              />
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              {faction && (
+                <Button variant="contained" disabled>
+                  Waiting for others
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  } else {
+    return null
+  }
+}
+
+export default ActionsArea

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -90,10 +90,10 @@ const GamePage = (props: GamePageProps) => {
     setAllSecrets,
     setWars,
     setEnemyLeaders,
+    latestActions,
+    setLatestActions,
   } = useGameContext()
-  const [latestActions, setLatestActions] = useState<Collection<Action>>(
-    new Collection<Action>()
-  )
+  
 
   // Set game-specific state using initial data
   useEffect(() => {
@@ -728,7 +728,7 @@ const GamePage = (props: GamePageProps) => {
             </div>
             <div className="xl:flex-1 xl:max-w-[540px] bg-neutral-50 dark:bg-neutral-700 rounded shadow">
               <section className="flex flex-col h-[75vh] xl:h-full">
-                <ProgressSection latestActions={latestActions} />
+                <ProgressSection />
               </section>
             </div>
           </div>

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -378,7 +378,7 @@ const GamePage = (props: GamePageProps) => {
   }, [props.gameId, setAllSecrets, fetchData])
 
   const fetchNotifications = useCallback(async () => {
-    const minIndex = -10 // Fetch the last 10 notifications
+    const minIndex = -50 // Fetch the last 50 notifications
     const maxIndex = -1
     const url = `action-logs/?game=${props.gameId}&min_index=${minIndex}&max_index=${maxIndex}`
     fetchData(

--- a/frontend/components/ProgressSection.tsx
+++ b/frontend/components/ProgressSection.tsx
@@ -1,171 +1,17 @@
-import { useEffect, useState } from "react"
-import { Button } from "@mui/material"
-import EastIcon from "@mui/icons-material/East"
-
-import Collection from "@/classes/Collection"
-import Action from "@/classes/Action"
-import ActionDataCollection from "@/data/actions.json"
-import FactionIcon from "@/components/FactionIcon"
 import { useGameContext } from "@/contexts/GameContext"
-import { useCookieContext } from "@/contexts/CookieContext"
-import ActionDialog from "@/components/ActionDialog"
-import ActionDataCollectionType from "@/types/Action"
-import Faction from "@/classes/Faction"
-import FactionLink from "@/components/FactionLink"
 import NotificationList from "@/components/NotificationList"
-
-const typedActionDataCollection: ActionDataCollectionType = ActionDataCollection
-
-const SEQUENTIAL_PHASES = ["Forum", "Last Forum"]
-
-interface ProgressSectionProps {
-  latestActions: Collection<Action>
-}
+import ActionsArea from "@/components/ActionsArea"
 
 // Progress section showing who players are waiting for
-const ProgressSection = ({ latestActions }: ProgressSectionProps) => {
-  const { user } = useCookieContext()
-  const { game, latestPhase, allPlayers, allFactions } = useGameContext()
-  const [thisFactionsPendingActions, setThisFactionsPendingActions] = useState<
-    Collection<Action>
-  >(new Collection<Action>())
-  const [dialogOpen, setDialogOpen] = useState<boolean>(false)
-  const [faction, setFaction] = useState<Faction | null>(null)
+const ProgressSection = () => {
+  const { game } = useGameContext()
 
-  // Update faction
-  useEffect(() => {
-    const player = allPlayers.asArray.find((p) => p.user?.id === user?.id)
-    setFaction(allFactions.asArray.find((f) => f.player === player?.id) ?? null)
-  }, [user, allPlayers, allFactions, setFaction])
-
-  // Update actions
-  useEffect(() => {
-    setThisFactionsPendingActions(
-      new Collection<Action>(
-        latestActions?.asArray.filter(
-          (a) => a.faction === faction?.id && a.completed === false
-        ) ?? []
-      )
-    )
-  }, [latestActions, faction, setThisFactionsPendingActions])
-
-  const rankedFactions = allFactions.asArray.sort(
-    (a: Faction, b: Faction) => a.rank - b.rank
+  return (
+    <div className="box-border h-full px-4 pt-2 pb-4 flex flex-col gap-4">
+      <NotificationList />
+      {!game?.end_date && <ActionsArea />}
+    </div>
   )
-
-  if (thisFactionsPendingActions) {
-    const requiredAction = thisFactionsPendingActions.asArray.find(
-      (a) => a.required === true
-    )
-
-    let waitingForDesc = <span></span>
-    const pendingActions = latestActions.asArray.filter(
-      (a) => a.completed === false
-    )
-    const firstPotentialAction = pendingActions[0]
-    if (pendingActions.length > 1) {
-      waitingForDesc = (
-        <span>
-          Waiting for {pendingActions.length} factions to{" "}
-          {typedActionDataCollection[firstPotentialAction.type]["sentence"]}
-        </span>
-      )
-    } else if (pendingActions.length === 1) {
-      const onlyPendingFaction = allFactions.asArray.find(
-        (f) => f.id === firstPotentialAction.faction
-      )
-      if (onlyPendingFaction)
-        waitingForDesc = (
-          <span>
-            Waiting for{" "}
-            {faction === onlyPendingFaction ? (
-              <span>you</span>
-            ) : (
-              <FactionLink faction={onlyPendingFaction} />
-            )}{" "}
-            to{" "}
-            {typedActionDataCollection[firstPotentialAction.type]["sentence"]}
-          </span>
-        )
-    }
-
-    return (
-      <div className="box-border h-full px-4 pt-2 pb-4 flex flex-col gap-4">
-        <NotificationList />
-        {!game?.end_date && (
-          <div className="flex flex-col gap-2">
-            <h3 className="leading-none m-0 ml-2 text-base text-neutral-600 dark:text-neutral-100">
-              Actions
-            </h3>
-            <div className="p-2 bg-white dark:bg-neutral-600 border border-solid border-neutral-200 dark:border-neutral-750 rounded shadow-inner flex flex-col gap-3 items-center">
-              <p className="text-center">{waitingForDesc}</p>
-              <div className="h-full flex gap-3 justify-center">
-                {rankedFactions.map((faction, index) => {
-                  const potential = latestActions.asArray.some(
-                    (a) => a.faction === faction.id && a.completed === false
-                  )
-                  return (
-                    <div
-                      key={index}
-                      className="mt-1 flex items-start justify-center gap-3"
-                    >
-                      {index !== 0 &&
-                        SEQUENTIAL_PHASES.some(
-                          (name) => name === latestPhase?.name
-                        ) && (
-                          <div className="self-start w-1 h-6 relative">
-                            <div className="absolute bottom-1/2 right-1/2 translate-x-1/2 translate-y-1/2">
-                              <EastIcon fontSize="small" />
-                            </div>
-                          </div>
-                        )}
-                      <div className="w-6 h-6 flex items-start justify-center">
-                        <FactionIcon
-                          faction={faction}
-                          size={!potential ? 18 : 24}
-                          muted={!potential}
-                          selectable
-                        />
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-            <div className="my-0">
-              {thisFactionsPendingActions.allIds.length > 0 &&
-              requiredAction ? (
-                <div className="flex flex-col">
-                  <Button
-                    variant="contained"
-                    onClick={() => setDialogOpen(true)}
-                  >
-                    {typedActionDataCollection[requiredAction.type]["title"]}
-                  </Button>
-                  <ActionDialog
-                    actions={thisFactionsPendingActions}
-                    open={dialogOpen}
-                    setOpen={setDialogOpen}
-                    onClose={() => setDialogOpen(false)}
-                  />
-                </div>
-              ) : (
-                <div className="flex flex-col">
-                  {faction && (
-                    <Button variant="contained" disabled>
-                      Waiting for others
-                    </Button>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-    )
-  } else {
-    return null
-  }
 }
 
 export default ProgressSection

--- a/frontend/components/actionLogs/ActionLog_FaceMortality.tsx
+++ b/frontend/components/actionLogs/ActionLog_FaceMortality.tsx
@@ -9,16 +9,16 @@ import FactionLink from "@/components/FactionLink"
 import TermLink from "@/components/TermLink"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
   senatorDetails?: boolean
 }
 
-// Notification for when a senator dies during the mortality phase
-const FaceMortalityNotification = ({
+// ActionLog for when a senator dies during the mortality phase
+const FaceMortalityActionLog = ({
   notification,
   senatorDetails,
-}: NotificationProps) => {
+}: ActionLogProps) => {
   const { allFactions, allSenators } = useGameContext()
 
   // Get notification-specific data
@@ -99,4 +99,4 @@ const FaceMortalityNotification = ({
   )
 }
 
-export default FaceMortalityNotification
+export default FaceMortalityActionLog

--- a/frontend/components/actionLogs/ActionLog_MatchedEnemyLeader.tsx
+++ b/frontend/components/actionLogs/ActionLog_MatchedEnemyLeader.tsx
@@ -6,14 +6,14 @@ import EnemyLeader from "@/classes/EnemyLeader"
 import { useGameContext } from "@/contexts/GameContext"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
 }
 
-// Notification for when an existing enemy leader is matched by a war during the forum phase
-const MatchedEnemyLeaderNotification = ({
+// ActionLog for when an existing enemy leader is matched by a war during the forum phase
+const MatchedEnemyLeaderActionLog = ({
   notification,
-}: NotificationProps) => {
+}: ActionLogProps) => {
   const { wars, enemyLeaders } = useGameContext()
 
   // Get notification-specific data
@@ -46,4 +46,4 @@ const MatchedEnemyLeaderNotification = ({
   )
 }
 
-export default MatchedEnemyLeaderNotification
+export default MatchedEnemyLeaderActionLog

--- a/frontend/components/actionLogs/ActionLog_MatchedWar.tsx
+++ b/frontend/components/actionLogs/ActionLog_MatchedWar.tsx
@@ -6,12 +6,12 @@ import { useGameContext } from "@/contexts/GameContext"
 import { capitalize } from "@mui/material/utils"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
 }
 
-// Notification for when an existing war is matched by another war or an enemy leader during the forum phase
-const MatchedWarNotification = ({ notification }: NotificationProps) => {
+// ActionLog for when an existing war is matched by another war or an enemy leader during the forum phase
+const MatchedWarActionLog = ({ notification }: ActionLogProps) => {
   const { enemyLeaders, wars } = useGameContext()
 
   // Get notification-specific data
@@ -54,4 +54,4 @@ const MatchedWarNotification = ({ notification }: NotificationProps) => {
   )
 }
 
-export default MatchedWarNotification
+export default MatchedWarActionLog

--- a/frontend/components/actionLogs/ActionLog_NewEnemyLeader.tsx
+++ b/frontend/components/actionLogs/ActionLog_NewEnemyLeader.tsx
@@ -13,12 +13,12 @@ import ActionLogLayout from "@/components/ActionLogLayout"
 const typedEnemyLeaderDataCollection: EnemyLeaderDataCollectionType =
   EnemyLeaderDataCollection
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
 }
 
-// Notification for when a new enemy leader appears during the forum phase
-const NewEnemyLeaderNotification = ({ notification }: NotificationProps) => {
+// ActionLog for when a new enemy leader appears during the forum phase
+const NewEnemyLeaderActionLog = ({ notification }: ActionLogProps) => {
   const { allFactions, enemyLeaders, wars } = useGameContext()
 
   // Get notification-specific data
@@ -68,4 +68,4 @@ const NewEnemyLeaderNotification = ({ notification }: NotificationProps) => {
   )
 }
 
-export default NewEnemyLeaderNotification
+export default NewEnemyLeaderActionLog

--- a/frontend/components/actionLogs/ActionLog_NewFamily.tsx
+++ b/frontend/components/actionLogs/ActionLog_NewFamily.tsx
@@ -9,16 +9,16 @@ import FactionLink from "../FactionLink"
 import Faction from "@/classes/Faction"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
   senatorDetails?: boolean
 }
 
-// Notification for when a senator dies during the mortality phase
-const NewFamilyNotification = ({
+// ActionLog for when a senator dies during the mortality phase
+const NewFamilyActionLog = ({
   notification,
   senatorDetails,
-}: NotificationProps) => {
+}: ActionLogProps) => {
   const { allFactions, allSenators } = useGameContext()
 
   // Get notification-specific data
@@ -55,4 +55,4 @@ const NewFamilyNotification = ({
   )
 }
 
-export default NewFamilyNotification
+export default NewFamilyActionLog

--- a/frontend/components/actionLogs/ActionLog_NewSecret.tsx
+++ b/frontend/components/actionLogs/ActionLog_NewSecret.tsx
@@ -7,13 +7,13 @@ import FactionLink from "../FactionLink"
 import Faction from "@/classes/Faction"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
   senatorDetails?: boolean
 }
 
-// Notification for when a senator dies during the mortality phase
-const NewSecretNotification = ({ notification }: NotificationProps) => {
+// ActionLog for when a senator dies during the mortality phase
+const NewSecretActionLog = ({ notification }: ActionLogProps) => {
   const { allFactions } = useGameContext()
 
   // Get notification-specific data
@@ -44,4 +44,4 @@ const NewSecretNotification = ({ notification }: NotificationProps) => {
   )
 }
 
-export default NewSecretNotification
+export default NewSecretActionLog

--- a/frontend/components/actionLogs/ActionLog_NewTurn.tsx
+++ b/frontend/components/actionLogs/ActionLog_NewTurn.tsx
@@ -3,12 +3,12 @@ import TimeIcon from "@/images/icons/time.svg"
 import ActionLog from "@/classes/ActionLog"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
 }
 
-// Notification for when a senator dies during the mortality phase
-const NewTurnNotification = ({ notification }: NotificationProps) => {
+// ActionLog for when a senator dies during the mortality phase
+const NewTurnActionLog = ({ notification }: ActionLogProps) => {
   // Get notification-specific data
   const turnIndex = notification.data?.turn_index ?? null
 
@@ -25,4 +25,4 @@ const NewTurnNotification = ({ notification }: NotificationProps) => {
   )
 }
 
-export default NewTurnNotification
+export default NewTurnActionLog

--- a/frontend/components/actionLogs/ActionLog_NewWar.tsx
+++ b/frontend/components/actionLogs/ActionLog_NewWar.tsx
@@ -9,12 +9,12 @@ import { capitalize } from "@mui/material/utils"
 import EnemyLeader from "@/classes/EnemyLeader"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
 }
 
-// Notification for when a new war appears during the forum phase
-const NewWarNotification = ({ notification }: NotificationProps) => {
+// ActionLog for when a new war appears during the forum phase
+const NewWarActionLog = ({ notification }: ActionLogProps) => {
   const { allFactions, wars, enemyLeaders } = useGameContext()
 
   // Get notification-specific data
@@ -95,4 +95,4 @@ const NewWarNotification = ({ notification }: NotificationProps) => {
   )
 }
 
-export default NewWarNotification
+export default NewWarActionLog

--- a/frontend/components/actionLogs/ActionLog_SelectFactionLeader.tsx
+++ b/frontend/components/actionLogs/ActionLog_SelectFactionLeader.tsx
@@ -8,16 +8,16 @@ import FactionLink from "@/components/FactionLink"
 import { useCookieContext } from "@/contexts/CookieContext"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
   senatorDetails?: boolean
 }
 
-// Notification for when a new faction leader is selected
-const SelectFactionLeaderNotification = ({
+// ActionLog for when a new faction leader is selected
+const SelectFactionLeaderActionLog = ({
   notification,
   senatorDetails,
-}: NotificationProps) => {
+}: ActionLogProps) => {
   const { allFactions, allSenators } = useGameContext()
 
   // Get notification-specific data
@@ -73,4 +73,4 @@ const SelectFactionLeaderNotification = ({
   )
 }
 
-export default SelectFactionLeaderNotification
+export default SelectFactionLeaderActionLog

--- a/frontend/components/actionLogs/ActionLog_TemporaryRomeConsul.tsx
+++ b/frontend/components/actionLogs/ActionLog_TemporaryRomeConsul.tsx
@@ -9,15 +9,15 @@ import { useGameContext } from "@/contexts/GameContext"
 import TermLink from "@/components/TermLink"
 import ActionLogLayout from "@/components/ActionLogLayout"
 
-interface NotificationProps {
+interface ActionLogProps {
   notification: ActionLog
   senatorDetails?: boolean
 }
 
-const TemporaryRomeConsulNotification = ({
+const TemporaryRomeConsulActionLog = ({
   notification,
   senatorDetails,
-}: NotificationProps) => {
+}: ActionLogProps) => {
   const { allFactions, allSenators } = useGameContext()
 
   // Get notification-specific data
@@ -76,4 +76,4 @@ const TemporaryRomeConsulNotification = ({
   )
 }
 
-export default TemporaryRomeConsulNotification
+export default TemporaryRomeConsulActionLog

--- a/frontend/contexts/GameContext.tsx
+++ b/frontend/contexts/GameContext.tsx
@@ -21,6 +21,7 @@ import Turn from "@/classes/Turn"
 import Secret from "@/classes/Secret"
 import War from "@/classes/War"
 import EnemyLeader from "@/classes/EnemyLeader"
+import Action from "@/classes/Action"
 
 interface GameContextType {
   game: Game | null
@@ -59,6 +60,8 @@ interface GameContextType {
   setWars: Dispatch<SetStateAction<Collection<War>>>
   enemyLeaders: Collection<EnemyLeader>
   setEnemyLeaders: Dispatch<SetStateAction<Collection<EnemyLeader>>>
+  latestActions: Collection<Action>
+  setLatestActions: Dispatch<SetStateAction<Collection<Action>>>
 }
 
 const GameContext = createContext<GameContextType | null>(null)
@@ -115,6 +118,9 @@ export const GameProvider = (props: GameProviderProps): JSX.Element => {
   const [enemyLeaders, setEnemyLeaders] = useState<Collection<EnemyLeader>>(
     new Collection<EnemyLeader>()
   )
+  const [latestActions, setLatestActions] = useState<Collection<Action>>(
+    new Collection<Action>()
+  )
 
   return (
     <GameContext.Provider
@@ -155,6 +161,8 @@ export const GameProvider = (props: GameProviderProps): JSX.Element => {
         setWars,
         enemyLeaders,
         setEnemyLeaders,
+        latestActions,
+        setLatestActions,
       }}
     >
       {props.children}


### PR DESCRIPTION
Refactor the progress section to make the code more organized. Increase the default number of action logs in the notification list from 10 to 50. Make the actions area have a fixed size so that changes to the current pending action don't resize the notification list (this was causing notification list "sticky mode" to be disabled without the user scrolling up).