### PR TITLE
Fix custom faction name field bug

### DIFF
--- a/frontend/components/CustomizeFactionName.tsx
+++ b/frontend/components/CustomizeFactionName.tsx
@@ -39,7 +39,7 @@ const CustomizeFactionName = ({ faction }: CustomizeFactionNameProps) => {
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     // Limit the name to 30 characters
     if (event.target.value.length > 30) {
-      event.target.value = event.target.value.slice(0, 30)
+      event.target.value = name
     }
     setName(event.target.value)
   }


### PR DESCRIPTION
Fix a small bug in the custom faction name field where typing in the middle of the name would cut off the last character once the character limit is hit.