### PR TITLE
Add a flash animation to the detail section

### DIFF
--- a/frontend/components/DetailSection.tsx
+++ b/frontend/components/DetailSection.tsx
@@ -7,16 +7,17 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack"
 import SenatorDetailSection from "@/components/entityDetails/EntityDetail_Senator"
 import FactionDetailSection from "@/components/entityDetails/EntityDetail_Faction"
 import { useGameContext } from "@/contexts/GameContext"
-import HraoTerm from "@/components/terms/Term_Hrao"
-import RomeConsulTerm from "@/components/terms/Term_RomeConsul"
 import SelectedDetail from "@/types/SelectedDetail"
 import terms from "@/componentTables/termComponents"
+import { useCookieContext } from "@/contexts/CookieContext"
 
-const BROWSING_HISTORY_LENGTH = 20
+const BROWSING_HISTORY_LENGTH = 100
 
 // Section showing details about selected entities
 const DetailSection = () => {
-  const { selectedDetail, setSelectedDetail } = useGameContext()
+  const { darkMode } = useCookieContext()
+  const { selectedDetail, setSelectedDetail, sameSelectionCounter } =
+    useGameContext()
   const detailSectionRef = useRef<HTMLDivElement>(null)
   const [browsingHistory, setBrowsingHistory] = useState<SelectedDetail[]>([])
 
@@ -28,7 +29,7 @@ const DetailSection = () => {
       return
     }
     setBrowsingHistory((currentHistory) => {
-      // If current history has over 5 items, remove the first item
+      // If current history has over too many items, remove the first item
       currentHistory =
         currentHistory.length >= BROWSING_HISTORY_LENGTH
           ? currentHistory.slice(1)
@@ -45,6 +46,16 @@ const DetailSection = () => {
       return [...currentHistory, selectedDetail]
     })
   }, [selectedDetail])
+
+  // Flash the detail section when an already selected item is selected again
+  const [flash, setFlash] = useState(false)
+  useEffect(() => {
+    setFlash(true)
+    const timer = setTimeout(() => setFlash(false), 800) // adjust timing as needed
+    return () => {
+      if (flash) clearTimeout(timer)
+    }
+  }, [sameSelectionCounter])
 
   // Go back to the previous detail using detail browsing history
   const goBack = useCallback(() => {
@@ -65,7 +76,11 @@ const DetailSection = () => {
   const getTermDetails = () => terms[selectedDetail.name] as ReactNode
 
   return (
-    <div className="box-border h-full flex flex-col bg-neutral-50 dark:bg-neutral-700 rounded shadow">
+    <div
+      className={`${
+        flash ? (darkMode ? "darkModeFlash" : "lightModeFlash") : ""
+      } box-border h-full flex flex-col bg-neutral-50 dark:bg-neutral-700 rounded shadow outline-offset-[-2px]`}
+    >
       <div className="flex gap-2 justify-between items-center p-1 pl-2 border-0 border-b border-solid border-neutral-200 dark:border-neutral-750">
         <h3 className="leading-none m-0 ml-2 text-base text-neutral-600 dark:text-neutral-100">
           Selected {selectedDetail.id ? selectedDetail.type : "Term"}
@@ -88,7 +103,7 @@ const DetailSection = () => {
       </div>
       <div
         ref={detailSectionRef}
-        className="box-border h-full flex-1 overflow-y-auto bg-white dark:bg-neutral-600 rounded-b"
+        className={`box-border h-full flex-1 overflow-y-auto bg-white dark:bg-neutral-600 rounded-b`}
       >
         {selectedDetail.type === "Senator" && (
           <SenatorDetailSection detailSectionRef={detailSectionRef} />

--- a/frontend/components/FactionLink.tsx
+++ b/frontend/components/FactionLink.tsx
@@ -11,7 +11,7 @@ interface FactionLinkProps {
 }
 
 const FactionLink = ({ faction, includeIcon }: FactionLinkProps) => {
-  const { selectedDetail, setSelectedDetail } = useGameContext()
+  const { setSelectedDetail } = useGameContext()
 
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -34,9 +34,6 @@ const FactionLink = ({ faction, includeIcon }: FactionLinkProps) => {
       {faction.getName()} Faction
     </>
   )
-
-  if (selectedDetail?.type === "Faction" && selectedDetail.id === faction.id)
-    return <span>{getContent()}</span>
 
   return (
     <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>

--- a/frontend/components/GamePage.tsx
+++ b/frontend/components/GamePage.tsx
@@ -627,10 +627,7 @@ const GamePage = (props: GamePageProps) => {
     }
   }, [latestActions, setLatestActions, latestStep])
 
-  const handleMainTabChange = (
-    _: React.SyntheticEvent,
-    newValue: number
-  ) => {
+  const handleMainTabChange = (_: React.SyntheticEvent, newValue: number) => {
     setMainTab(newValue)
   }
 
@@ -683,7 +680,7 @@ const GamePage = (props: GamePageProps) => {
         <div className="flex flex-col gap-2 xl:overflow-auto xl:grow">
           <MetaSection />
           <div className="flex flex-col gap-2 xl:flex-row xl:overflow-auto xl:flex-1">
-            <div className="xl:overflow-auto xl:flex-1 xl:max-w-[540px]">
+            <div className="xl:flex-1 xl:max-w-[540px] max-h-[75vh] xl:max-h-none">
               <DetailSection />
             </div>
             <div className="xl:flex-1 xl:grow-[2] bg-neutral-50 dark:bg-neutral-700 rounded shadow overflow-auto">

--- a/frontend/components/Search.tsx
+++ b/frontend/components/Search.tsx
@@ -102,7 +102,7 @@ const Search = () => {
         className={
           "p-2 px-3 border border-solid rounded flex min-w-[140px] items-center \
           text-neutral-500 dark:text-neutral-300 bg-white dark:bg-neutral-650 \
-          border-neutral-300 dark:border-neutral-500 hover:border-neutral-400 dark:hover:border-neutral-300"
+          border-neutral-300 dark:border-neutral-500 hover:border-neutral-500 dark:hover:border-neutral-200"
         }
       >
         <SearchIcon />

--- a/frontend/components/SenatorLink.tsx
+++ b/frontend/components/SenatorLink.tsx
@@ -10,7 +10,7 @@ interface SenatorLinkProps {
 }
 
 const SenatorLink = ({ senator }: SenatorLinkProps) => {
-  const { setSelectedDetail, selectedDetail } = useGameContext()
+  const { setSelectedDetail } = useGameContext()
 
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -22,9 +22,6 @@ const SenatorLink = ({ senator }: SenatorLinkProps) => {
         id: senator.id,
       } as SelectedDetail)
   }
-
-  if (selectedDetail?.type === "Senator" && selectedDetail.id === senator.id)
-    return <span>{senator.displayName}</span>
 
   return (
     <SenatorSummary senator={senator} inline portrait>

--- a/frontend/components/TermLink.tsx
+++ b/frontend/components/TermLink.tsx
@@ -34,8 +34,7 @@ const TermLink = ({
   includeIcon,
   disabled,
 }: TermLinkProps) => {
-  const { selectedDetail, setSelectedDetail, setDialog } =
-    useGameContext()
+  const { setSelectedDetail, setDialog } = useGameContext()
 
   // Use the name to get the correct image
   const getIcon = (): StaticImageData | string => {
@@ -68,11 +67,7 @@ const TermLink = ({
 
   // Get the JSX for the link
   const getLink = () => {
-    if (
-      disabled ||
-      (selectedDetail?.type === "Term" && selectedDetail.name === name)
-    )
-      return <span>{getContent()}</span>
+    if (disabled) return <span>{getContent()}</span>
 
     return (
       <Link

--- a/frontend/contexts/GameContext.tsx
+++ b/frontend/contexts/GameContext.tsx
@@ -3,6 +3,7 @@ import {
   ReactNode,
   SetStateAction,
   createContext,
+  useCallback,
   useContext,
   useState,
 } from "react"
@@ -65,6 +66,8 @@ interface GameContextType {
   setLatestActions: Dispatch<SetStateAction<Collection<Action>>>
   dialog: Dialog
   setDialog: Dispatch<SetStateAction<Dialog>>
+  sameSelectionCounter: number
+  setSameSelectionCounter: Dispatch<SetStateAction<number>>
 }
 
 const GameContext = createContext<GameContextType | null>(null)
@@ -99,7 +102,7 @@ export const GameProvider = (props: GameProviderProps): JSX.Element => {
   const [allTitles, setAllTitles] = useState<Collection<Title>>(
     new Collection<Title>()
   )
-  const [selectedDetail, setSelectedDetail] = useState<SelectedDetail | null>(
+  const [selectedDetail, _setSelectedDetail] = useState<SelectedDetail | null>(
     null
   )
   const [actionLogs, setActionLogs] = useState<Collection<ActionLog>>(
@@ -125,6 +128,23 @@ export const GameProvider = (props: GameProviderProps): JSX.Element => {
     new Collection<Action>()
   )
   const [dialog, setDialog] = useState<Dialog>(null)
+  const [sameSelectionCounter, setSameSelectionCounter] = useState<number>(0)
+
+  // Wrapper for setSelectedDetail that increments sameSelectionCounter when an already selected item is selected again
+  const setSelectedDetail: Dispatch<SetStateAction<SelectedDetail | null>> =
+    useCallback(
+      (newValue) => {
+        if (
+          (newValue as SelectedDetail)?.id === selectedDetail?.id &&
+          (newValue as SelectedDetail)?.name === selectedDetail?.name
+        ) {
+          console.log("TEST")
+          setSameSelectionCounter((prev) => prev + 1)
+        }
+        _setSelectedDetail(newValue)
+      },
+      [selectedDetail]
+    )
 
   return (
     <GameContext.Provider
@@ -169,6 +189,8 @@ export const GameProvider = (props: GameProviderProps): JSX.Element => {
         setLatestActions,
         dialog,
         setDialog,
+        sameSelectionCounter,
+        setSameSelectionCounter,
       }}
     >
       {props.children}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -13,6 +13,7 @@ import "../styles/space.css"
 import "../styles/master.css"
 import "../styles/colors.css"
 import "../styles/dataGrid.css"
+import "../styles/animations.css"
 import ThemeWrapper from "@/components/ThemeWrapper"
 
 const openSansFont = Open_Sans({
@@ -51,7 +52,9 @@ function App({ Component, pageProps }: AppProps) {
       </style>
       <PageWrapper reference={nonModalContentRef}>
         <TopBar {...pageProps} />
-        <ThemeWrapper><Component {...pageProps} /></ThemeWrapper>
+        <ThemeWrapper>
+          <Component {...pageProps} />
+        </ThemeWrapper>
         <Footer />
       </PageWrapper>
     </RootProvider>

--- a/frontend/pages/games/[id]/index.tsx
+++ b/frontend/pages/games/[id]/index.tsx
@@ -6,8 +6,6 @@ import Link from "next/link"
 import useWebSocket from "react-use-websocket"
 
 import Button from "@mui/material/Button"
-import Stack from "@mui/material/Stack"
-import Card from "@mui/material/Card"
 import Avatar from "@mui/material/Avatar"
 import { capitalize } from "@mui/material/utils"
 import List from "@mui/material/List"

--- a/frontend/styles/animations.css
+++ b/frontend/styles/animations.css
@@ -1,0 +1,31 @@
+@keyframes lightModeFlash {
+  0% {
+    outline: 2px solid transparent;
+  }
+  10% {
+    outline: 2px solid var(--tyrian-800);
+  }
+  100% {
+    outline: 2px solid transparent;
+  }
+}
+
+.lightModeFlash {
+  animation: lightModeFlash 0.8s 1;
+}
+
+@keyframes darkModeFlash {
+  0% {
+    outline: 2px solid transparent;
+  }
+  10% {
+    outline: 2px solid var(--tyrian-200);
+  }
+  100% {
+    outline: 2px solid transparent;
+  }
+}
+
+.darkModeFlash {
+  animation: darkModeFlash 0.8s 1;
+}


### PR DESCRIPTION
Add a flash animation to the detail section, which appears when an already selected item is selected again. Retire the behavior of turning links into regular text if that item is already selected.