### PR TITLE
Action log for the end of the game

### DIFF
--- a/backend/rorapp/functions/faction_leader_helper.py
+++ b/backend/rorapp/functions/faction_leader_helper.py
@@ -13,7 +13,7 @@ from rorapp.functions.websocket_message_helper import (
     destroy_websocket_message,
 )
 from rorapp.functions.turn_starter import start_next_turn
-from rorapp.functions.game_ender import end_game
+from rorapp.functions.game_ender import end_game_with_influence_victory
 from rorapp.models import (
     Action,
     ActionLog,
@@ -198,5 +198,5 @@ def proceed_to_next_step_if_forum_phase(game_id, step, faction) -> List[dict]:
             if not step.phase.name.startswith("Final"):
                 messages_to_send.extend(start_next_turn(game_id, step))
             else:
-                messages_to_send.extend(end_game(game_id))
+                messages_to_send.extend(end_game_with_influence_victory(game_id))
     return messages_to_send

--- a/backend/rorapp/functions/game_ender.py
+++ b/backend/rorapp/functions/game_ender.py
@@ -1,7 +1,35 @@
+from typing import List
 from django.utils import timezone
+from rorapp.functions.progress_helper import get_latest_step
 from rorapp.models import Game
 from rorapp.functions.websocket_message_helper import create_websocket_message
+from rorapp.models.action_log import ActionLog
+from rorapp.models.faction import Faction
+from rorapp.models.senator import Senator
 from rorapp.serializers import GameDetailSerializer
+
+
+def end_game_with_influence_victory(game_id: int) -> List[dict]:
+    messages_to_send = []
+
+    winning_faction = find_influence_winner(game_id)
+
+    latest_step = get_latest_step(game_id)
+    new_action_log_index = (
+        ActionLog.objects.filter(step__phase__turn__game=game_id)
+        .order_by("-index")[0]
+        .index
+        + 1
+    )
+    faction_wins_action_log = ActionLog(
+        index=new_action_log_index,
+        step=latest_step,
+        type="faction_wins",
+        data={"type": "influence", "faction": winning_faction.id},
+    )
+    faction_wins_action_log.save()
+
+    messages_to_send.extend(end_game(game_id))
 
 
 def end_game(game_id: int) -> None:
@@ -9,3 +37,48 @@ def end_game(game_id: int) -> None:
     game.end_date = timezone.now()
     game.save()
     return [create_websocket_message("game", GameDetailSerializer(game).data)]
+
+
+def find_influence_winner(game_id: int) -> Faction:
+    factions = Faction.objects.filter(game=game_id)
+    winning_faction = None
+    current_highest_influence = 0
+    current_highest_senator_influence = 0
+    current_highest_votes = 0
+    for faction in factions:
+        senators = Senator.objects.filter(alive=True, faction=faction).order_by(
+            "influence"
+        )
+        highest_senator_influence = senators.first().influence
+        influence = 0
+        votes = 0
+        for senator in senators:
+            influence += senator.influence
+            votes += senator.votes
+
+        # Highest influence wins
+        if influence > current_highest_influence:
+            winning_faction = faction
+            current_highest_senator_influence = highest_senator_influence
+            current_highest_votes = votes
+
+        # Tiebreaker: highest influence on an individual senator
+        elif (
+            influence == current_highest_influence
+            and highest_senator_influence > current_highest_senator_influence
+        ):
+            winning_faction = faction
+            current_highest_senator_influence = highest_senator_influence
+            current_highest_influence = influence
+
+        # Second tiebreaker: highest votes
+        elif (
+            influence == current_highest_influence
+            and highest_senator_influence == current_highest_senator_influence
+            and votes > current_highest_votes
+        ):
+            winning_faction = faction
+            current_highest_senator_influence = highest_senator_influence
+            current_highest_influence = influence
+
+    return winning_faction

--- a/frontend/components/ActionLog.tsx
+++ b/frontend/components/ActionLog.tsx
@@ -11,6 +11,7 @@ import MatchedEnemyLeaderActionLog from "@/components/actionLogs/ActionLog_Match
 import NewSecretActionLog from "@/components/actionLogs/ActionLog_NewSecret"
 import PersonalRevenueActionLog from "@/components/actionLogs/ActionLog_PersonalRevenue"
 import EraEndsActionLog from "@/components/actionLogs/ActionLog_EraEnds"
+import FactionWinsActionLog from "@/components/actionLogs/ActionLog_FactionWins"
 
 interface ActionLogItemProps {
   notification: ActionLog
@@ -19,6 +20,7 @@ interface ActionLogItemProps {
 
 const notifications: { [key: string]: React.ComponentType<any> } = {
   era_ends: EraEndsActionLog,
+  faction_wins: FactionWinsActionLog,
   mortality: MortalityActionLog,
   matched_enemy_leader: MatchedEnemyLeaderActionLog,
   matched_war: MatchedWarActionLog,

--- a/frontend/components/actionLogs/ActionLog_FactionWins.tsx
+++ b/frontend/components/actionLogs/ActionLog_FactionWins.tsx
@@ -1,0 +1,47 @@
+import Image from "next/image"
+import TimeIcon from "@/images/icons/time.svg"
+import ActionLog from "@/classes/ActionLog"
+import ActionLogLayout from "@/components/ActionLogLayout"
+import TermLink from "@/components/TermLink"
+import Faction from "@/classes/Faction"
+import { useGameContext } from "@/contexts/GameContext"
+import FactionLink from "@/components/FactionLink"
+
+interface ActionLogProps {
+  notification: ActionLog
+}
+
+// ActionLog for when a faction wins the game
+const FactionWinsActionLog = ({ notification }: ActionLogProps) => {
+  const { allFactions } = useGameContext()
+
+  // Get notification-specific data
+  const faction: Faction | null = notification.faction
+    ? allFactions.byId[notification.faction] ?? null
+    : null
+
+  const getIcon = () => (
+    <div className="h-[18px] w-[24px] flex justify-center">
+      <Image src={TimeIcon} alt="Time icon" width={30} height={30} />
+    </div>
+  )
+
+  if (!faction) return null
+
+  return (
+    <ActionLogLayout
+      actionLog={notification}
+      icon={getIcon()}
+      title={`${faction.getName()} Faction Wins`}
+      faction={faction}
+    >
+      <p>
+        Rome has survived, but there can only be one winner.{" "}
+        <FactionLink faction={faction} /> has won by surpassing all other{" "}
+        <TermLink name="Faction" plural /> in Influence.
+      </p>
+    </ActionLogLayout>
+  )
+}
+
+export default FactionWinsActionLog

--- a/frontend/components/actionLogs/ActionLog_NewWar.tsx
+++ b/frontend/components/actionLogs/ActionLog_NewWar.tsx
@@ -53,8 +53,12 @@ const NewWarActionLog = ({ notification }: ActionLogProps) => {
       case "imminent":
         return (
           <span>
-            Imminent due to{" "}{isMatchedByMultiple ? "" : "a "}
-            <TermLink name="Matching Wars and Enemy Leaders" displayName="Matching War" plural={isMatchedByMultiple} />
+            Imminent due to {isMatchedByMultiple ? "" : "a "}
+            <TermLink
+              name="Matching Wars and Enemy Leaders"
+              displayName="Matching War"
+              plural={isMatchedByMultiple}
+            />
           </span>
         )
       case "active":
@@ -78,7 +82,12 @@ const NewWarActionLog = ({ notification }: ActionLogProps) => {
           </span>
         )
       default:
-        return capitalize(initialStatus)
+        return (
+          <TermLink
+            name={`${capitalize(initialStatus)} War`}
+            displayName={capitalize(initialStatus)}
+          />
+        )
     }
   }
 


### PR DESCRIPTION
Closes #416

Introduces the "faction_wins" action log, which is issued at the end of the Final Forum Phase.