### PR TITLE
Handle long faction names better in the UI

### DIFF
--- a/frontend/components/ActionLogLayout.tsx
+++ b/frontend/components/ActionLogLayout.tsx
@@ -80,7 +80,7 @@ const ActionLogLayout = ({
         </div>
       )}
       <b>{title}</b>
-      {children}
+      <span className="text-pretty">{children}</span>
     </Alert>
   )
 }

--- a/frontend/components/CustomizeFactionName.tsx
+++ b/frontend/components/CustomizeFactionName.tsx
@@ -16,6 +16,8 @@ import request from "@/functions/request"
 
 import TermLink from "@/components/TermLink"
 import { useCookieContext } from "@/contexts/CookieContext"
+import FactionIcon from "@/components/FactionIcon"
+import FactionName from "@/components/FactionName"
 
 interface CustomizeFactionNameProps {
   faction: Faction
@@ -27,6 +29,7 @@ const CustomizeFactionName = ({ faction }: CustomizeFactionNameProps) => {
     refreshToken,
     setAccessToken,
     setRefreshToken,
+    user,
     setUser,
   } = useCookieContext()
   const [open, setOpen] = useState<boolean>(false)
@@ -34,6 +37,10 @@ const CustomizeFactionName = ({ faction }: CustomizeFactionNameProps) => {
   const [nameFeedback, setNameFeedback] = useState<string>("")
 
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    // Limit the name to 30 characters
+    if (event.target.value.length > 30) {
+      event.target.value = event.target.value.slice(0, 30)
+    }
     setName(event.target.value)
   }
 
@@ -70,6 +77,13 @@ const CustomizeFactionName = ({ faction }: CustomizeFactionNameProps) => {
     }
   }
 
+  // Create a custom Faction object with the custom name for showing previews
+  const customFactionObject = Object.assign(
+    Object.create(Object.getPrototypeOf(faction)),
+    faction
+  )
+  customFactionObject.customName = name
+
   return (
     <>
       <Button variant="outlined" size="small" onClick={() => setOpen(true)}>
@@ -88,25 +102,57 @@ const CustomizeFactionName = ({ faction }: CustomizeFactionNameProps) => {
         <form onSubmit={handleSubmit}>
           <DialogContent dividers className="flex flex-col gap-4">
             <p>
-              You may replace &quot;{faction.getName()} Faction&quot; with a
-              custom <TermLink name="Faction" displayName="Faction" /> name.
-              This name will be displayed to other players.
+              You may replace your{" "}
+              <TermLink name="Faction" displayName="Faction" />
+              &apos;s default name with a custom name. This name will be
+              displayed to other players.
             </p>
             <p>
               Once customized, your faction&apos;s name can&apos;t be changed
               again.
             </p>
             <TextField
-              required
               id="name"
               label="Name"
               error={nameFeedback != ""}
               onChange={handleNameChange}
               helperText={capitalize(nameFeedback)}
             />
+            <div className="flex flex-col gap-1">
+              <p className="text-sm">Full name preview</p>
+              <div className="p-2 border border-solid rounded border-neutral-300 dark:border-neutral-800">
+                <p>
+                  <b>
+                    <FactionIcon faction={faction} size={17} />{" "}
+                    <FactionName faction={customFactionObject} />
+                  </b>{" "}
+                  <span>
+                    {name.length > 0 && (
+                      <span>
+                        (<FactionName faction={faction} />)
+                      </span>
+                    )}{" "}
+                    of {user?.username}
+                  </span>
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <p className="text-sm">Short name preview</p>
+              <div className="flex gap-1 w-[164px] p-2 border border-solid rounded border-neutral-300 dark:border-neutral-800">
+                <b>
+                  <FactionIcon faction={faction} size={17} />
+                </b>{" "}
+                <b>
+                  <FactionName faction={customFactionObject} maxWidth={140} />
+                </b>
+              </div>
+            </div>
           </DialogContent>
           <DialogActions>
-            <Button type="submit">Confirm</Button>
+            <Button type="submit" disabled={name.length === 0}>
+              Confirm
+            </Button>
           </DialogActions>
         </form>
       </Dialog>

--- a/frontend/components/FactionLink.tsx
+++ b/frontend/components/FactionLink.tsx
@@ -5,13 +5,15 @@ import Faction from "@/classes/Faction"
 import SelectedDetail from "@/types/SelectedDetail"
 import FactionIcon from "@/components/FactionIcon"
 import FactionSummary from "@/components/entitySummaries/FactionSummary"
+import FactionName from "@/components/FactionName"
 
 interface FactionLinkProps {
   faction: Faction
   includeIcon?: boolean
+  maxWidth?: number
 }
 
-const FactionLink = ({ faction, includeIcon }: FactionLinkProps) => {
+const FactionLink = ({ faction, includeIcon, maxWidth }: FactionLinkProps) => {
   const { setSelectedDetail } = useGameContext()
 
   const handleClick = (
@@ -32,14 +34,14 @@ const FactionLink = ({ faction, includeIcon }: FactionLinkProps) => {
           <FactionIcon faction={faction} size={17} />
         </span>
       )}
-      {faction.customName ?? <span>{faction.getName()} Faction</span>}
+      <FactionName faction={faction} maxWidth={maxWidth} />
     </>
   )
 
   return (
     <FactionSummary faction={faction} inline>
       <Link href="#" onClick={handleClick} sx={{ verticalAlign: "baseline" }}>
-        {getContent()}
+        {maxWidth ? <div className="flex">{getContent()}</div> : getContent()}
       </Link>
     </FactionSummary>
   )

--- a/frontend/components/FactionName.tsx
+++ b/frontend/components/FactionName.tsx
@@ -1,0 +1,38 @@
+import Faction from "@/classes/Faction"
+
+interface FactionNameProps {
+  faction: Faction
+  maxWidth?: number
+}
+
+// Faction name contained in a span, unless `maxWidth` is specified, in which case it is contained in a div.
+const FactionName = ({ faction, maxWidth }: FactionNameProps) => {
+  if (!faction) return null
+
+  if (faction.customName) {
+    if (maxWidth) {
+      return (
+        <div
+          className="text-nowrap overflow-hidden text-ellipsis"
+          style={{ maxWidth: maxWidth }}
+        >
+          {faction.customName}
+        </div>
+      )
+    } else {
+      const longestWord = faction.customName
+        .split(" ")
+        .reduce((a, b) => (a.length > b.length ? a : b))
+      // Only break all if the longest word in the name is longer than 11 characters (less than 1% of words in the English language are this long)
+      if (longestWord.length > 11) {
+        return <span className="break-all">{faction.customName}</span>
+      } else {
+        return <span>{faction.customName}</span>
+      }
+    }
+  } else {
+    return <span>{faction.getName()} Faction</span>
+  }
+}
+
+export default FactionName

--- a/frontend/components/MetaSection.tsx
+++ b/frontend/components/MetaSection.tsx
@@ -120,7 +120,7 @@ const MetaSection = () => {
               <h3 className="text-sm">Your Faction</h3>
               <div className="flex items-center gap-3">
                 <div>
-                  <FactionLink faction={faction} includeIcon />
+                  <FactionLink faction={faction} maxWidth={130} includeIcon />
                 </div>
                 <AttributeFlex attributes={attributeItems} />
               </div>
@@ -141,7 +141,7 @@ const MetaSection = () => {
                 {hraoFaction && (
                   <span>
                     {" "}
-                    of the <FactionLink faction={hraoFaction} />
+                    of the <FactionLink faction={hraoFaction} maxWidth={130} />
                   </span>
                 )}
               </span>

--- a/frontend/components/SenatorFactionInfo.tsx
+++ b/frontend/components/SenatorFactionInfo.tsx
@@ -3,6 +3,7 @@ import { useGameContext } from "@/contexts/GameContext"
 import FactionLink from "@/components/FactionLink"
 import Senator from "@/classes/Senator"
 import FactionIcon from "@/components/FactionIcon"
+import FactionName from "@/components/FactionName"
 
 interface SenatorFactionInfoProps {
   senator: Senator
@@ -37,7 +38,7 @@ const SenatorFactionInfo = ({
             <span style={{ marginRight: 4 }}>
               <FactionIcon faction={faction} size={17} />
             </span>
-            {faction.customName ?? <span>{faction.getName()} Faction</span>}
+            <FactionName faction={faction} />
           </span>
         )}
         {isFactionLeader ? " Leader" : " Member"}

--- a/frontend/components/SenatorListItem.tsx
+++ b/frontend/components/SenatorListItem.tsx
@@ -159,10 +159,10 @@ const SenatorListItem = ({ senator, ...props }: SenatorListItemProps) => {
             <p>
               {faction && senator.alive ? (
                 props.selectable ? (
-                  <span>
-                    <FactionLink faction={faction} includeIcon />{" "}
+                  <div className="flex gap-1">
+                    <FactionLink faction={faction} maxWidth={140} includeIcon />{" "}
                     {factionLeader && "Leader"}
-                  </span>
+                  </div>
                 ) : (
                   factionLeader && <span>Faction Leader</span>
                 )

--- a/frontend/components/entityDetails/FactionDetails.tsx
+++ b/frontend/components/entityDetails/FactionDetails.tsx
@@ -19,7 +19,8 @@ import SenatorLink from "@/components/SenatorLink"
 import TermLink from "@/components/TermLink"
 import SecretList from "@/components/SecretList"
 import { useCookieContext } from "@/contexts/CookieContext"
-import CustomizeFactionName from "@/components/ChangeFactionName"
+import CustomizeFactionName from "@/components/CustomizeFactionName"
+import FactionName from "@/components/FactionName"
 
 // Detail section content for a faction
 const FactionDetails = () => {
@@ -175,10 +176,7 @@ const FactionDetails = () => {
         has {senators.allIds.length} member{senators.allIds.length !== 1 && "s"}
         {hraoSenator && (
           <span>
-            , including the{" "}
-            <TermLink
-              name="HRAO"
-            />
+            , including the <TermLink name="HRAO" />
             {majorOffices.length == 0 && (
               <span>
                 {": "}
@@ -216,10 +214,15 @@ const FactionDetails = () => {
             <h4 className="text-lg">
               {faction.customName ? (
                 <span>
-                  <b>{faction.customName}</b> ({faction.getName()} Faction)
+                  <b>
+                    <FactionName faction={faction} />
+                  </b>{" "}
+                  ({faction.getName()} Faction)
                 </span>
               ) : (
-                <b>{faction.getName()} Faction</b>
+                <b>
+                  <FactionName faction={faction} />
+                </b>
               )}{" "}
               of {player ? player.user?.username : "unknown"}
             </h4>

--- a/frontend/components/entitySummaries/FactionSummary.tsx
+++ b/frontend/components/entitySummaries/FactionSummary.tsx
@@ -3,6 +3,7 @@ import Faction from "@/classes/Faction"
 import { useGameContext } from "@/contexts/GameContext"
 import { Popover } from "@mui/material"
 import FactionIcon from "@/components/FactionIcon"
+import FactionName from "@/components/FactionName"
 
 const POPOVER_DELAY = 200
 
@@ -66,18 +67,13 @@ const FactionSummary = ({ faction, children, inline }: FactionSummaryProps) => {
           onClose={handleClose}
           disableRestoreFocus
         >
-          <div className="py-3 px-4 max-w-[360px]">
+          <div className="py-3 px-4">
             <span style={{ marginRight: 4 }}>
               <FactionIcon faction={faction} size={17} />
             </span>
-            {faction.customName ? (
-              <span>
-                <span className="font-semibold">{faction.customName}</span> (
-                {faction.getName()} Faction)
-              </span>
-            ) : (
-              <span className="font-semibold">{faction.getName()} Faction</span>
-            )}{" "}
+            <span className="font-semibold">
+              <FactionName faction={faction} />
+            </span>{" "}
             of {player.user?.username ?? "unknown user"}
           </div>
         </Popover>


### PR DESCRIPTION
Closes #482

Handle long faction names better in the UI. Improve the customize faction name dialog by adding previews and preventing the user from typing names that are too long.