### PR TITLE
Fix nested `<div>` browser console error

### DIFF
--- a/frontend/components/SenatorSummary.tsx
+++ b/frontend/components/SenatorSummary.tsx
@@ -53,13 +53,13 @@ const SenatorSummary = ({
 
   return (
     <>
-      <div
+      <span
         onMouseEnter={handleOpen}
         onMouseLeave={handleClose}
         style={{ display: inline ? "inline" : "flex" }}
       >
         {children}
-      </div>
+      </span>
       {open && (
         <Popover
           sx={{


### PR DESCRIPTION
Fix an issue where the browser console showed an error relating to a `<div>` being nested inside a `<p>`.