### PR TITLE
Fix content shift MUI tooltip issue

### DIFF
--- a/frontend/styles/master.css
+++ b/frontend/styles/master.css
@@ -21,6 +21,12 @@ body.dark {
   background-color: var(--neutral-800);
 }
 
+@media (min-width: 1280px) {
+  body {
+    overflow-y: hidden;
+  }
+}
+
 #__next {
   display: flex;
   flex-flow: column;


### PR DESCRIPTION
Fix an issue where a scrollbar would momentarily appear and shift all page content to the left if a MUI tooltip was scrolled off screen.