### PR TITLE
feat: add database reset script

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,14 +5,14 @@ dj-database-url==2.2.0
 django==5.1.15
 django-allauth[socialaccount]==65.14.1
 django-cors-headers==4.4.0
+django-extensions==4.1
 django-stubs[compatible-mypy]==5.0.2
 djangorestframework==3.15.2
 djangorestframework-stubs[compatible-mypy]==3.15.0
 mypy==1.10.1
 psycopg2-binary==2.9.9
-python-dotenv==1.2.2
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-django==4.8.0
+python-dotenv==1.2.2
 roman==5.0
-django-extensions==4.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-django==4.8.0
 roman==5.0
+django-extensions==4.1

--- a/backend/reset_db.py
+++ b/backend/reset_db.py
@@ -1,0 +1,42 @@
+"""
+Wipes the database, runs all migrations, and creates a superuser.
+
+Usage: python reset_db.py
+Superuser credentials after reset: admin / password
+"""
+
+import os
+import subprocess
+import sys
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(script_dir)
+
+for candidate in [
+    os.path.join(script_dir, ".venv", "Scripts", "python.exe"),  # Windows
+    os.path.join(script_dir, ".venv", "bin", "python"),  # Unix/Mac
+]:
+    if os.path.exists(candidate):
+        python = candidate
+        break
+else:
+    python = sys.executable
+
+subprocess.run([python, "manage.py", "reset_db", "--noinput"], check=True)
+subprocess.run([python, "manage.py", "migrate"], check=True)
+subprocess.run(
+    [
+        python,
+        "manage.py",
+        "createsuperuser",
+        "--noinput",
+        "--username",
+        "admin",
+        "--email",
+        "admin@example.com",
+    ],
+    env={**os.environ, "DJANGO_SUPERUSER_PASSWORD": "password"},
+    check=True,
+)
+
+print("\nDone")

--- a/backend/rorsite/settings.py
+++ b/backend/rorsite/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "allauth.headless",
     "allauth.socialaccount",
     "allauth.socialaccount.providers.google",
+    "django_extensions",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
This script wipes the local database and rebuilds it from scratch, which is useful when switching between feature branches during development.

Adds a new requirement. Run `pip install -r requirements.txt` to ensure the `django_extensions` module is installed.