### PR TITLE
Senator tab improvements

### DIFF
--- a/frontend/components/SenateTab.tsx
+++ b/frontend/components/SenateTab.tsx
@@ -6,6 +6,7 @@ import SenateSector from "@/components/SenateSector"
 const EMPTY_SPACE_ANGLE = 50 // Angular distance between sectors
 const SIZE = 720 // Width of the Senate diagram
 const MARGIN = 10 // Margin around the diagram
+const MAX_SEAT_SIZE = 100 // Maximum size of a seat
 
 interface SectorData {
   senators: Senator[]
@@ -52,7 +53,9 @@ const SenateTab = () => {
     (acc, sector) => acc + sector.senators.length,
     0
   )
-  const seatSize = Math.max(40, Math.min(80, 110 - totalMembers * 1.5))
+  let seatSize = Math.max(40, Math.min(MAX_SEAT_SIZE, 110 - totalMembers * 1.5))
+  // Round to the nearest multiple of 2
+  seatSize = Math.floor(seatSize / 2) * 2
 
   const minimumSpace = (0.055 * seatSize) / 80
 

--- a/frontend/components/SenatorPortrait.tsx
+++ b/frontend/components/SenatorPortrait.tsx
@@ -78,12 +78,8 @@ const SenatorPortrait = ({
   blurryPlaceholder,
   round,
 }: SenatorPortraitProps) => {
-  const {
-    allFactions,
-    allTitles,
-    selectedDetail,
-    setSelectedDetail,
-  } = useGameContext()
+  const { allFactions, allTitles, selectedDetail, setSelectedDetail } =
+    useGameContext()
 
   // Get senator-specific data
   const faction: Faction | null = senator.faction
@@ -215,18 +211,20 @@ const SenatorPortrait = ({
 
   const showIcons = size > 70
 
-  // Get JSX for the portrait
-  const PortraitElement = selectable ? "button" : "div"
-
-  const getPortrait = () => (
-    <PortraitElement
-      className={`select-none ${
-        selectable ? "border-none p-0 bg-transparent cursor-pointer" : ""
-      }`}
+  const renderButton = () => (
+    <button
+      className="absolute top-0 left-0 h-full w-full z-50 cursor-pointer select-none border-none p-0 bg-transparent"
+      style={{
+        borderRadius: round ? "50%" : 4,
+      }}
       onMouseOver={handleMouseOver}
       onMouseLeave={handleMouseLeave}
       onClick={handleClick}
-    >
+    />
+  )
+
+  return (
+    <div>
       <figure
         style={{
           height: size,
@@ -290,22 +288,24 @@ const SenatorPortrait = ({
             )}
             {size > 120 && (
               <Tooltip title="Senator ID" arrow>
-                <div className="absolute z-50 bottom-1 px-[6px] py-0.5 text-sm text-white bg-[rgba(0,_0,_0,_0.4)] user-none">
+                <div className="absolute z-40 bottom-1 px-[6px] py-0.5 text-sm text-white bg-[rgba(0,_0,_0,_0.4)] user-none">
                   # {senator.code}
                 </div>
               </Tooltip>
             )}
           </>
         )}
+        {selectable &&
+          (summary ? (
+            <SenatorSummary senator={senator}>
+              <div style={{ height: size, width: size }}>{renderButton()}</div>
+            </SenatorSummary>
+          ) : (
+            renderButton()
+          ))}
       </figure>
-    </PortraitElement>
+    </div>
   )
-
-  if (summary) {
-    return <SenatorSummary senator={senator}>{getPortrait()}</SenatorSummary>
-  } else {
-    return getPortrait()
-  }
 }
 
 export default SenatorPortrait


### PR DESCRIPTION
- Allow the senator portraits in the senate tab to be larger if there are not many senators
- Make the clickable area of rounded portraits round, to match the visual shape of the portrait