### PR TITLE
Show title icon in round senator portrait

### DIFF
--- a/frontend/components/SenatorPortrait.module.css
+++ b/frontend/components/SenatorPortrait.module.css
@@ -1,7 +1,3 @@
-.senatorPortrait {
-  user-select: none;
-}
-
 .senatorPortrait.selectable {
   cursor: pointer;
 
@@ -23,10 +19,6 @@
   margin-block-end: 0;
   margin-inline-start: 0;
   margin-inline-end: 0;
-}
-
-.bg {
-  position: absolute;
 }
 
 .code {

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -218,7 +218,7 @@ const SenatorPortrait = ({
   const PortraitElement = selectable ? "button" : "div"
   const getPortrait = () => (
     <PortraitElement
-      className={`${styles.senatorPortrait} ${
+      className={`select-none ${styles.senatorPortrait} ${
         selectable ? styles.selectable : ""
       }`}
       onMouseOver={handleMouseOver}
@@ -265,20 +265,21 @@ const SenatorPortrait = ({
             unoptimized
           />
         </div>
-        <div className={styles.bg} style={getBgStyle()}></div>
+        <div className="absolute" style={getBgStyle()}></div>
+        {majorOffice && (
+          <TitleIcon
+            title={majorOffice}
+            size={getIconSize()}
+            dead={!senator.alive}
+            round={round}
+          />
+        )}
         {!round && (
           <>
             {size > 120 && (
               <Tooltip title="Senator ID" arrow>
                 <div className={styles.code}># {senator.code}</div>
               </Tooltip>
-            )}
-            {majorOffice && (
-              <TitleIcon
-                title={majorOffice}
-                size={getIconSize()}
-                dead={!senator.alive}
-              />
             )}
             {senator.alive === false && (
               <Image

--- a/frontend/components/TitleIcon.module.css
+++ b/frontend/components/TitleIcon.module.css
@@ -1,7 +1,0 @@
-.titleIcon {
-  position: absolute;
-  left: 3px;
-  bottom: 3px;
-  z-index: 2;
-  box-sizing: border-box;
-}

--- a/frontend/components/TitleIcon.tsx
+++ b/frontend/components/TitleIcon.tsx
@@ -1,23 +1,26 @@
 import Image from "next/image"
 import RomeConsulIcon from "@/images/icons/romeConsul.svg"
-import styles from "./TitleIcon.module.css"
 import Title from "@/classes/Title"
 
 interface TitleIconProps {
   title: Title
   size: number
   dead?: boolean
+  round?: boolean
 }
 
-const TitleIcon = (props: TitleIconProps) => {
-  if (props.title.name.includes("Rome Consul")) {
+const TitleIcon = ({ title, size, dead, round }: TitleIconProps) => {
+  const positionDistance = round ? 6 : 3
+
+  if (title.name.includes("Rome Consul")) {
     return (
       <Image
-        className={`${styles.titleIcon} ${props.dead ? "grayscale-[100%]" : ""}`}
+        className={`absolute z-20 box-border ${dead ? "grayscale-[100%]" : ""}`}
         src={RomeConsulIcon}
-        height={props.size}
-        width={props.size}
+        height={size}
+        width={size}
         alt="Rome Consul icon"
+        style={{ left: positionDistance, bottom: positionDistance }}
       />
     )
   } else {

--- a/frontend/styles/master.css
+++ b/frontend/styles/master.css
@@ -125,3 +125,7 @@ textarea {
   font-family: inherit;
   font-size: inherit;
 }
+
+img {
+  -webkit-user-drag: none;
+}


### PR DESCRIPTION
Show a senator's title icon in their round senator portrait (senator diagram). Also prevent images from being dragged into other tabs/downloaded for Chrome users.