### PR TITLE
chore: rename CI jobs

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -6,7 +6,6 @@ on:
       - main
 
   workflow_dispatch:
-  
 
 jobs:
   ci_backend_filter:

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -8,21 +8,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  changes:
+  ci_backend_filter:
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.changes.outputs.backend }}
+      file_changes: ${{ steps.changes.outputs.file_changes }}
     steps:
       - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
-            backend:
+            file_changes:
               - 'backend/**'
 
   build_and_test:
-    needs: changes
-    if: needs.changes.outputs.backend == 'true'
+    needs: ci_backend_filter
+    if: needs.ci_backend_filter.outputs.file_changes == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -6,6 +6,7 @@ on:
       - main
 
   workflow_dispatch:
+  
 
 jobs:
   ci_backend_filter:

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -7,7 +7,6 @@ on:
 
   workflow_dispatch:
 
-
 jobs:
   ci_backend_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -7,6 +7,7 @@ on:
 
   workflow_dispatch:
 
+
 jobs:
   ci_backend_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -8,22 +8,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  changes:
+  ci_frontend_filter:
     runs-on: ubuntu-latest
     outputs:
-      frontend_or_backend: ${{ steps.changes.outputs.frontend_or_backend }}
+      file_changes: ${{ steps.changes.outputs.file_changes }}
     steps:
       - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
-            frontend_or_backend:
+            file_changes:
               - 'frontend/**'
               - 'backend/**'
 
   build_and_test:
-    needs: changes
-    if: needs.changes.outputs.frontend_or_backend == 'true'
+    needs: ci_frontend_filter
+    if: needs.ci_frontend_filter.outputs.file_changes == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This allows branch protection rules to differentiate frontend/backend CI jobs:

<img width="1093" height="722" alt="image" src="https://github.com/user-attachments/assets/e752b26b-91fa-43ff-b679-28952a13dc18" />
