### PR TITLE
perf: reduce frequency of `send_game_state` calls

### DIFF
--- a/backend/rorapp/signals/__init__.py
+++ b/backend/rorapp/signals/__init__.py
@@ -1,2 +1,2 @@
 from .faction import faction_created, faction_deleted
-from .game import game_updated
+from .game import game_created, game_updated

--- a/backend/rorapp/signals/game.py
+++ b/backend/rorapp/signals/game.py
@@ -5,9 +5,11 @@ from rorapp.game_state.send_game_state import send_game_state
 
 
 @receiver(post_save, sender=Game)
+def game_created(sender, instance, created, **kwargs):
+    if created:
+        send_game_state(instance.id)
+
+
 @receiver(post_delete, sender=Game)
 def game_updated(sender, instance, **kwargs):
-    game_id = instance.id
-
-    # TODO: Consider calling send_game_state from somewhere else because this might be getting called too often
-    send_game_state(game_id)
+    send_game_state(instance.id)

--- a/backend/rorapp/views/game.py
+++ b/backend/rorapp/views/game.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied
 
+from rorapp.game_state.send_game_state import send_game_state
 from rorapp.models import Game
 from rorapp.serializers import GameSerializer
 
@@ -31,7 +32,8 @@ class GameViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         self.validate_host(instance.host)
         serializer.save()
+        send_game_state(instance.id)
 
-    def perform_destroy(self, instance):
+    def perform_destroy(self, instance: Game):
         self.validate_host(instance.host)
         instance.delete()

--- a/backend/rorapp/views/start_game.py
+++ b/backend/rorapp/views/start_game.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from rorapp.effects.meta.effect_executor import execute_effects
+from rorapp.game_state.send_game_state import send_game_state
 from rorapp.models import Faction, Game
 from rorapp.models.senator import Senator
 
@@ -84,5 +85,6 @@ class StartGameViewSet(viewsets.ViewSet):
         game.save()
 
         execute_effects(game.id)
+        send_game_state(game.id)
 
         return Response({"message": "Game started"}, status=200)

--- a/backend/rorapp/views/submit_action.py
+++ b/backend/rorapp/views/submit_action.py
@@ -11,6 +11,7 @@ from rorapp.actions.meta.registry import action_registry
 from rorapp.actions.meta.action_base import ActionBase
 from rorapp.effects.meta.effect_executor import execute_effects
 from rorapp.game_state.game_state_live import GameStateLive
+from rorapp.game_state.send_game_state import send_game_state
 from rorapp.models import AvailableAction, Faction, Game
 
 
@@ -52,5 +53,6 @@ class SubmitActionViewSet(viewsets.ViewSet):
         game = Game.objects.get(id=game_id)
         game.step += 1
         game.save()
+        send_game_state(game.id)
 
         return Response({"message": "Action submitted"}, status=200)


### PR DESCRIPTION
The `send_game_state` method was being called every time the game was updated, meaning that if the game was updated several times during a request cycle, the game state would be sent to clients several times, which is bad for performance/costs. Also, with game state being sent part way through a request cycle, before the DB transaction had been closed, it was possible for clients to receive invalid state.

This is all fixed now - each request cycle involves game state being sent once, right at the end, after anything that might fail will have failed.