### PR TITLE
ci: file change based filtering

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -1,4 +1,4 @@
-name: Build and test backend
+name: CI backend
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ jobs:
             backend:
               - 'backend/**'
 
-  ci_backend:
+  build_and_test:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -8,7 +8,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.changes.outputs.backend }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+
   ci_backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -1,4 +1,4 @@
-name: Build and test frontend
+name: CI frontend
 
 on:
   pull_request:
@@ -21,7 +21,7 @@ jobs:
               - 'frontend/**'
               - 'backend/**'
 
-  ci_frontend:
+  build_and_test:
     needs: changes
     if: needs.changes.outputs.frontend_or_backend == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -8,7 +8,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      frontend_or_backend: ${{ steps.changes.outputs.frontend_or_backend }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            frontend_or_backend:
+              - 'frontend/**'
+              - 'backend/**'
+
   ci_frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend_or_backend == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This change will allow CI checks to be skipped if the changes in the PR are irrelevant. For example:

- The backend CI check doesn't need to build and run tests if the PR only changes frontend code
- The frontend CI check doesn't need to build and run tests if the PR only changes rorcli code

The [Paths Changes Filter](https://github.com/dorny/paths-filter) is used rather than a trigger-level filter because both CI checks (`ci_frontend` and `ci_backend`) are required for the Ruleset that protects the `main` branch.