### PR TITLE
feat: famine severity

### DIFF
--- a/backend/rorapp/effects/initiative_roll.py
+++ b/backend/rorapp/effects/initiative_roll.py
@@ -112,6 +112,8 @@ class InitiativeRollEffect(EffectBase):
                         )
                 war.save()
 
+                if war.famine:
+                    new_war_message = f"{new_war_message} This war increases famine severity."
                 Log.create_object(game_id, new_war_message)
                 for message in matching_war_messages:
                     Log.create_object(game_id, message)

--- a/backend/rorapp/effects/population.py
+++ b/backend/rorapp/effects/population.py
@@ -1,6 +1,7 @@
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
+from rorapp.helpers.text import format_list
 from rorapp.models import Game, Log, War
 
 
@@ -20,14 +21,19 @@ class PopulationEffect(EffectBase):
         unprosecuted_war_count = War.objects.filter(
             game=game_id, unprosecuted=True
         ).count()
-        unrest_increase = unprosecuted_war_count
-        reasons = ""
+        famine_severity = War.objects.filter(game=game_id, famine=True).count()
+        unrest_increase = unprosecuted_war_count + famine_severity
+        reasons = []
         if unprosecuted_war_count > 0:
-            reasons += f"{unprosecuted_war_count} unprosecuted {'wars' if unprosecuted_war_count > 1 else 'war'}"
+            reasons.append(
+                f"{unprosecuted_war_count} unprosecuted {'wars' if unprosecuted_war_count > 1 else 'war'}"
+            )
+        if famine_severity > 0:
+            reasons.append(f"famine severity {famine_severity}")
         if unrest_increase > 0:
             Log.create_object(
                 game_id,
-                f"Unrest increased by {unrest_increase} due to {reasons}.",
+                f"Unrest level increased by {unrest_increase} as a result of {format_list(reasons)}.",
             )
         game.unrest += unrest_increase
 

--- a/backend/rorapp/models/game.py
+++ b/backend/rorapp/models/game.py
@@ -96,6 +96,10 @@ class Game(models.Model):
     def famine_severity(self: "Game") -> int:
         return self.wars.filter(famine=True).count()
 
+    @property
+    def unprosecuted_wars(self: "Game") -> int:
+        return self.wars.filter(unprosecuted=True).count()
+
     # Change unrest safely, returning actual change
     def change_unrest(self, change) -> int:
         new_unrest = self.unrest + change

--- a/backend/rorapp/models/game.py
+++ b/backend/rorapp/models/game.py
@@ -92,6 +92,10 @@ class Game(models.Model):
     def deck_count(self: "Game") -> int:
         return len(self.deck)
 
+    @property
+    def famine_severity(self: "Game") -> int:
+        return self.wars.filter(famine=True).count()
+
     # Change unrest safely, returning actual change
     def change_unrest(self, change) -> int:
         new_unrest = self.unrest + change

--- a/backend/rorapp/serializers/game.py
+++ b/backend/rorapp/serializers/game.py
@@ -83,7 +83,8 @@ class GameSerializer(serializers.ModelSerializer):
             "available_concessions",
             "status",
             "votes_pending",
-            "deck_count"
+            "deck_count",
+            "famine_severity",
         ]
         read_only_fields = [
             "created_on",
@@ -104,5 +105,6 @@ class GameSerializer(serializers.ModelSerializer):
             "available_concessions",
             "status",
             "votes_pending",
-            "deck_count"
+            "deck_count",
+            "famine_severity",
         ]

--- a/backend/rorapp/serializers/game.py
+++ b/backend/rorapp/serializers/game.py
@@ -85,6 +85,7 @@ class GameSerializer(serializers.ModelSerializer):
             "votes_pending",
             "deck_count",
             "famine_severity",
+            "unprosecuted_wars",
         ]
         read_only_fields = [
             "created_on",
@@ -107,4 +108,5 @@ class GameSerializer(serializers.ModelSerializer):
             "votes_pending",
             "deck_count",
             "famine_severity",
+            "unprosecuted_wars",
         ]

--- a/frontend/classes/Game.ts
+++ b/frontend/classes/Game.ts
@@ -35,6 +35,7 @@ export interface GameData {
   votes_pending: number
   deck_count: number
   famine_severity: number
+  unprosecuted_wars: number
 }
 
 class Game {
@@ -74,6 +75,7 @@ class Game {
   votesPending: number
   deckCount: number
   famineSeverity: number
+  unprosecutedWars: number
 
   constructor(data: GameData) {
     this.id = data.id
@@ -102,6 +104,7 @@ class Game {
     this.votesPending = data.votes_pending
     this.deckCount = data.deck_count
     this.famineSeverity = data.famine_severity
+    this.unprosecutedWars = data.unprosecuted_wars
   }
 }
 

--- a/frontend/classes/Game.ts
+++ b/frontend/classes/Game.ts
@@ -34,6 +34,7 @@ export interface GameData {
   status: string
   votes_pending: number
   deck_count: number
+  famine_severity: number
 }
 
 class Game {
@@ -72,6 +73,7 @@ class Game {
   status: string
   votesPending: number
   deckCount: number
+  famineSeverity: number
 
   constructor(data: GameData) {
     this.id = data.id
@@ -99,6 +101,7 @@ class Game {
     this.status = data.status
     this.votesPending = data.votes_pending
     this.deckCount = data.deck_count
+    this.famineSeverity = data.famine_severity
   }
 }
 

--- a/frontend/components/GameContainer.tsx
+++ b/frontend/components/GameContainer.tsx
@@ -225,9 +225,14 @@ const GameContainer = ({
                     <div>
                       State treasury: {publicGameState.game.stateTreasury}T
                     </div>
+                  </div>
+                  <div className="flex flex-wrap gap-x-4">
                     <div>Unrest level: {publicGameState.game.unrest}</div>
                     <div>
                       Famine severity: {publicGameState.game.famineSeverity}
+                    </div>
+                    <div>
+                      Unprosecuted wars: {publicGameState.game.unprosecutedWars}
                     </div>
                   </div>
 
@@ -495,8 +500,13 @@ const GameContainer = ({
                                   </span>
                                 </div>
                                 {war.unprosecuted && (
-                                  <div className="flex items-center rounded-full bg-neutral-200 px-2 py-0.5 text-center text-sm text-neutral-600">
+                                  <div className="flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-center text-sm text-purple-600">
                                     Unprosecuted
+                                  </div>
+                                )}
+                                {war.famine && (
+                                  <div className="flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-center text-sm text-purple-600">
+                                    Increases famine
                                   </div>
                                 )}
                                 {war.navalStrength > 0 && (
@@ -518,11 +528,6 @@ const GameContainer = ({
                               {war.seriesName && (
                                 <div className="">
                                   Series: {war.seriesName} Wars
-                                </div>
-                              )}
-                              {war.famine && (
-                                <div className="text-sm text-red-600">
-                                  Increases famine severity
                                 </div>
                               )}
                             </div>

--- a/frontend/components/GameContainer.tsx
+++ b/frontend/components/GameContainer.tsx
@@ -226,6 +226,9 @@ const GameContainer = ({
                       State treasury: {publicGameState.game.stateTreasury}T
                     </div>
                     <div>Unrest level: {publicGameState.game.unrest}</div>
+                    <div>
+                      Famine severity: {publicGameState.game.famineSeverity}
+                    </div>
                   </div>
 
                   <div>
@@ -518,8 +521,8 @@ const GameContainer = ({
                                 </div>
                               )}
                               {war.famine && (
-                                <div className="text-sm">
-                                  Causes famine when active
+                                <div className="text-sm text-red-600">
+                                  Increases famine severity
                                 </div>
                               )}
                             </div>


### PR DESCRIPTION
Some wars now increase famine (just the 1st Illyrian War in the Early Republic scenario).

Famine severity and unprosecuted wars are now shown in the UI, alongside unrest level.