### PR TITLE
Fix senator portrait cursor

### DIFF
--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -222,7 +222,7 @@ const SenatorPortrait = ({
   const getPortrait = () => (
     <PortraitElement
       className={`select-none ${
-        selectable ? "border-none p-0 bg-transparent" : ""
+        selectable ? "border-none p-0 bg-transparent cursor-pointer" : ""
       }`}
       onMouseOver={handleMouseOver}
       onMouseLeave={handleMouseLeave}


### PR DESCRIPTION
Fix a regression introduced by #443 that caused the cursor to no longer show a pointer when hovering over a senator portrait.