### PR TITLE
feat: add chance fields

### DIFF
--- a/backend/rorapp/actions/attract_knight.py
+++ b/backend/rorapp/actions/attract_knight.py
@@ -61,6 +61,14 @@ class AttractKnightAction(ActionBase):
                         "name": "Talents",
                         "min": [0],
                         "max": [5, "signal:max_talents"],
+                        "signals": {"talents": "VALUE"},
+                    },
+                    {
+                        "type": "chance",
+                        "name": "Chance of success",
+                        "dice": 1,
+                        "target_min": 6,
+                        "modifiers": ["signal:talents"],
                     },
                 ],
             )

--- a/frontend/app/account/edit/page.tsx
+++ b/frontend/app/account/edit/page.tsx
@@ -104,7 +104,7 @@ const AccountEditPage = () => {
                 type="text"
                 value={newUsername}
                 onChange={(e) => setNewUsername(e.target.value)}
-                className="w-[300px] p-1 border border-neutral-500 rounded"
+                className="w-[300px] p-1 border border-neutral-600 rounded"
               />
             </div>
             {errors.username && (

--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -34,14 +34,14 @@ const AccountPage = () => {
         </div>
         <div className="flex flex-col gap-4">
           <div>
-            <h3 className="text-sm pb-2 text-neutral-500">Public</h3>
+            <h3 className="text-sm pb-2 text-neutral-600">Public</h3>
             <p>
               <span className="inline-block w-[100px]">Username:</span>{" "}
               {user.username}
             </p>
           </div>
           <div>
-            <h3 className="text-sm pb-2 text-neutral-500">
+            <h3 className="text-sm pb-2 text-neutral-600">
               Private (hidden from other players)
             </h3>
             <p>

--- a/frontend/app/games/[id]/edit/page.tsx
+++ b/frontend/app/games/[id]/edit/page.tsx
@@ -124,7 +124,7 @@ const EditGamePage = () => {
                   type="text"
                   value={newName}
                   onChange={(e) => setNewName(e.target.value)}
-                  className="w-[300px] p-1 border border-neutral-500 rounded"
+                  className="w-[300px] p-1 border border-neutral-600 rounded"
                 />
               </div>
               {errors.name && (

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -184,7 +184,7 @@ const GamePage = () => {
           </div>
           <div className="flex flex-col gap-1">
             <p>Hosted by {publicGameState.game.host.username}</p>
-            <div className="flex flex-col gap-1 text-sm text-neutral-500">
+            <div className="flex flex-col gap-1 text-sm text-neutral-600">
               <p>Created on {formatDate(publicGameState.game.createdOn)}</p>
               {publicGameState.game.startedOn && (
                 <p>Started on {formatDate(publicGameState.game.startedOn)}</p>
@@ -226,7 +226,7 @@ const GamePage = () => {
                             </button>
                           )}
                           {!faction && myFactionId && (
-                            <span className="text-neutral-500">Open</span>
+                            <span className="text-neutral-600">Open</span>
                           )}
                           {faction && faction.id === myFactionId && (
                             <button

--- a/frontend/app/games/new/page.tsx
+++ b/frontend/app/games/new/page.tsx
@@ -73,7 +73,7 @@ const NewGamePage = () => {
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  className="min-w-[300px] p-1 border border-neutral-500 rounded"
+                  className="min-w-[300px] p-1 border border-neutral-600 rounded"
                 />
               </div>
               {errors.name && (

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -8,7 +8,7 @@ const NotFound = () => {
   return (
     <div className="w-full pt-16 flex flex-col gap-4 items-center">
       <h2>404 - Page Not Found</h2>
-      <p className="text-neutral-500 text-center">
+      <p className="text-neutral-600 text-center">
         {user ? (
           <>
             Either this page doesn&apos;t exist, or you don&apos;t have

--- a/frontend/classes/AvailableAction.ts
+++ b/frontend/classes/AvailableAction.ts
@@ -23,6 +23,10 @@ export interface ActionField {
   ]
   min?: (number | string)[]
   max?: (number | string)[]
+  signals?: ActionSignals
+  dice?: number
+  target_min?: number
+  modifiers?: (number | string)[]
 }
 
 export interface AvailableActionData {

--- a/frontend/components/ActionDescription.tsx
+++ b/frontend/components/ActionDescription.tsx
@@ -4,18 +4,10 @@ const factionLeaderDescription = (
 
 const actionDescriptionRegistry = {
   "Attract knight": (
-    <>
-      <p>
-        A senator may spend talents to attempt to attract a knight. Each knight
-        increases the senator&apos;s personal revenue and votes by +1.
-      </p>
-      <p className="text-sm">
-        Base chance of success is{" "}
-        <span className="text-lg leading-4">1&frasl;6</span>. Each talent spent
-        increases the chance of success by a further{" "}
-        <span className="text-lg leading-4">1&frasl;6</span>.
-      </p>
-    </>
+    <p>
+      A senator may spend talents to attempt to attract a knight. Each knight
+      a senator controls increases their personal revenue and votes by +1.
+    </p>
   ),
   "Change faction leader": factionLeaderDescription,
   Contribute: (

--- a/frontend/components/Breadcrumb.tsx
+++ b/frontend/components/Breadcrumb.tsx
@@ -21,7 +21,7 @@ const Breadcrumb = ({ items }: BreadcrumbProps) => {
   return (
     <div className="flex flex-wrap">
       {items.map((item: BreadcrumbItem, index: number) => (
-        <div key={index} className="text-neutral-500 flex">
+        <div key={index} className="text-neutral-600 flex">
           {item.href ? (
             <div className="max-w-[400px] text-ellipsis whitespace-nowrap overflow-hidden text-blue-600 hover:underline">
               <Link href={item.href}>{item.text}</Link>

--- a/frontend/components/GameContainer.tsx
+++ b/frontend/components/GameContainer.tsx
@@ -20,7 +20,7 @@ const GameContainer = ({
 }: GameContainerProps) => {
   return (
     <div className="flex flex-col">
-      <div className="flex relative">
+      <div className="relative">
         {privateGameState && privateGameState?.availableActions.length > 0 && (
           <div className="absolute h-full flex">
             <div className="w-2 bg-blue-500 lg:bg-transparent" />
@@ -72,14 +72,14 @@ const GameContainer = ({
                         className="flex flex-col md:flex-row gap-x-4 items-baseline"
                       >
                         <div className="flex flex-col sm:flex-row gap-x-4 text-sm">
-                          <div className="text-neutral-500 whitespace-nowrap">
+                          <div className="text-neutral-600 whitespace-nowrap">
                             {formatDate(log.createdOn)}
                           </div>
                           <div className="flex gap-x-2">
-                            <div className="text-neutral-500 whitespace-nowrap">
+                            <div className="text-neutral-600 whitespace-nowrap">
                               Turn {log.turn}
                             </div>
-                            <div className="text-neutral-500 whitespace-nowrap">
+                            <div className="text-neutral-600 whitespace-nowrap">
                               {log.phase} phase
                             </div>
                           </div>
@@ -105,7 +105,7 @@ const GameContainer = ({
                   <div
                     className={`pl-1 border-y border-l ${
                       myFaction
-                        ? "bg-neutral-500 border-neutral-500"
+                        ? "bg-neutral-600 border-neutral-600"
                         : "bg-neutral-300 border-neutral-400"
                     }`}
                   />
@@ -134,14 +134,14 @@ const GameContainer = ({
                               <div className="sm:min-w-[200px]">
                                 <p className="">
                                   {senator.displayName}{" "}
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     ({senator.code})
                                   </span>
                                 </p>
                               </div>
                               <div className="flex gap-x-4 gap-y-1 flex-wrap">
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Military
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -149,7 +149,7 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Oratory
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -157,7 +157,7 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Loyalty
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -165,7 +165,7 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Influence
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -173,7 +173,7 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Popularity
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -181,7 +181,7 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Knights
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -189,7 +189,7 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Votes
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -197,7 +197,7 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 <div>
-                                  <span className="text-neutral-500 text-sm">
+                                  <span className="text-neutral-600 text-sm">
                                     Talents
                                   </span>{" "}
                                   <span className="inline-block w-[15px]">
@@ -282,7 +282,7 @@ const GameContainer = ({
                   )
                 )
               ) : (
-                <p className="text-neutral-500">None right now</p>
+                <p className="text-neutral-600">None right now</p>
               )}
             </div>
           </div>

--- a/frontend/utils/dice.ts
+++ b/frontend/utils/dice.ts
@@ -1,0 +1,33 @@
+type ProbabilityTable = {
+  [key: number]: number
+}
+
+const probabilityTable1d6: ProbabilityTable = {
+  1: 1 / 6,
+  2: 1 / 6,
+  3: 1 / 6,
+  4: 1 / 6,
+  5: 1 / 6,
+  6: 1 / 6,
+}
+
+const getDiceProbability = (
+  dice: 1 | 2 | 3,
+  modifier: number,
+  target_min: number
+) => {
+  let probabilityTable = probabilityTable1d6
+  // TODO support 2d6 and 3d6
+  // TODO support other types of target, e.g. specific numbers
+
+  let totalProbability = 0
+  for (let result in probabilityTable) {
+    const modifiedResult = Number(result) + modifier
+    if (modifiedResult >= Number(target_min)) {
+      totalProbability += probabilityTable[result]
+    }
+  }
+  return totalProbability
+}
+
+export default getDiceProbability


### PR DESCRIPTION
There's now a read only chance field, which can show the probabilities for gambling mechanics. Currently it's just used to show the probability of success when attempting to attract a knight.

![image](https://github.com/user-attachments/assets/19e5ae30-ac45-4ee4-97b9-ff78d6a408ad)
