### PR TITLE
fix: passage of time and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ An online adaptation of a board game called [The Republic of Rome](https://board
     - [ ] Epidemic
     - [ ] Evil omens
     - [ ] Internal disorder
-    - [ ] Manpower shortage
+    - [x] Manpower shortage
     - [ ] New alliance
     - [ ] Pretender emerges
     - [ ] Refuge
@@ -46,7 +46,6 @@ An online adaptation of a board game called [The Republic of Rome](https://board
     - [ ] Trial of Verres
   - [x] New senator
   - [x] New war
-  - [ ] New bequest
   - [x] New leader
   - [x] Concession card
     - [x] Tax farmers
@@ -137,4 +136,3 @@ An online adaptation of a board game called [The Republic of Rome](https://board
 - [x] Military overwhelmed
 - [ ] Influence peddling
 - [x] Combat calculator tool
-- [ ] Persuasion tool

--- a/backend/rorapp/actions/call_popular_appeal.py
+++ b/backend/rorapp/actions/call_popular_appeal.py
@@ -171,6 +171,7 @@ class CallPopularAppealAction(ActionBase):
                     ):
                         kill_senator(senator)
 
+            assert game.current_proposal is not None
             game.add_defeated_proposal(game.current_proposal)
             game.save()
 

--- a/backend/rorapp/actions/call_popular_appeal.py
+++ b/backend/rorapp/actions/call_popular_appeal.py
@@ -1,6 +1,7 @@
 import math
 from typing import Any, Dict, Optional, List
 from rorapp.actions.meta.action_base import ActionBase
+from rorapp.helpers.game_data import get_senator_codes
 from rorapp.actions.meta.execution_result import ExecutionResult
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
@@ -160,17 +161,18 @@ class CallPopularAppealAction(ActionBase):
             if excess > 0:
                 senators = Senator.objects.filter(game=game_id)
                 vulnerable = [accused.id, prosecutor.id]
-                for _ in range(excess):
-                    chits = random_resolver.draw_mortality_chits(1)
-                    if chits:
-                        chit = chits[0]
-                        for senator in senators:
-                            if (
-                                senator.code == chit
-                                and senator.id in vulnerable
-                                and senator.alive
-                            ):
-                                kill_senator(senator)
+                chits = set(random_resolver.draw_mortality_chits(excess))
+                for senator in senators:
+                    family_code, _ = get_senator_codes(senator.code)
+                    if (
+                        senator.id in vulnerable
+                        and senator.alive
+                        and family_code in chits
+                    ):
+                        kill_senator(senator)
+
+            game.add_defeated_proposal(game.current_proposal)
+            game.save()
 
             # All factions mark DONE
             all_factions = list(Faction.objects.filter(game=game_id))

--- a/backend/rorapp/actions/give_speech.py
+++ b/backend/rorapp/actions/give_speech.py
@@ -8,6 +8,7 @@ from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.game_state.game_state_live import GameStateLive
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
+from rorapp.helpers.game_data import get_senator_codes
 from rorapp.helpers.kill_senator import CauseOfDeath, kill_senator
 from rorapp.helpers.text import format_list
 from rorapp.models import AvailableAction, Faction, Game, Log, Senator
@@ -203,7 +204,7 @@ class GiveSpeechAction(ActionBase):
                 s
                 for s in senators
                 if s.location == "Rome"
-                and any(s.code.startswith(str(c)) for c in codes)
+                and get_senator_codes(s.code)[0] in {str(c) for c in codes}
             ]
 
             if len(mob_victims) >= 2:

--- a/backend/rorapp/actions/initiative_auction_pay.py
+++ b/backend/rorapp/actions/initiative_auction_pay.py
@@ -118,11 +118,8 @@ class InitiativeAuctionPayAction(ActionBase):
 
         factions = Faction.objects.filter(game=game_id)
         for initiative_index in Faction.INITIATIVE_INDICES:
-            if not any(
-                f.has_status_item(FactionStatusItem.initiative(initiative_index))
-                for f in factions
-            ):
-                faction.add_status_item(FactionStatusItem.initiative(initiative_index))
+            if not any(f.has_initiative(initiative_index) for f in factions):
+                faction.add_initiative(initiative_index)
                 faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
                 faction.save()
 

--- a/backend/rorapp/actions/play_statesman.py
+++ b/backend/rorapp/actions/play_statesman.py
@@ -5,7 +5,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.game_state.game_state_live import GameStateLive
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.game_data import get_senator_code, load_senators, load_statesmen
+from rorapp.helpers.game_data import get_senator_codes, load_senators, load_statesmen
 from rorapp.models import AvailableAction, Faction, Game, Log, Senator
 
 _STATESMAN_PREFIX = "statesman:"
@@ -57,7 +57,7 @@ class PlayStatesmanAction(ActionBase):
         options = []
         for card in statesman_cards:
             statesman_code = card[len(_STATESMAN_PREFIX):]
-            family_code = get_senator_code(statesman_code)[0]
+            family_code = get_senator_codes(statesman_code)[0]
 
             # Skip if same statesman already in play
             if any(s.code == statesman_code and s.alive for s in snapshot.senators):
@@ -109,7 +109,7 @@ class PlayStatesmanAction(ActionBase):
 
         card = selection["Statesman"]
         statesman_code = card[len(_STATESMAN_PREFIX):]
-        family_code = get_senator_code(statesman_code)[0]
+        family_code = get_senator_codes(statesman_code)[0]
 
         statesmen_dict = load_statesmen()
         match = next(

--- a/backend/rorapp/effects/__init__.py
+++ b/backend/rorapp/effects/__init__.py
@@ -8,6 +8,7 @@ from .initiative_auction_auto_skip import InitiativeAuctionAutoSkipEffect
 from .initiative_auction_first import InitiativeAuctionFirstEffect
 from .initiative_auction_next import InitiativeAuctionNextEffect
 from .persuasion_auto_skip import PersuasionAutoSkipEffect
+from .play_cards_auto_skip import PlayCardsAutoSkipEffect
 from .persuasion_counter_bribe_first import PersuasionCounterBribeFirstEffect
 from .persuasion_counter_bribe_next import PersuasionCounterBribeNextEffect
 from .persuasion_decision_auto_resolve import PersuasionDecisionAutoResolveEffect

--- a/backend/rorapp/effects/auto_appoint_censor.py
+++ b/backend/rorapp/effects/auto_appoint_censor.py
@@ -21,7 +21,8 @@ class AutoAppointCensorEffect(EffectBase):
 
         candidates, is_fallback = get_eligible_censor_candidates(game_state.senators)
         defeated_names = {
-            p[len("Elect Censor "):] for p in game_state.game.defeated_proposals
+            p[len("Elect Censor ") :]
+            for p in game_state.game.defeated_proposals
             if p.startswith("Elect Censor ")
         }
         candidates = [c for c in candidates if c.display_name not in defeated_names]
@@ -34,7 +35,8 @@ class AutoAppointCensorEffect(EffectBase):
         senators = list(Senator.objects.filter(game=game_id, alive=True))
         candidates, is_fallback = get_eligible_censor_candidates(senators)
         defeated_names = {
-            p[len("Elect Censor "):] for p in game.defeated_proposals
+            p[len("Elect Censor ") :]
+            for p in game.defeated_proposals
             if p.startswith("Elect Censor ")
         }
         candidates = [c for c in candidates if c.display_name not in defeated_names]
@@ -62,8 +64,12 @@ class AutoAppointCensorEffect(EffectBase):
         censor.save()
 
         Log.create_object(
-            game_id=game_id,
-            text=f"{censor.display_name}, the only eligible candidate, was automatically appointed Censor. He gained 5 influence.",
+            game_id,
+            f"{censor.display_name}, the only eligible candidate, was automatically appointed Censor. He gained 5 influence.",
+        )
+        Log.create_object(
+            game_id,
+            f"{censor.display_name} took over as presiding magistrate to conduct prosecutions.",
         )
 
         game.clear_defeated_proposals()

--- a/backend/rorapp/effects/elect_censor.py
+++ b/backend/rorapp/effects/elect_censor.py
@@ -58,8 +58,12 @@ class ElectCensorEffect(EffectBase):
                 censor.save()
 
                 Log.create_object(
-                    game_id=game.id,
-                    text=f"{censor.display_name} was elected Censor. He gained 5 influence.",
+                    game.id,
+                    f"{censor.display_name} was elected Censor. He gained 5 influence.",
+                )
+                Log.create_object(
+                    game.id,
+                    f"{censor.display_name} took over as presiding magistrate to conduct prosecutions.",
                 )
 
             game.clear_defeated_proposals()

--- a/backend/rorapp/effects/initiative_auction_auto_pay.py
+++ b/backend/rorapp/effects/initiative_auction_auto_pay.py
@@ -85,15 +85,8 @@ class InitiativeAuctionAutoPayEffect(EffectBase):
 
                 factions = Faction.objects.filter(game=game_id)
                 for initiative_index in Faction.INITIATIVE_INDICES:
-                    if not any(
-                        f.has_status_item(
-                            FactionStatusItem.initiative(initiative_index)
-                        )
-                        for f in factions
-                    ):
-                        faction.add_status_item(
-                            FactionStatusItem.initiative(initiative_index)
-                        )
+                    if not any(f.has_initiative(initiative_index) for f in factions):
+                        faction.add_initiative(initiative_index)
                         faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
                         faction.save()
 

--- a/backend/rorapp/effects/initiative_auction_first.py
+++ b/backend/rorapp/effects/initiative_auction_first.py
@@ -23,10 +23,7 @@ class InitiativeAuctionFirstEffect(EffectBase):
     def execute(self, game_id: int, random_resolver: RandomResolver) -> bool:
         factions = Faction.objects.filter(game=game_id)
         for initiative_index in Faction.INITIATIVE_INDICES:
-            if not any(
-                f.has_status_item(FactionStatusItem.initiative(initiative_index))
-                for f in factions
-            ):
+            if not any(f.has_initiative(initiative_index) for f in factions):
                 for faction in factions:
                     if any(
                         s.has_title(Senator.Title.HRAO)

--- a/backend/rorapp/effects/initiative_auction_next.py
+++ b/backend/rorapp/effects/initiative_auction_next.py
@@ -69,10 +69,7 @@ class InitiativeAuctionNextEffect(EffectBase):
         winning_faction.save()
 
         for initiative_index in Faction.INITIATIVE_INDICES:
-            if not any(
-                f.has_status_item(FactionStatusItem.initiative(initiative_index))
-                for f in factions
-            ):
+            if not any(f.has_initiative(initiative_index) for f in factions):
                 if winning_bid_amount > 0:
                     Log.create_object(
                         game_id,

--- a/backend/rorapp/effects/initiative_first.py
+++ b/backend/rorapp/effects/initiative_first.py
@@ -2,7 +2,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.models import Faction, Game, Senator
+from rorapp.models import Faction, Game, Log, Senator
 
 
 class InitiativeFirstEffect(EffectBase):
@@ -15,6 +15,13 @@ class InitiativeFirstEffect(EffectBase):
         )
 
     def execute(self, game_id: int, random_resolver: RandomResolver) -> bool:
+        # Passage of time: remove event cards from the forum (§1.07.1)
+        game = Game.objects.get(id=game_id)
+        for effect_value in game.effects:
+            Log.create_object(game_id, f"The {effect_value} has ended.")
+        game.clear_effects()
+        game.save()
+
         factions = [
             f
             for f in Faction.objects.filter(game=game_id)
@@ -28,7 +35,7 @@ class InitiativeFirstEffect(EffectBase):
                 )
             ):
                 faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
-                faction.add_status_item(FactionStatusItem.initiative(1))
+                faction.add_initiative(1)
                 faction.save()
 
                 game = Game.objects.get(id=game_id)

--- a/backend/rorapp/effects/initiative_first.py
+++ b/backend/rorapp/effects/initiative_first.py
@@ -18,7 +18,8 @@ class InitiativeFirstEffect(EffectBase):
         # Passage of time: remove event cards from the forum (§1.07.1)
         game = Game.objects.get(id=game_id)
         for effect_value in game.effects:
-            Log.create_object(game_id, f"The {effect_value} has ended.")
+            base_name = effect_value.split(":")[0]
+            Log.create_object(game_id, f"The {base_name} has ended.")
         game.clear_effects()
         game.save()
 

--- a/backend/rorapp/effects/initiative_next.py
+++ b/backend/rorapp/effects/initiative_next.py
@@ -20,20 +20,12 @@ class InitiativeNextEffect(EffectBase):
 
         for initiative_index in reversed(Faction.INITIATIVE_INDICES):
             for faction in factions:
-                if faction.has_status_item(
-                    FactionStatusItem.initiative(initiative_index)
-                ):
+                if faction.has_initiative(initiative_index):
                     game = Game.objects.get(id=game_id)
                     if initiative_index == Faction.INITIATIVE_INDICES[-1]:
                         # Last initiative has been taken
                         for faction in factions:
-                            for i in Faction.INITIATIVE_INDICES:
-                                if faction.has_status_item(
-                                    FactionStatusItem.initiative(i)
-                                ):
-                                    faction.remove_status_item(
-                                        FactionStatusItem.initiative(i)
-                                    )
+                            faction.clear_initiatives()
                         Faction.objects.bulk_update(factions, ["status_items"])
                         game.phase = Game.Phase.FORUM
                         game.sub_phase = Game.SubPhase.PUTTING_ROME_IN_ORDER
@@ -41,15 +33,11 @@ class InitiativeNextEffect(EffectBase):
                         return True
 
                     # Figure out which faction is next
-                    next_initiative = FactionStatusItem.initiative(initiative_index + 1)
                     next_faction = get_next_faction_in_order(factions, faction.position)
 
-                    if not any(
-                        next_faction.has_status_item(FactionStatusItem.initiative(i))
-                        for i in Faction.INITIATIVE_INDICES
-                    ):
+                    if not next_faction.get_initiatives():
                         # Next faction hasn't yet took an initiative
-                        next_faction.add_status_item(next_initiative)
+                        next_faction.add_initiative(initiative_index + 1)
                         next_faction.add_status_item(
                             FactionStatusItem.CURRENT_INITIATIVE
                         )

--- a/backend/rorapp/effects/initiative_roll.py
+++ b/backend/rorapp/effects/initiative_roll.py
@@ -8,7 +8,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.game_data import (
-    get_senator_code,
+    get_senator_codes,
     load_enemy_leaders,
     load_senators,
 )
@@ -189,7 +189,7 @@ class InitiativeRollEffect(EffectBase):
                             for s in Senator.objects.filter(
                                 game=game_id, alive=True, family=False
                             )
-                            if get_senator_code(s.code)[0] == senator_code
+                            if get_senator_codes(s.code)[0] == senator_code
                         ),
                         None,
                     )

--- a/backend/rorapp/effects/meta/registry.py
+++ b/backend/rorapp/effects/meta/registry.py
@@ -24,6 +24,7 @@ effect_registry: List[Type[EffectBase]] = [
     InitiativeAuctionFirstEffect,
     InitiativeAuctionNextEffect,
     PersuasionAutoSkipEffect,
+    PlayCardsAutoSkipEffect,
     PersuasionCounterBribeFirstEffect,
     PersuasionCounterBribeNextEffect,
     PersuasionDecisionAutoResolveEffect,

--- a/backend/rorapp/effects/mortality.py
+++ b/backend/rorapp/effects/mortality.py
@@ -2,6 +2,7 @@ from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
+from rorapp.helpers.game_data import get_senator_codes
 from rorapp.helpers.kill_senator import kill_senator
 from rorapp.helpers.text import format_list
 from rorapp.models import Game, Senator, Log, War
@@ -18,12 +19,6 @@ class MortalityEffect(EffectBase):
 
     def execute(self, game_id: int, random_resolver: RandomResolver) -> bool:
         game = Game.objects.get(id=game_id)
-
-        # Clear per-turn effects at the start of a new turn
-        for effect_value in game.effects:
-            Log.create_object(game_id, f"The {effect_value} has ended.")
-        game.clear_effects()
-        game.save()
 
         # Activate any imminent wars
         wars = War.objects.filter(game=game_id, status=War.Status.IMMINENT).order_by(
@@ -55,7 +50,7 @@ class MortalityEffect(EffectBase):
         senators = Senator.objects.filter(game=game_id, alive=True)
         codes = random_resolver.draw_mortality_chits()
         for code in codes:
-            victims = [s for s in senators if s.code.startswith(str(code))]
+            victims = [s for s in senators if get_senator_codes(s.code)[0] == str(code)]
             if victims:
                 victim = victims[0]
                 if victim:

--- a/backend/rorapp/effects/play_cards_auto_skip.py
+++ b/backend/rorapp/effects/play_cards_auto_skip.py
@@ -1,0 +1,39 @@
+from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.classes.random_resolver import RandomResolver
+from rorapp.effects.meta.effect_base import EffectBase
+from rorapp.game_state.game_state_snapshot import GameStateSnapshot
+from rorapp.helpers.get_next_faction_in_order import get_next_faction_in_order
+from rorapp.models import Faction, Game, Log
+
+
+class PlayCardsAutoSkipEffect(EffectBase):
+
+    def validate(self, game_state: GameStateSnapshot) -> bool:
+        if game_state.game.sub_phase != Game.SubPhase.PLAY_STATESMEN_CONCESSIONS or game_state.game.phase not in (
+            Game.Phase.INITIAL,
+            Game.Phase.REVOLUTION,
+        ):
+            return False
+
+        current_faction = next(
+            (f for f in game_state.factions if f.has_status_item(FactionStatusItem.AWAITING_DECISION)),
+            None,
+        )
+        return current_faction is not None and len(current_faction.cards) == 0
+
+    def execute(self, game_id: int, random_resolver: RandomResolver) -> bool:
+        factions = Faction.objects.filter(game=game_id)
+        current_faction = factions.get(status_items__contains=[FactionStatusItem.AWAITING_DECISION.value])
+
+        Log.create_object(game_id, f"{current_faction.display_name} has no cards to play.")
+
+        current_faction.add_status_item(FactionStatusItem.DONE)
+        current_faction.remove_status_item(FactionStatusItem.AWAITING_DECISION)
+        current_faction.save()
+
+        next_faction = get_next_faction_in_order(factions, current_faction.position)
+        if not next_faction.has_status_item(FactionStatusItem.DONE):
+            next_faction.add_status_item(FactionStatusItem.AWAITING_DECISION)
+            next_faction.save()
+
+        return True

--- a/backend/rorapp/effects/play_cards_auto_skip.py
+++ b/backend/rorapp/effects/play_cards_auto_skip.py
@@ -25,8 +25,6 @@ class PlayCardsAutoSkipEffect(EffectBase):
         factions = Faction.objects.filter(game=game_id)
         current_faction = factions.get(status_items__contains=[FactionStatusItem.AWAITING_DECISION.value])
 
-        Log.create_object(game_id, f"{current_faction.display_name} has no cards to play.")
-
         current_faction.add_status_item(FactionStatusItem.DONE)
         current_faction.remove_status_item(FactionStatusItem.AWAITING_DECISION)
         current_faction.save()

--- a/backend/rorapp/effects/proposal_raise_forces.py
+++ b/backend/rorapp/effects/proposal_raise_forces.py
@@ -1,5 +1,6 @@
 from typing import List
 from rorapp.classes.concession import Concession
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
@@ -47,9 +48,9 @@ class ProposalRaiseForcesEffect(EffectBase):
                 if unit_type.startswith("fleet"):
                     fleets_to_raise = int(unit_count)
 
-            legions_cost = legions_to_raise * 10
-            fleets_cost = fleets_to_raise * 10
-            total_cost = legions_cost + fleets_cost
+            manpower_shortage_count = game.count_effect(GameEffect.MANPOWER_SHORTAGE)
+            cost_per_unit = 10 * (manpower_shortage_count + 1)
+            total_cost = (legions_to_raise + fleets_to_raise) * cost_per_unit
             game.state_treasury -= total_cost
 
             existing_legions = Legion.objects.filter(game=game)

--- a/backend/rorapp/helpers/end_prosecutions.py
+++ b/backend/rorapp/helpers/end_prosecutions.py
@@ -1,4 +1,5 @@
 from rorapp.models import Game, Senator
+from rorapp.models.log import Log
 
 
 def end_prosecutions(game_id: int) -> None:
@@ -13,7 +14,8 @@ def end_prosecutions(game_id: int) -> None:
             senator.clear_corrupt_concessions()
             senator.save()
 
-    # Return PM to Rome Consul (HRAO)
+    # Return PM to HRAO
+    hrao = None
     for senator in senators:
         if senator.has_title(Senator.Title.CENSOR):
             senator.remove_title(Senator.Title.PRESIDING_MAGISTRATE)
@@ -21,6 +23,13 @@ def end_prosecutions(game_id: int) -> None:
         if senator.has_title(Senator.Title.HRAO):
             senator.add_title(Senator.Title.PRESIDING_MAGISTRATE)
             senator.save()
+            hrao = senator
+
+    if hrao:
+        Log.create_object(
+            game_id,
+            f"With prosecutions over, {hrao.display_name} took over as presiding magistrate.",
+        )
 
     # Reset prosecution tracking
     game.prosecutions_remaining = 0

--- a/backend/rorapp/helpers/game_data.py
+++ b/backend/rorapp/helpers/game_data.py
@@ -21,7 +21,7 @@ def load_enemy_leaders() -> dict:
         return json.load(f)
 
 
-def get_senator_code(statesman_code: str) -> tuple[str, str]:
-    family_code = statesman_code.rstrip("abcdefghijklmnopqrstuvwxyz")
-    statesman_letter = statesman_code[len(family_code) :]
+def get_senator_codes(full_code: str) -> tuple[str, str]:
+    family_code = full_code.rstrip("abcdefghijklmnopqrstuvwxyz")
+    statesman_letter = full_code[len(family_code) :]
     return family_code, statesman_letter

--- a/backend/rorapp/helpers/hrao.py
+++ b/backend/rorapp/helpers/hrao.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from rorapp.helpers.game_data import get_senator_code
+from rorapp.helpers.game_data import get_senator_codes
 from rorapp.models import Faction, Game, Log, Senator
 
 
@@ -29,7 +29,7 @@ def highest_ranking_senator(
             if s.has_title(office):
                 office_rank = rank
                 break
-        family_code, statesman_letter = get_senator_code(s.code)
+        family_code, statesman_letter = get_senator_codes(s.code)
         return (
             office_rank,
             -s.influence,
@@ -70,5 +70,5 @@ def set_hrao(game_id) -> None:
         faction = Faction.objects.get(game=game_id, id=selected_hrao.faction.id)
         Log.create_object(
             game_id=game.id,
-            text=f"{selected_hrao.display_name} of {faction.display_name} is the new HRAO.",
+            text=f"{selected_hrao.display_name} of {faction.display_name} became HRAO.",
         )

--- a/backend/rorapp/helpers/kill_senator.py
+++ b/backend/rorapp/helpers/kill_senator.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from rorapp.classes.concession import Concession
-from rorapp.helpers.game_data import get_senator_code, load_senators
+from rorapp.helpers.game_data import get_senator_codes, load_senators
 from rorapp.helpers.hrao import set_hrao
 from rorapp.helpers.text import format_list
 from rorapp.models import Campaign, Faction, Fleet, Game, Legion, Log, Senator
@@ -25,7 +25,7 @@ def kill_senator(senator: Senator, cause_of_death: CauseOfDeath = CauseOfDeath.N
     campaigns: List[Campaign] = []
 
     senators_dict = load_senators()
-    family_code = get_senator_code(senator.code)[0]
+    family_code = get_senator_codes(senator.code)[0]
     senator_data = next(
         (v for v in senators_dict.values() if v["code"] == int(family_code)),
         None,

--- a/backend/rorapp/helpers/resolve_combat.py
+++ b/backend/rorapp/helpers/resolve_combat.py
@@ -1,7 +1,7 @@
 import math
 from typing import List
 from rorapp.classes.random_resolver import RandomResolver
-from rorapp.helpers.game_data import load_statesmen
+from rorapp.helpers.game_data import get_senator_codes, load_statesmen
 from rorapp.helpers.kill_senator import CauseOfDeath, kill_senator
 from rorapp.helpers.text import format_list
 from rorapp.helpers.unit_lists import unit_list_to_string
@@ -279,7 +279,7 @@ def resolve_combat(
         commander_killed = True
     else:
         codes = random_resolver.draw_mortality_chits(fleet_losses + legion_losses)
-        if any(commander.code.startswith(str(c)) for c in codes):
+        if get_senator_codes(commander.code)[0] in {str(c) for c in codes}:
             commander_killed = True
     if commander_killed:
         kill_senator(commander, CauseOfDeath.BATTLE)

--- a/backend/rorapp/models/faction.py
+++ b/backend/rorapp/models/faction.py
@@ -57,6 +57,26 @@ class Faction(models.Model):
         status_value = status.value if isinstance(status, FactionStatusItem) else status
         return status_value in self.status_items
 
+    # Initiative status_items helpers
+
+    def get_initiatives(self) -> List[int]:
+        return [
+            int(status.split(" ")[1])
+            for status in self.status_items
+            if status.startswith("initiative")
+        ]
+
+    def add_initiative(self, n: int) -> None:
+        self.status_items.append(FactionStatusItem.initiative(n))
+
+    def has_initiative(self, n: int) -> bool:
+        return FactionStatusItem.initiative(n) in self.status_items
+
+    def clear_initiatives(self) -> None:
+        self.status_items = [
+            s for s in self.status_items if not s.startswith("initiative")
+        ]
+
     # Bid amount status_items helpers
 
     def get_bid_amount(self) -> Optional[int]:

--- a/backend/rorapp/models/game.py
+++ b/backend/rorapp/models/game.py
@@ -158,21 +158,40 @@ class Game(models.Model):
 
     # effects methods
 
+    def _get_effect_entry(self, effect: GameEffect) -> "str | None":
+        base = effect.value
+        for entry in self.effects:
+            if entry == base or entry.startswith(f"{base}:"):
+                return entry
+        return None
+
     def add_effect(self, effect: GameEffect) -> None:
-        self.effects.append(effect.value)
+        entry = self._get_effect_entry(effect)
+        if entry is None:
+            self.effects.append(effect.value)
+        else:
+            level = self.count_effect(effect)
+            self.effects.remove(entry)
+            self.effects.append(f"{effect.value}:{level + 1}")
 
     def remove_effect(self, effect: GameEffect) -> None:
-        if effect.value in self.effects:
-            self.effects.remove(effect.value)
+        entry = self._get_effect_entry(effect)
+        if entry is not None:
+            self.effects.remove(entry)
 
     def clear_effects(self) -> None:
         self.effects = []
 
     def has_effect(self, effect: GameEffect) -> bool:
-        return effect.value in self.effects
+        return self._get_effect_entry(effect) is not None
 
     def count_effect(self, effect: GameEffect) -> int:
-        return self.effects.count(effect.value)
+        entry = self._get_effect_entry(effect)
+        if entry is None:
+            return 0
+        if ":" in entry:
+            return int(entry.split(":")[1])
+        return 1
 
     # defeated_proposals methods
 

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_1_passage_of_time_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_1_passage_of_time_test.py
@@ -1,0 +1,25 @@
+import pytest
+from rorapp.classes.game_effect_item import GameEffect
+from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
+from rorapp.models import Game, Senator
+
+
+@pytest.mark.django_db
+def test_effects_are_cleared_at_start_of_forum_phase(basic_game: Game):
+    # Arrange
+    game = basic_game
+    game.phase = Game.Phase.FORUM
+    game.sub_phase = Game.SubPhase.START
+    game.add_effect(GameEffect.MANPOWER_SHORTAGE)
+    game.save()
+
+    senator = Senator.objects.filter(game=game, alive=True).first()
+    senator.add_title(Senator.Title.HRAO)
+    senator.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.effects == []

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_1_passage_of_time_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_1_passage_of_time_test.py
@@ -14,6 +14,7 @@ def test_effects_are_cleared_at_start_of_forum_phase(basic_game: Game):
     game.save()
 
     senator = Senator.objects.filter(game=game, alive=True).first()
+    assert senator is not None
     senator.add_title(Senator.Title.HRAO)
     senator.save()
 

--- a/backend/tests/s1_basic_game/s1_11_revolution_phase/s1_11_1_play_statesmen_concessions_test.py
+++ b/backend/tests/s1_basic_game/s1_11_revolution_phase/s1_11_1_play_statesmen_concessions_test.py
@@ -19,6 +19,27 @@ def _setup_play_phase(game: Game, faction: Faction, cards: list):
 
 
 @pytest.mark.django_db
+def test_faction_with_no_cards_is_auto_skipped(basic_game: Game):
+    # Arrange
+    game = basic_game
+    faction1: Faction = game.factions.get(position=1)
+    faction2: Faction = game.factions.get(position=2)
+    _setup_play_phase(game, faction1, [])
+    faction2.cards = ["statesman:1a"]  # prevent faction2 from also being auto-skipped
+    faction2.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    faction1.refresh_from_db()
+    faction2.refresh_from_db()
+    assert faction1.has_status_item(FactionStatusItem.DONE)
+    assert not faction1.has_status_item(FactionStatusItem.AWAITING_DECISION)
+    assert faction2.has_status_item(FactionStatusItem.AWAITING_DECISION)
+
+
+@pytest.mark.django_db
 def test_revolution_start_enters_card_trading(revolution_game: Game):
     # Arrange
     game = revolution_game

--- a/backend/tests/s3_scenarios/s3_01_early_republic/s3_01_9_initial_faction_phase_test.py
+++ b/backend/tests/s3_scenarios/s3_01_early_republic/s3_01_9_initial_faction_phase_test.py
@@ -127,6 +127,7 @@ def test_initial_phase_done_advances_to_play_cards(basic_game: Game, resolver: F
         faction.add_status_item(FactionStatusItem.DONE)
         faction.save()
 
+    assert julius.faction_id is not None
     hrao_faction = Faction.objects.get(id=julius.faction_id)
     hrao_faction.cards = ["statesman:1a"]
     hrao_faction.save()

--- a/backend/tests/s3_scenarios/s3_01_early_republic/s3_01_9_initial_faction_phase_test.py
+++ b/backend/tests/s3_scenarios/s3_01_early_republic/s3_01_9_initial_faction_phase_test.py
@@ -127,6 +127,10 @@ def test_initial_phase_done_advances_to_play_cards(basic_game: Game, resolver: F
         faction.add_status_item(FactionStatusItem.DONE)
         faction.save()
 
+    hrao_faction = Faction.objects.get(id=julius.faction_id)
+    hrao_faction.cards = ["statesman:1a"]
+    hrao_faction.save()
+
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
 

--- a/frontend/components/CombatCalculatorItem.tsx
+++ b/frontend/components/CombatCalculatorItem.tsx
@@ -253,15 +253,13 @@ const CombatCalculatorItem = ({
             className="rounded-md border border-blue-600 p-1 disabled:cursor-not-allowed disabled:bg-neutral-100"
           >
             <option value="">-- select an option --</option>
-            {publicGameState.senators?.map(
-              (senator: Senator, index: number) => (
-                <option key={index} value={senator.id}>
-                  <>
-                    {senator?.displayName} ({senator.military})
-                  </>
+            {[...publicGameState.senators]
+              .sort((a, b) => a.familyName.localeCompare(b.familyName))
+              .map((senator: Senator) => (
+                <option key={senator.id} value={senator.id}>
+                  {senator.displayName} ({senator.military})
                 </option>
-              ),
-            )}
+              ))}
           </select>
         </div>
         <div className="flex flex-col gap-1">

--- a/frontend/components/GameContainer.tsx
+++ b/frontend/components/GameContainer.tsx
@@ -16,10 +16,11 @@ import { getDeployedForces } from "@/helpers/deploymentProposal"
 import getDiceProbability from "@/helpers/dice"
 import { forceListToString } from "@/helpers/forceLists"
 import { STATESMAN_ABILITIES } from "@/helpers/statesmen"
-import { formatList, toSentenceCase } from "@/helpers/text"
+import { formatList, toFamilyAdjective, toSentenceCase } from "@/helpers/text"
 
 import ActionDispatcher from "./ActionDispatcher"
 import CombatCalculator from "./CombatCalculator"
+import GameEffects from "./GameEffects"
 import { ActionSelection } from "./GenericActionForm"
 import LogList from "./LogList"
 import SenatorDisplay from "./SenatorDisplay"
@@ -237,33 +238,29 @@ const GameContainer = ({
                     </div>
                   </div>
 
-                  {publicGameState.game.effects.length > 0 && (
-                    <div>
-                      Effects:
-                      <ul>
-                        {publicGameState.game.effects.map((effects, index) => (
-                          <li
-                            key={index}
-                            className="ml-10 list-disc first-letter:uppercase"
-                          >
-                            {effects}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
+                  <GameEffects effects={publicGameState.game.effects} />
 
                   <div>
-                    Reserve forces: {reserveLegions.length}{" "}
-                    {reserveLegions.length == 1 ? "legion" : "legions"}
-                    {reserveLegions.length > 0 && (
-                      <> ({forceListToString(reserveLegions)})</>
-                    )}
-                    {" and "}
-                    {reserveFleets.length}{" "}
-                    {reserveFleets.length == 1 ? "fleet" : "fleets"}
-                    {reserveFleets.length > 0 && (
-                      <> ({forceListToString(reserveFleets)})</>
+                    Reserve forces:
+                    {reserveLegions.length === 0 && reserveFleets.length === 0 ? (
+                      " none"
+                    ) : (
+                      <ul>
+                        {reserveLegions.length > 0 && (
+                          <li className="ml-10 list-disc">
+                            {reserveLegions.length}{" "}
+                            {reserveLegions.length === 1 ? "legion" : "legions"}{" "}
+                            <span className="text-neutral-600">({forceListToString(reserveLegions)})</span>
+                          </li>
+                        )}
+                        {reserveFleets.length > 0 && (
+                          <li className="ml-10 list-disc">
+                            {reserveFleets.length}{" "}
+                            {reserveFleets.length === 1 ? "fleet" : "fleets"}{" "}
+                            <span className="text-neutral-600">({forceListToString(reserveFleets)})</span>
+                          </li>
+                        )}
+                      </ul>
                     )}
                   </div>
                   {publicGameState.game.concessions.length > 0 && (
@@ -289,7 +286,7 @@ const GameContainer = ({
                   {publicGameState.senators.filter((s) => !s.alive).length >
                     0 && (
                     <div>
-                      Dead senators:
+                      Families that may return to politics:
                       <ul>
                         {publicGameState.senators
                           .filter((s) => !s.alive)
@@ -298,7 +295,7 @@ const GameContainer = ({
                           )
                           .map((senator, index) => (
                             <li key={index} className="ml-10 list-disc">
-                              {senator.familyName}
+                              {toFamilyAdjective(senator.familyName)} family
                             </li>
                           ))}
                       </ul>
@@ -839,7 +836,9 @@ const GameContainer = ({
                               setExpandedActionId(expanded ? id : null)
                             }
                             resetKey={actionResetKey}
-                            onSubmitSuccess={() => handleActionSubmitSuccess(id)}
+                            onSubmitSuccess={() =>
+                              handleActionSubmitSuccess(id)
+                            }
                           />
                         )
                       })

--- a/frontend/components/GameEffects.tsx
+++ b/frontend/components/GameEffects.tsx
@@ -1,0 +1,67 @@
+type EffectFormatter = {
+  label: (level: number) => string
+  annotation?: (level: number) => string
+}
+
+const EFFECT_FORMATTERS: Record<string, EffectFormatter> = {
+  "manpower shortage": {
+    label: (level) =>
+      level === 1 ? "Manpower shortage" : "Increased manpower shortage",
+    annotation: (level) => `+${level * 10}T legion/fleet cost`,
+  },
+}
+
+const parseEffect = (
+  effectString: string,
+): { baseName: string; level: number } => {
+  const colonIndex = effectString.indexOf(":")
+  return {
+    baseName:
+      colonIndex >= 0 ? effectString.slice(0, colonIndex) : effectString,
+    level:
+      colonIndex >= 0 ? parseInt(effectString.slice(colonIndex + 1), 10) : 1,
+  }
+}
+
+const formatEffect = (
+  effectString: string,
+): { label: string; annotation?: string } => {
+  const { baseName, level } = parseEffect(effectString)
+  const formatter = EFFECT_FORMATTERS[baseName]
+  if (formatter) {
+    return {
+      label: formatter.label(level),
+      annotation: formatter.annotation?.(level),
+    }
+  }
+  return { label: baseName.charAt(0).toUpperCase() + baseName.slice(1) }
+}
+
+interface GameEffectsProps {
+  effects: string[]
+}
+
+const GameEffects = ({ effects }: GameEffectsProps) => {
+  if (effects.length === 0) return null
+
+  return (
+    <div>
+      Effects:
+      <ul>
+        {effects.map((effect, index) => {
+          const { label, annotation } = formatEffect(effect)
+          return (
+            <li key={index} className="ml-10 list-disc">
+              {label}
+              {annotation && (
+                <span className="text-neutral-600"> ({annotation})</span>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export default GameEffects


### PR DESCRIPTION
- Add logs for presiding magistrate transitions related to the prosecution sub-phase.
- Move "passage of time" from mortality to start of forum phase, where it belongs.
- Sort senators properly in the combat calculator UI.
- Refactor initiative status item helpers.
- Improve appearance of effects and reserve forces in UI.
- Make manpower shortage level matter for legion and fleet cost.
- Add auto skip effect to bypass play statesmen/concessions if the faction has 0 cards.