### PR TITLE
Allow the action dialog to be minimized

### DIFF
--- a/frontend/components/ActionDialog.tsx
+++ b/frontend/components/ActionDialog.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { Dialog } from "@mui/material"
 
 import Collection from "@/classes/Collection"
 import Action from "@/classes/Action"
@@ -8,10 +7,10 @@ import FaceMortalityDialog from "./actionDialogs/ActionDialog_FaceMortality"
 import InitiateSituationDialog from "./actionDialogs/ActionDialog_InitiateSituation"
 
 interface ActionDialogProps {
-  actions: Collection<Action>
   open: boolean
   setOpen: (open: boolean) => void
   onClose: () => void
+  actions: Collection<Action>
 }
 
 const dialogs: { [key: string]: React.ComponentType<any> } = {
@@ -21,15 +20,23 @@ const dialogs: { [key: string]: React.ComponentType<any> } = {
 }
 
 // Dialog box that displays the action that the player must take
-const ActionDialog = (props: ActionDialogProps) => {
-  const requiredAction = props.actions.asArray.find((a) => a.required === true)
+const ActionDialog = ({
+  open,
+  setOpen,
+  onClose,
+  actions,
+}: ActionDialogProps) => {
+  const requiredAction = actions.asArray.find((a) => a.required === true)
   if (requiredAction) {
     const ContentComponent = dialogs[requiredAction.type]
 
     return (
-      <Dialog onClose={props.onClose} open={props.open} className="m-0">
-        <ContentComponent setOpen={props.setOpen} actions={props.actions} />
-      </Dialog>
+      <ContentComponent
+        open={open}
+        setOpen={setOpen}
+        onClose={onClose}
+        actions={actions}
+      />
     )
   } else {
     return null

--- a/frontend/components/actionDialogs/ActionDialog_FaceMortality.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_FaceMortality.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import Image from "next/image"
 import {
   Button,
+  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -17,12 +18,19 @@ import { useCookieContext } from "@/contexts/CookieContext"
 import { useGameContext } from "@/contexts/GameContext"
 
 interface FaceMortalityDialogProps {
+  open: boolean
   setOpen: (open: boolean) => void
+  onClose: () => void
   actions: Collection<Action>
 }
 
 // Action dialog allows the player to ready up for mortality
-const FaceMortalityDialog = (props: FaceMortalityDialogProps) => {
+const FaceMortalityDialog = ({
+  open,
+  setOpen,
+  onClose,
+  actions,
+}: FaceMortalityDialogProps) => {
   const {
     accessToken,
     refreshToken,
@@ -36,11 +44,9 @@ const FaceMortalityDialog = (props: FaceMortalityDialogProps) => {
 
   // Set required action
   useEffect(() => {
-    const requiredAction = props.actions.asArray.find(
-      (a) => a.required === true
-    )
+    const requiredAction = actions.asArray.find((a) => a.required === true)
     if (requiredAction) setRequiredAction(requiredAction)
-  }, [props.actions])
+  }, [actions])
 
   // Handle dialog submission
   const handleSubmit = async () => {
@@ -54,15 +60,15 @@ const FaceMortalityDialog = (props: FaceMortalityDialogProps) => {
         setRefreshToken,
         setUser
       )
-      props.setOpen(false)
+      setOpen(false)
     }
   }
 
   return (
-    <>
+    <Dialog onClose={onClose} open={open} className="m-0">
       <DialogTitle>Ready to Face Mortality?</DialogTitle>
       <div className="absolute right-2 top-2">
-        <IconButton aria-label="close" onClick={() => props.setOpen(false)}>
+        <IconButton aria-label="close" onClick={() => setOpen(false)}>
           <CloseIcon />
         </IconButton>
       </div>
@@ -88,7 +94,7 @@ const FaceMortalityDialog = (props: FaceMortalityDialogProps) => {
       <DialogActions>
         <Button onClick={handleSubmit}>I&apos;m ready</Button>
       </DialogActions>
-    </>
+    </Dialog>
   )
 }
 

--- a/frontend/components/actionDialogs/ActionDialog_InitiateSituation.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_InitiateSituation.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
-import Image from "next/image"
 import {
   Button,
+  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -11,18 +11,24 @@ import CloseIcon from "@mui/icons-material/Close"
 
 import Action from "@/classes/Action"
 import Collection from "@/classes/Collection"
-import DeadIcon from "@/images/icons/dead.svg"
 import request from "@/functions/request"
 import { useCookieContext } from "@/contexts/CookieContext"
 import { useGameContext } from "@/contexts/GameContext"
 
 interface InitiateSituationDialogProps {
+  open: boolean
   setOpen: (open: boolean) => void
+  onClose: () => void
   actions: Collection<Action>
 }
 
 // Action dialog allows the player to ready up for mortality
-const InitiateSituationDialog = (props: InitiateSituationDialogProps) => {
+const InitiateSituationDialog = ({
+  open,
+  setOpen,
+  onClose,
+  actions,
+}: InitiateSituationDialogProps) => {
   const {
     accessToken,
     refreshToken,
@@ -36,11 +42,9 @@ const InitiateSituationDialog = (props: InitiateSituationDialogProps) => {
 
   // Set required action
   useEffect(() => {
-    const requiredAction = props.actions.asArray.find(
-      (a) => a.required === true
-    )
+    const requiredAction = actions.asArray.find((a) => a.required === true)
     if (requiredAction) setRequiredAction(requiredAction)
-  }, [props.actions])
+  }, [actions])
 
   // Handle dialog submission
   const handleSubmit = async () => {
@@ -54,15 +58,15 @@ const InitiateSituationDialog = (props: InitiateSituationDialogProps) => {
         setRefreshToken,
         setUser
       )
-      props.setOpen(false)
+      setOpen(false)
     }
   }
 
   return (
-    <>
+    <Dialog onClose={onClose} open={open} className="m-0">
       <DialogTitle>Initiate a Situation</DialogTitle>
       <div className="absolute right-2 top-2">
-        <IconButton aria-label="close" onClick={() => props.setOpen(false)}>
+        <IconButton aria-label="close" onClick={() => setOpen(false)}>
           <CloseIcon />
         </IconButton>
       </div>
@@ -70,16 +74,19 @@ const InitiateSituationDialog = (props: InitiateSituationDialogProps) => {
       <DialogContent dividers className="flex flex-col gap-4">
         <div>
           <p>
-            You must initiate a random Situation. It could be a Secret, a Senator, an Event, a War or an Enemy Leader.
+            You must initiate a random Situation. It could be a Secret, a
+            Senator, an Event, a War or an Enemy Leader.
           </p>
-          <p className="mt-4 text-sm">This feature is incomplete, so nothing actually happens.</p>
+          <p className="mt-4 text-sm">
+            This feature is incomplete, so nothing actually happens.
+          </p>
         </div>
       </DialogContent>
 
       <DialogActions>
         <Button onClick={handleSubmit}>Initiate</Button>
       </DialogActions>
-    </>
+    </Dialog>
   )
 }
 

--- a/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
+++ b/frontend/components/actionDialogs/ActionDialog_SelectFactionLeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import {
   Button,
+  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -17,12 +18,19 @@ import { useCookieContext } from "@/contexts/CookieContext"
 import request from "@/functions/request"
 
 interface SelectFactionLeaderDialogProps {
+  open: boolean
   setOpen: (open: boolean) => void
+  onClose: () => void
   actions: Collection<Action>
 }
 
 // Action dialog content that displays a list of senators to choose from to be the faction leader
-const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps) => {
+const SelectFactionLeaderDialog = ({
+  open,
+  setOpen,
+  onClose,
+  actions,
+}: SelectFactionLeaderDialogProps) => {
   const {
     accessToken,
     refreshToken,
@@ -33,7 +41,7 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps) => {
   const { game, allSenators, allFactions, allTitles } = useGameContext()
 
   const requiredAction =
-    props.actions.asArray.find((a) => a.required === true) ?? null
+    actions.asArray.find((a) => a.required === true) ?? null
   const senators = new Collection<Senator>(
     allSenators.asArray.filter((senator) =>
       requiredAction?.parameters.includes(senator.id)
@@ -64,7 +72,7 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps) => {
         setUser,
         { leader_id: selectedSenator.id }
       )
-      props.setOpen(false)
+      setOpen(false)
     }
   }
 
@@ -77,10 +85,10 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps) => {
   if (requiredAction) {
     const faction = allFactions.byId[requiredAction.faction] ?? null
     return (
-      <>
+      <Dialog onClose={onClose} open={open} className="m-0">
         <DialogTitle>Select your Faction Leader</DialogTitle>
         <div className="absolute right-2 top-2">
-          <IconButton aria-label="close" onClick={() => props.setOpen(false)}>
+          <IconButton aria-label="close" onClick={() => setOpen(false)}>
             <CloseIcon />
           </IconButton>
         </div>
@@ -113,7 +121,7 @@ const SelectFactionLeaderDialog = (props: SelectFactionLeaderDialogProps) => {
             Select
           </Button>
         </DialogActions>
-      </>
+      </Dialog>
     )
   } else {
     return null


### PR DESCRIPTION
Closes #445 by allowing the action dialog to be minimized, preserving the state of the dialog content. Currently, this is only impactful for the select faction leader action dialog.