### PR TITLE
feat: make the hints for the Combat Calculator transfer button more useful

### DIFF
--- a/frontend/components/CombatCalculator.tsx
+++ b/frontend/components/CombatCalculator.tsx
@@ -254,7 +254,7 @@ const CombatCalculator = ({
         }
       }
 
-      let unitsNeeded = []
+      const unitsNeeded = []
       if (canTransfer && calculation.regularLegions > 0) {
         const deployed = getDeployedForces(
           publicGameState,


### PR DESCRIPTION
Where before it might have said:

"Insufficient regular legions in reserve (need 12, have 4)"

It now says:

"Not enough forces in reserve (need 8 more regular legions and 2 more fleets)"
