### PR TITLE
fix: prevent submit action race conditions

### DIFF
--- a/backend/rorapp/views/submit_action.py
+++ b/backend/rorapp/views/submit_action.py
@@ -31,7 +31,8 @@ class SubmitActionViewSet(viewsets.ViewSet):
 
         # Validation
         try:
-            game = Game.objects.get(id=game_id)
+            # Lock the game row to ensure all actions for this game are processed sequentially
+            game = Game.objects.select_for_update().get(id=game_id)
         except Game.DoesNotExist:
             raise NotFound("Game not found")
         try:

--- a/backend/tests/test_senate/test_vote.py
+++ b/backend/tests/test_senate/test_vote.py
@@ -1,4 +1,5 @@
 import pytest
+import threading
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 from rorapp.classes.random_resolver import FakeRandomResolver
 from rorapp.models import AvailableAction, Faction, Game
@@ -68,3 +69,58 @@ def test_can_vote_yea(basic_game: Game):
     game.refresh_from_db()
     faction_votes = sum(s.votes for s in faction.senators.all())
     assert game.votes_yea == initial_votes_yea + faction_votes
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_voting(basic_game: Game):
+
+    # Arrange
+    game = basic_game
+    game.phase = Game.Phase.SENATE
+    game.current_proposal = "Test proposal"
+    game.save()
+    initial_votes_yea = game.votes_yea
+    faction: Faction = game.factions.get(position=1)
+    faction.add_status_item(Faction.StatusItem.CALLED_TO_VOTE)
+    faction.save()
+
+    execute_effects_and_manage_actions(game.id)
+
+    factory = APIRequestFactory()
+    view = SubmitActionViewSet.as_view({"post": "submit_action"})
+    results = []
+
+    def submit_vote():
+        request = factory.post(
+            f"/api/games/{game.id}/submit-action/Vote yea", {}, format="json"
+        )
+        force_authenticate(request, user=faction.player)
+        try:
+            response = view(
+                request,
+                game_id=game.id,
+                action_name="Vote yea",
+            )
+            results.append(("success", response.status_code))
+        except Exception as e:
+            results.append(("error", str(e)))
+
+    thread1 = threading.Thread(target=submit_vote)
+    thread2 = threading.Thread(target=submit_vote)
+
+    # Act
+    # This simulates the player clicking "vote yea" twice in quick succession
+    thread1.start()
+    thread2.start()
+    thread1.join()
+    thread2.join()
+
+    # Assert
+    game.refresh_from_db()
+    faction.refresh_from_db()
+
+    faction_votes = sum(s.votes for s in faction.senators.all())
+    assert game.votes_yea == initial_votes_yea + faction_votes
+
+    successful_requests = [r for r in results if r[0] == "success" and r[1] == 200]
+    assert len(successful_requests) == 1


### PR DESCRIPTION
Closes #594 by locking the game object when each action is submitted, preventing race conditions.