### PR TITLE
Add senator mouseover summary

### DIFF
--- a/frontend/components/AttributeFlex.tsx
+++ b/frontend/components/AttributeFlex.tsx
@@ -14,8 +14,11 @@ interface AttributeGridProps {
   attributes: Attribute[]
 }
 
-const getAttributeItem = (item: Attribute, darkMode: boolean, index?: number) => {
-
+const getAttributeItem = (
+  item: Attribute,
+  darkMode: boolean,
+  index?: number
+) => {
   const titleCaseName = capitalize(item.name)
   return (
     <Tooltip key={index} title={titleCaseName} arrow>
@@ -53,7 +56,8 @@ const AttributeFlex = ({ attributes }: AttributeGridProps) => {
   const { darkMode } = useCookieContext()
 
   const getButton = (item: Attribute, index: number) => {
-    if (item.onClick === undefined) return getAttributeItem(item, darkMode, index)
+    if (item.onClick === undefined)
+      return getAttributeItem(item, darkMode, index)
     return (
       <button
         key={index}

--- a/frontend/components/FactionListItem.tsx
+++ b/frontend/components/FactionListItem.tsx
@@ -85,7 +85,7 @@ const FactionListItem = (props: FactionListItemProps) => {
             senator={senator}
             size={80}
             selectable
-            nameTooltip
+            summary
             blurryPlaceholder
           />
         ))}

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -93,7 +93,6 @@ const GamePage = (props: GamePageProps) => {
     latestActions,
     setLatestActions,
   } = useGameContext()
-  
 
   // Set game-specific state using initial data
   useEffect(() => {
@@ -626,10 +625,10 @@ const GamePage = (props: GamePageProps) => {
           )
       )
     }
-  }, [latestActions, latestStep])
+  }, [latestActions, setLatestActions, latestStep])
 
   const handleMainTabChange = (
-    event: React.SyntheticEvent,
+    _: React.SyntheticEvent,
     newValue: number
   ) => {
     setMainTab(newValue)

--- a/frontend/components/SenateSeat.tsx
+++ b/frontend/components/SenateSeat.tsx
@@ -31,7 +31,7 @@ const SenateSeat = ({ angle, radius, size, senator }: SenateSeatProps) => {
           size={size}
           selectable
           round
-          nameTooltip
+          summary
         />
       </div>
     </div>

--- a/frontend/components/SenatorFactionAndFacts.tsx
+++ b/frontend/components/SenatorFactionAndFacts.tsx
@@ -1,0 +1,71 @@
+import Faction from "@/classes/Faction"
+import { useGameContext } from "@/contexts/GameContext"
+import FactionLink from "@/components/FactionLink"
+import Senator from "@/classes/Senator"
+import SenatorFactList from "@/components/SenatorFactList"
+import FactionIcon from "./FactionIcon"
+
+interface SenatorFactionAndFactsProps {
+  senator: Senator
+  selectable?: boolean
+}
+
+const SenatorFactionAndFacts = ({
+  senator,
+  selectable,
+}: SenatorFactionAndFactsProps) => {
+  const { allFactions, allTitles } = useGameContext()
+
+  // Get senator-specific data
+  const faction: Faction | null = senator?.faction
+    ? allFactions.byId[senator.faction] ?? null
+    : null
+  const isFactionLeader: boolean = senator
+    ? allTitles.asArray.some(
+        (t) => t.senator === senator.id && t.name == "Faction Leader"
+      )
+    : false
+
+  // Get JSX for the faction description
+  const getFactionDescription = () => {
+    if (!faction) return null
+    return (
+      <span className="ml-px">
+        {selectable ? (
+          <FactionLink faction={faction} includeIcon={true} />
+        ) : (
+          <span>
+            <span style={{ marginRight: 4 }}>
+              <FactionIcon faction={faction} size={17} />
+            </span>
+            {faction.getName()} Faction
+          </span>
+        )}
+        {isFactionLeader ? " Leader" : " Member"}
+      </span>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p>
+        {faction && senator.alive ? (
+          <span>{getFactionDescription()}</span>
+        ) : senator.alive ? (
+          "Unaligned"
+        ) : (
+          <span>
+            {faction ? (
+              <span>Died as {getFactionDescription()}</span>
+            ) : (
+              "Was always Unaligned"
+            )}
+          </span>
+        )}
+      </p>
+      <SenatorFactList senator={senator} selectable={selectable} />
+    </div>
+  )
+}
+
+export default SenatorFactionAndFacts

--- a/frontend/components/SenatorLink.tsx
+++ b/frontend/components/SenatorLink.tsx
@@ -3,6 +3,7 @@ import { Link } from "@mui/material"
 import { useGameContext } from "@/contexts/GameContext"
 import Senator from "@/classes/Senator"
 import SelectedDetail from "@/types/SelectedDetail"
+import SenatorSummary from "@/components/SenatorSummary"
 
 interface SenatorLinkProps {
   senator: Senator
@@ -26,9 +27,11 @@ const SenatorLink = ({ senator }: SenatorLinkProps) => {
     return <span>{senator.displayName}</span>
 
   return (
-    <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
-      {senator.displayName}
-    </Link>
+    <SenatorSummary senator={senator}>
+      <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
+        {senator.displayName}
+      </Link>
+    </SenatorSummary>
   )
 }
 

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react"
+import { useState, MouseEvent } from "react"
 import Image, { StaticImageData } from "next/image"
+import { Tooltip } from "@mui/material"
 
 import Senator from "@/classes/Senator"
 import Faction from "@/classes/Faction"
-import styles from "./SenatorPortrait.module.css"
+import styles from "@/components/SenatorPortrait.module.css"
 import Title from "@/classes/Title"
 import TitleIcon from "@/components/TitleIcon"
 import SelectedDetail from "@/types/SelectedDetail"
@@ -12,7 +13,7 @@ import FactionLeaderPattern from "@/images/patterns/factionLeader.svg"
 import DeadIcon from "@/images/icons/dead.svg"
 import { useGameContext } from "@/contexts/GameContext"
 import Collection from "@/classes/Collection"
-import { Tooltip } from "@mui/material"
+import SenatorSummary from "@/components/SenatorSummary"
 
 import Cornelius from "@/images/portraits/cornelius.png"
 import Fabius from "@/images/portraits/fabius.png"
@@ -63,7 +64,7 @@ interface SenatorPortraitProps {
   senator: Senator
   size: number
   selectable?: boolean
-  nameTooltip?: boolean
+  summary?: boolean
   blurryPlaceholder?: boolean
   round?: boolean
 }
@@ -74,7 +75,7 @@ const SenatorPortrait = ({
   senator,
   size,
   selectable,
-  nameTooltip,
+  summary,
   blurryPlaceholder,
   round,
 }: SenatorPortraitProps) => {
@@ -216,6 +217,7 @@ const SenatorPortrait = ({
 
   // Get JSX for the portrait
   const PortraitElement = selectable ? "button" : "div"
+
   const getPortrait = () => (
     <PortraitElement
       className={`select-none ${styles.senatorPortrait} ${
@@ -301,12 +303,8 @@ const SenatorPortrait = ({
     </PortraitElement>
   )
 
-  if (nameTooltip) {
-    return (
-      <Tooltip title={senator.displayName} arrow>
-        {getPortrait()}
-      </Tooltip>
-    )
+  if (summary) {
+    return <SenatorSummary senator={senator}>{getPortrait()}</SenatorSummary>
   } else {
     return getPortrait()
   }

--- a/frontend/components/SenatorSummary.tsx
+++ b/frontend/components/SenatorSummary.tsx
@@ -42,34 +42,36 @@ const SenatorSummary = ({ senator, children }: SenatorSummaryProps) => {
       >
         {children}
       </div>
-      <Popover
-        sx={{
-          pointerEvents: "none",
-          marginTop: "4px",
-        }}
-        open={open}
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "center",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "center",
-        }}
-        onClose={handleClose}
-        disableRestoreFocus
-      >
-        <div className="py-3 px-4 max-w-[260px] flex flex-col gap-4">
-          <p className="font-semibold w-full text-center">
-            {senator.displayName}
-          </p>
-          <SenatorFactionAndFacts senator={senator} />
-          <div className="flex justify-center">
-            <AttributeFlex attributes={attributeItems}></AttributeFlex>
+      {open && (
+        <Popover
+          sx={{
+            pointerEvents: "none",
+            marginTop: "4px",
+          }}
+          open={open}
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "center",
+          }}
+          transformOrigin={{
+            vertical: "top",
+            horizontal: "center",
+          }}
+          onClose={handleClose}
+          disableRestoreFocus
+        >
+          <div className="py-3 px-4 max-w-[260px] flex flex-col gap-4">
+            <p className="font-semibold w-full text-center">
+              {senator.displayName}
+            </p>
+            <SenatorFactionAndFacts senator={senator} />
+            <div className="flex justify-center">
+              <AttributeFlex attributes={attributeItems}></AttributeFlex>
+            </div>
           </div>
-        </div>
-      </Popover>
+        </Popover>
+      )}
     </>
   )
 }

--- a/frontend/components/SenatorSummary.tsx
+++ b/frontend/components/SenatorSummary.tsx
@@ -1,0 +1,77 @@
+import { MouseEvent, ReactNode, useState } from "react"
+import Senator from "@/classes/Senator"
+import { Popover } from "@mui/material"
+import AttributeFlex, { Attribute } from "@/components/AttributeFlex"
+import InfluenceIcon from "@/images/icons/influence.svg"
+import TalentsIcon from "@/images/icons/talents.svg"
+import VotesIcon from "@/images/icons/votes.svg"
+import SenatorFactionAndFacts from "@/components/SenatorFactionAndFacts"
+
+interface SenatorSummaryProps {
+  senator: Senator
+  children: ReactNode
+}
+
+const SenatorSummary = ({ senator, children }: SenatorSummaryProps) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const handleOpen = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+  const open = Boolean(anchorEl)
+
+  // Attribute data
+  const attributeItems: Attribute[] = [
+    {
+      name: "influence",
+      value: senator.influence,
+      icon: InfluenceIcon,
+    },
+    { name: "talents", value: senator.talents, icon: TalentsIcon },
+    { name: "votes", value: senator.votes, icon: VotesIcon },
+  ]
+
+  return (
+    <>
+      <div
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
+        className="inline"
+      >
+        {children}
+      </div>
+      <Popover
+        sx={{
+          pointerEvents: "none",
+          marginTop: "4px",
+        }}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+        onClose={handleClose}
+        disableRestoreFocus
+      >
+        <div className="py-3 px-4 max-w-[260px] flex flex-col gap-4">
+          <p className="font-semibold w-full text-center">
+            {senator.displayName}
+          </p>
+          <SenatorFactionAndFacts senator={senator} />
+          <div className="flex justify-center">
+            <AttributeFlex attributes={attributeItems}></AttributeFlex>
+          </div>
+        </div>
+      </Popover>
+    </>
+  )
+}
+
+export default SenatorSummary

--- a/frontend/components/WarStrength.tsx
+++ b/frontend/components/WarStrength.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import { useState, MouseEvent } from "react"
 import EnemyLeader from "@/classes/EnemyLeader"
 import War from "@/classes/War"
 import { useGameContext } from "@/contexts/GameContext"
@@ -12,8 +12,8 @@ interface WarStrengthProps {
 const WarStrength = ({ war, type }: WarStrengthProps) => {
   const { wars, enemyLeaders } = useGameContext()
 
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null)
-  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const handlePopoverOpen = (event: MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
   }
   const handlePopoverClose = () => {
@@ -76,9 +76,7 @@ const WarStrength = ({ war, type }: WarStrengthProps) => {
           <div className="py-3 px-4 flex flex-col gap-1">
             <p>
               Base {capitalize(type)} Strength{" "}
-              <span className="font-bold">
-                {baseStrength}
-              </span>
+              <span className="font-bold">{baseStrength}</span>
             </p>
             {matchingActiveWars.length > 0 &&
               matchingActiveWars.map((matchingWar) => (

--- a/frontend/components/entityDetails/EntityDetail_Faction.tsx
+++ b/frontend/components/entityDetails/EntityDetail_Faction.tsx
@@ -226,7 +226,7 @@ const FactionDetails = () => {
                   senator={senator}
                   size={90}
                   selectable
-                  nameTooltip
+                  summary
                 />
               ))}
             </div>

--- a/frontend/components/entityDetails/EntityDetail_Senator.tsx
+++ b/frontend/components/entityDetails/EntityDetail_Senator.tsx
@@ -26,7 +26,7 @@ import Collection from "@/classes/Collection"
 import SenatorActionLog from "@/classes/SenatorActionLog"
 import ActionLogContainer from "@/components/ActionLog"
 import AttributeGrid, { Attribute } from "@/components/AttributeGrid"
-import SenatorFactList from "@/components/SenatorFactList"
+import SenatorFactionAndFacts from "@/components/SenatorFactionAndFacts"
 
 type FixedAttribute = {
   name: "military" | "oratory" | "loyalty"
@@ -80,13 +80,6 @@ const SenatorDetails = (props: SenatorDetailsProps) => {
   const player: Player | null = faction?.player
     ? allPlayers.byId[faction.player] ?? null
     : null
-  const titles: Collection<Title> = senator
-    ? new Collection<Title>(
-        allTitles.asArray.filter(
-          (t) => t.senator === senator.id && t.name !== "Faction Leader"
-        ) ?? new Collection<Title>()
-      )
-    : new Collection<Title>()
   const isFactionLeader: boolean = senator
     ? allTitles.asArray.some(
         (t) => t.senator === senator.id && t.name == "Faction Leader"
@@ -338,18 +331,6 @@ const SenatorDetails = (props: SenatorDetailsProps) => {
     )
   }
 
-  // Get JSX for the faction description
-  const getFactionDescription = () => {
-    if (!faction) return null
-    return (
-      <span>
-        <FactionLink faction={faction} includeIcon />{" "}
-        {isFactionLeader ? "Leader" : "Member"}
-        {player ? <span> ({player.user?.username})</span> : null}
-      </span>
-    )
-  }
-
   // If there is no senator selected, render nothing
   if (!senator || !portraitSize) return null
 
@@ -357,26 +338,11 @@ const SenatorDetails = (props: SenatorDetailsProps) => {
     <div className="h-full box-border flex flex-col overflow-y-auto">
       <div className="flex gap-4 m-4">
         <SenatorPortrait senator={senator} size={portraitSize} />
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-3">
           <h4 className="text-lg">
             <b>{senator.displayName}</b>
           </h4>
-          <p>
-            {faction && senator.alive ? (
-              <span>{getFactionDescription()}</span>
-            ) : senator.alive ? (
-              "Unaligned"
-            ) : (
-              <span>
-                {faction ? (
-                  <span>Died as {getFactionDescription()}</span>
-                ) : (
-                  "Was always Unaligned"
-                )}
-              </span>
-            )}
-          </p>
-          <SenatorFactList senator={senator} selectable />
+          <SenatorFactionAndFacts senator={senator} selectable />
         </div>
       </div>
       <div className="border-0 border-b border-solid border-neutral-200 dark:border-neutral-750">


### PR DESCRIPTION
Add a senator summary. This is a MUI Popover that appears when hovering over a senator portrait. It shows their faction, titles, and some attributes.