### PR TITLE
Make senators generate personal revenue

### DIFF
--- a/backend/rorapp/functions/revenue_phase_helper.py
+++ b/backend/rorapp/functions/revenue_phase_helper.py
@@ -1,0 +1,54 @@
+from rorapp.functions.progress_helper import get_latest_step
+from rorapp.functions.websocket_message_helper import create_websocket_message
+from rorapp.models import ActionLog, Game, Senator, Title
+from rorapp.serializers import ActionLogSerializer, SenatorSerializer
+
+
+def generate_personal_revenue(game_id: Game) -> dict:
+    """
+    Generate personal revenue for all aligned senators.
+
+    Args:
+        game_id (int): The game ID.
+
+    Returns:
+        dict: The WebSocket messages to send.
+    """
+
+    messages_to_send = []
+
+    aligned_senators = Senator.objects.filter(
+        game=game_id, alive=True, faction__isnull=False
+    )
+    faction_leader_titles = Title.objects.filter(
+        senator__game=game_id, name="Faction Leader", end_step__isnull=True
+    )
+    faction_leader_senator_ids = [title.senator.id for title in faction_leader_titles]
+
+    # Generate personal revenue for all aligned senators
+    for senator in aligned_senators:
+        if senator.id in faction_leader_senator_ids:
+            senator.talents += 3
+        else:
+            senator.talents += 1
+        senator.save()
+        messages_to_send.append(
+            create_websocket_message("senator", SenatorSerializer(senator).data)
+        )
+
+    # Create action log
+    latest_step = get_latest_step(game_id)
+    latest_action_log = (
+        ActionLog.objects.filter(step=latest_step).order_by("index").last()
+    )
+    action_log = ActionLog(
+        index=latest_action_log.index,
+        step=latest_step,
+        type="personal_revenue",
+    )
+    action_log.save()
+    messages_to_send.append(
+        create_websocket_message("action_log", ActionLogSerializer(action_log).data)
+    )
+
+    return messages_to_send

--- a/backend/rorapp/tests/mortality_phase_tests.py
+++ b/backend/rorapp/tests/mortality_phase_tests.py
@@ -81,9 +81,9 @@ class MortalityPhaseTests(TestCase):
     def check_action_log(self, game_id: int) -> None:
         previous_step = get_latest_step(game_id, 1)
         action_log = ActionLog.objects.filter(step=previous_step)
-        # It's possible to have more than 1 action log in the event if more than one senator dies,
+        # It's possible to have more than 2 action logs in the event that more than one senator dies,
         # but in this deterministic test no more than one senator should die
-        self.assertEqual(action_log.count(), 1)
+        self.assertEqual(action_log.count(), 2)
         self.assertEqual(action_log[0].type, "face_mortality")
 
     def kill_hrao(self, game_id: int) -> None:
@@ -97,7 +97,7 @@ class MortalityPhaseTests(TestCase):
         action_logs, messages = self.kill_senators(
             game_id, [highest_ranking_senator.id]
         )
-        self.assertEqual(len(messages), 18)
+        self.assertEqual(len(messages), 27)
         latest_action_log = action_logs[0]
 
         self.assertIsNone(latest_action_log.data["heir_senator"])
@@ -124,7 +124,7 @@ class MortalityPhaseTests(TestCase):
         faction_leader_title = Title.objects.get(senator=faction_leader)
 
         action_logs, messages = self.kill_senators(game_id, [faction_leader.id])
-        self.assertEqual(len(messages), 11)
+        self.assertEqual(len(messages), 20)
         latest_action_log = action_logs[0]
 
         heir_id = latest_action_log.data["heir_senator"]
@@ -150,7 +150,7 @@ class MortalityPhaseTests(TestCase):
         regular_senator = self.get_senators_with_title(game_id, None)[0]
 
         action_logs, messages = self.kill_senators(game_id, [regular_senator.id])
-        self.assertEqual(len(messages), 8)
+        self.assertEqual(len(messages), 16)
         latest_action_log = action_logs[0]
 
         self.assertIsNone(latest_action_log.data["heir_senator"])
@@ -167,7 +167,7 @@ class MortalityPhaseTests(TestCase):
         two_regular_senators = self.get_senators_with_title(game_id, None)[0:2]
         senator_ids = [senator.id for senator in two_regular_senators]
         _, messages = self.kill_senators(game_id, senator_ids)
-        self.assertEqual(len(messages), 14)
+        self.assertEqual(len(messages), 20)
         post_death_living_senator_count = Senator.objects.filter(
             game=game_id, alive=True
         ).count()

--- a/frontend/components/ActionLog.tsx
+++ b/frontend/components/ActionLog.tsx
@@ -1,14 +1,15 @@
 import ActionLog from "@/classes/ActionLog"
-import SelectFactionLeaderActionLog from "./actionLogs/ActionLog_SelectFactionLeader"
-import FaceMortalityActionLog from "./actionLogs/ActionLog_FaceMortality"
-import TemporaryRomeConsulActionLog from "./actionLogs/ActionLog_TemporaryRomeConsul"
-import NewTurnActionLog from "./actionLogs/ActionLog_NewTurn"
-import NewFamilyActionLog from "./actionLogs/ActionLog_NewFamily"
-import NewWarActionLog from "./actionLogs/ActionLog_NewWar"
-import MatchedWarActionLog from "./actionLogs/ActionLog_MatchedWar"
-import NewEnemyLeaderActionLog from "./actionLogs/ActionLog_NewEnemyLeader"
-import MatchedEnemyLeaderActionLog from "./actionLogs/ActionLog_MatchedEnemyLeader"
-import NewSecretActionLog from "./actionLogs/ActionLog_NewSecret"
+import SelectFactionLeaderActionLog from "@/components/actionLogs/ActionLog_SelectFactionLeader"
+import FaceMortalityActionLog from "@/components/actionLogs/ActionLog_FaceMortality"
+import TemporaryRomeConsulActionLog from "@/components/actionLogs/ActionLog_TemporaryRomeConsul"
+import NewTurnActionLog from "@/components/actionLogs/ActionLog_NewTurn"
+import NewFamilyActionLog from "@/components/actionLogs/ActionLog_NewFamily"
+import NewWarActionLog from "@/components/actionLogs/ActionLog_NewWar"
+import MatchedWarActionLog from "@/components/actionLogs/ActionLog_MatchedWar"
+import NewEnemyLeaderActionLog from "@/components/actionLogs/ActionLog_NewEnemyLeader"
+import MatchedEnemyLeaderActionLog from "@/components/actionLogs/ActionLog_MatchedEnemyLeader"
+import NewSecretActionLog from "@/components/actionLogs/ActionLog_NewSecret"
+import PersonalRevenueActionLog from "@/components/actionLogs/ActionLog_PersonalRevenue"
 
 interface ActionLogItemProps {
   notification: ActionLog
@@ -24,6 +25,7 @@ const notifications: { [key: string]: React.ComponentType<any> } = {
   new_secret: NewSecretActionLog,
   new_turn: NewTurnActionLog,
   new_war: NewWarActionLog,
+  personal_revenue: PersonalRevenueActionLog,
   select_faction_leader: SelectFactionLeaderActionLog,
   temporary_rome_consul: TemporaryRomeConsulActionLog,
 }

--- a/frontend/components/FactionListItem.tsx
+++ b/frontend/components/FactionListItem.tsx
@@ -48,13 +48,13 @@ const FactionListItem = (props: FactionListItemProps) => {
   // Attribute data
   const attributeItems: Attribute[] = [
     {
-      name: "influence",
+      name: "Influence",
       value: totalInfluence,
       icon: InfluenceIcon,
     },
-    { name: "talents", value: totalTalents, icon: TalentsIcon },
-    { name: "votes", value: totalVotes, icon: VotesIcon },
-    { name: "secrets", value: secrets.length, icon: SecretsIcon },
+    { name: "Personal Talents", value: totalTalents, icon: TalentsIcon },
+    { name: "Votes", value: totalVotes, icon: VotesIcon },
+    { name: "Secrets", value: secrets.length, icon: SecretsIcon },
   ]
 
   if (!player?.user || senators.allIds.length === 0) return null

--- a/frontend/components/SenatorListItem.tsx
+++ b/frontend/components/SenatorListItem.tsx
@@ -128,6 +128,7 @@ const SenatorListItem = ({ senator, ...props }: SenatorListItemProps) => {
           size={80}
           selectable={props.selectable}
           blurryPlaceholder
+          summary
         />
       </div>
       <div className="w-full flex flex-col justify-between">

--- a/frontend/components/actionLogs/ActionLog_PersonalRevenue.tsx
+++ b/frontend/components/actionLogs/ActionLog_PersonalRevenue.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image"
+import TalentsIcon from "@/images/icons/talents.svg"
+import ActionLog from "@/classes/ActionLog"
+import ActionLogLayout from "@/components/ActionLogLayout"
+
+interface ActionLogProps {
+  notification: ActionLog
+}
+
+// ActionLog for when a senator dies during the mortality phase
+const PersonalRevenueActionLog = ({ notification }: ActionLogProps) => {
+  const getIcon = () => (
+    <div className="h-[18px] w-[24px] flex justify-center">
+      <Image src={TalentsIcon} alt="Talents icon" width={30} height={30} />
+    </div>
+  )
+
+  return (
+    <ActionLogLayout
+      actionLog={notification}
+      icon={getIcon()}
+      title="Personal Revenue"
+    >
+      <p>Aligned Senators have earned Personal Revenue.</p>
+    </ActionLogLayout>
+  )
+}
+
+export default PersonalRevenueActionLog


### PR DESCRIPTION
Make aligned senators generate personal revenue immediately after the mortality phase is resolved. No additional action is required from players and there is no revenue phase (yet).