### PR TITLE
Bring back faction color to faction summary

### DIFF
--- a/frontend/components/entitySummaries/FactionSummary.tsx
+++ b/frontend/components/entitySummaries/FactionSummary.tsx
@@ -74,6 +74,7 @@ const FactionSummary = ({ faction, children, inline }: FactionSummaryProps) => {
             <span className="font-semibold">
               <FactionName faction={faction} />
             </span>{" "}
+            {faction.customName && <span>({faction.getName()} Faction)</span>}{" "}
             of {player.user?.username ?? "unknown user"}
           </div>
         </Popover>


### PR DESCRIPTION
Bring back the faction color to the faction summary for a faction with a custom name. This was removed by mistake in PR #484.