### PR TITLE
chore: specify production environment for deploy backend workflow

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy_backend:
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - name: Checkout


### PR DESCRIPTION
I have created a `production` GitHub environment with deployment protection rules that prevent anyone other than me from running workflows that use it. The final step (this PR) is to configure the deploy backend workflow to use that environment.