### PR TITLE
Add a simple faction summary

### DIFF
--- a/frontend/components/FactionLink.tsx
+++ b/frontend/components/FactionLink.tsx
@@ -4,6 +4,7 @@ import { useGameContext } from "@/contexts/GameContext"
 import Faction from "@/classes/Faction"
 import SelectedDetail from "@/types/SelectedDetail"
 import FactionIcon from "@/components/FactionIcon"
+import FactionSummary from "@/components/FactionSummary"
 
 interface FactionLinkProps {
   faction: Faction
@@ -36,9 +37,11 @@ const FactionLink = ({ faction, includeIcon }: FactionLinkProps) => {
   )
 
   return (
-    <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
-      {getContent()}
-    </Link>
+    <FactionSummary faction={faction} inline>
+      <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
+        {getContent()}
+      </Link>
+    </FactionSummary>
   )
 }
 

--- a/frontend/components/FactionListItem.tsx
+++ b/frontend/components/FactionListItem.tsx
@@ -74,8 +74,7 @@ const FactionListItem = (props: FactionListItemProps) => {
       <p>
         <b>
           <FactionLink faction={props.faction} includeIcon />
-        </b>{" "}
-        of {player.user.username}
+        </b>
       </p>
       <AttributeFlex attributes={attributeItems} />
       <div className="flex flex-wrap gap-2">

--- a/frontend/components/FactionSummary.tsx
+++ b/frontend/components/FactionSummary.tsx
@@ -1,0 +1,81 @@
+import { MouseEvent, ReactNode, useState } from "react"
+import Faction from "@/classes/Faction"
+import { useGameContext } from "@/contexts/GameContext"
+import { Popover } from "@mui/material"
+import FactionLink from "./FactionLink"
+import FactionIcon from "./FactionIcon"
+
+interface FactionSummaryProps {
+  faction: Faction
+  children: ReactNode
+  inline?: boolean
+}
+
+const FactionSummary = ({ faction, children, inline }: FactionSummaryProps) => {
+  const { allPlayers } = useGameContext()
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null)
+  const handleOpen = (event: MouseEvent<HTMLElement>) => {
+    const currentTarget = event.currentTarget
+    const newTimeoutId = setTimeout(() => {
+      setAnchorEl(currentTarget)
+    }, 200) // Delay before opening the popover
+
+    setTimeoutId(newTimeoutId)
+  }
+  const handleClose = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+    setAnchorEl(null)
+  }
+  const open = Boolean(anchorEl)
+
+  // Get faction-specific data
+  const player = allPlayers.byId[faction.player] ?? null
+
+  return (
+    <>
+      <span
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
+        style={{ display: inline ? "inline" : "flex" }}
+      >
+        {children}
+      </span>
+      {open && (
+        <Popover
+          sx={{
+            pointerEvents: "none",
+            overflowX: "visible",
+            overflowY: "visible",
+            marginTop: "8px",
+          }}
+          open={open}
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "left",
+          }}
+          transformOrigin={{
+            vertical: "top",
+            horizontal: "left",
+          }}
+          onClose={handleClose}
+          disableRestoreFocus
+        >
+          <div className="py-3 px-4 max-w-[260px]">
+            <span style={{ marginRight: 4 }}>
+              <FactionIcon faction={faction} size={17} />
+            </span>
+            <span className="font-semibold">{faction.getName()} Faction </span>{" "}
+            of {player.user?.username ?? "unknown user"}
+          </div>
+        </Popover>
+      )}
+    </>
+  )
+}
+
+export default FactionSummary

--- a/frontend/components/Search.tsx
+++ b/frontend/components/Search.tsx
@@ -105,7 +105,7 @@ const Search = () => {
           border-neutral-300 dark:border-neutral-500 hover:border-neutral-500 dark:hover:border-neutral-200"
         }
       >
-        <span className="text-neutral-100 flex">
+        <span className="dark:text-neutral-100 flex">
           <SearchIcon />
         </span>
         <span className="grow">Search...</span>

--- a/frontend/components/Search.tsx
+++ b/frontend/components/Search.tsx
@@ -105,7 +105,9 @@ const Search = () => {
           border-neutral-300 dark:border-neutral-500 hover:border-neutral-500 dark:hover:border-neutral-200"
         }
       >
-        <SearchIcon />
+        <span className="text-neutral-100 flex">
+          <SearchIcon />
+        </span>
         <span className="grow">Search...</span>
       </button>
       <Dialog


### PR DESCRIPTION
Closes #415 by adding a faction summary that shows the icon and the username of the associated user.

![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/d9a2b5ea-0eef-4182-9742-e152510bdd98)
![image](https://github.com/iamlogand/republic-of-rome-online/assets/104830874/d2b81c7c-36cc-48c5-88a2-68c019b74e02)
