### PR TITLE
Fix final forum phase select faction leader WS

### DIFF
--- a/backend/rorapp/functions/faction_leader_helper.py
+++ b/backend/rorapp/functions/faction_leader_helper.py
@@ -187,7 +187,7 @@ def proceed_to_next_step_if_forum_phase(game_id, step, faction) -> List[dict]:
 
         if next_faction is not None:
             if step.phase.name.startswith("Final"):
-                messages_to_send.extend(
+                messages_to_send.append(
                     generate_select_faction_leader_action(next_faction)
                 )
             else:


### PR DESCRIPTION
Fix an issue where WebSocket messages for select faction leader actions were not being sent to clients during the final forum phase.