### PR TITLE
feat: enable allied enthusiasm

### DIFF
--- a/backend/rorapp/classes/game_effect_item.py
+++ b/backend/rorapp/classes/game_effect_item.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class GameEffect(Enum):
+    ALLIED_ENTHUSIASM = "allied enthusiasm"
     MANPOWER_SHORTAGE = "manpower shortage"
     NO_RECRUITMENT = "no recruitment"
     LAND_BILL_1 = "land bill I"

--- a/backend/rorapp/data/event.json
+++ b/backend/rorapp/data/event.json
@@ -1,0 +1,20 @@
+{
+  "early_republic": {
+    "3": "Mob Violence",
+    "4": "Natural Disaster",
+    "5": "Ally Deserts",
+    "6": "Evil Omens",
+    "7": "Refuge",
+    "8": "Epidemic",
+    "9": "Drought",
+    "10": "Evil Omens",
+    "11": "Storm at Sea",
+    "12": "Manpower Shortage",
+    "13": "Allied enthusiasm",
+    "14": "New Alliance",
+    "15": "Rhodian Alliance",
+    "16": "Enemy's Ally Deserts",
+    "17": "Enemy Leader Dies",
+    "18": "Trial of Verres"
+  }
+}

--- a/backend/rorapp/effects/initiative_roll.py
+++ b/backend/rorapp/effects/initiative_roll.py
@@ -45,9 +45,7 @@ class InitiativeRollEffect(EffectBase):
             events = load_events()
             event_name = events["early_republic"].get(str(event_roll), "Unknown Event")
             if handle_event(game, current_faction, event_name):
-                game.sub_phase = Game.SubPhase.PERSUASION_ATTEMPT
-                game.save()
-            return True
+                return True
 
         next_card = game.draw_card()
         if next_card is not None:

--- a/backend/rorapp/effects/initiative_roll.py
+++ b/backend/rorapp/effects/initiative_roll.py
@@ -44,10 +44,10 @@ class InitiativeRollEffect(EffectBase):
             event_roll = random_resolver.roll_dice(count=3)
             events = load_events()
             event_name = events["early_republic"].get(str(event_roll), "Unknown Event")
-            if handle_event(game, game_id, current_faction.display_name, event_name):
+            if handle_event(game, current_faction, event_name):
                 game.sub_phase = Game.SubPhase.PERSUASION_ATTEMPT
                 game.save()
-                return True
+            return True
 
         next_card = game.draw_card()
         if next_card is not None:

--- a/backend/rorapp/effects/initiative_roll.py
+++ b/backend/rorapp/effects/initiative_roll.py
@@ -10,8 +10,10 @@ from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.game_data import (
     get_senator_codes,
     load_enemy_leaders,
+    load_events,
     load_senators,
 )
+from rorapp.helpers.handle_event import handle_event
 from rorapp.helpers.text import format_list, to_family_adjective
 from rorapp.models import EnemyLeader, Faction, Game, Log, Senator, War
 
@@ -36,6 +38,16 @@ class InitiativeRollEffect(EffectBase):
 
         if not current_faction:
             return False
+
+        initiative = random_resolver.roll_dice(count=2)
+        if initiative == 7:
+            event_roll = random_resolver.roll_dice(count=3)
+            events = load_events()
+            event_name = events["early_republic"].get(str(event_roll), "Unknown Event")
+            if handle_event(game, game_id, current_faction.display_name, event_name):
+                game.sub_phase = Game.SubPhase.PERSUASION_ATTEMPT
+                game.save()
+                return True
 
         next_card = game.draw_card()
         if next_card is not None:

--- a/backend/rorapp/effects/revenue.py
+++ b/backend/rorapp/effects/revenue.py
@@ -74,7 +74,7 @@ class RevenueEffect(EffectBase):
             game.remove_effect(GameEffect.ALLIED_ENTHUSIASM)
             Log.create_object(
                 game_id=game.id,
-                text=f"Allied enthusiasm granted {enthusiasm_bonus}T to the State.",
+                text=f"The State received an additional {enthusiasm_bonus}T due to {'extreme ' if allied_enthusiasm_level >= 2 else ''}allied enthusiasm.",
             )
 
         # Senators earn personal revenue

--- a/backend/rorapp/effects/revenue.py
+++ b/backend/rorapp/effects/revenue.py
@@ -67,6 +67,16 @@ class RevenueEffect(EffectBase):
         state_text += "."
         Log.create_object(game_id=game.id, text=state_text)
 
+        allied_enthusiasm_level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
+        if allied_enthusiasm_level > 0:
+            enthusiasm_bonus = 75 if allied_enthusiasm_level >= 2 else 50
+            game.state_treasury += enthusiasm_bonus
+            game.remove_effect(GameEffect.ALLIED_ENTHUSIASM)
+            Log.create_object(
+                game_id=game.id,
+                text=f"Allied enthusiasm granted {enthusiasm_bonus}T to the State.",
+            )
+
         # Senators earn personal revenue
         factions = Faction.objects.filter(game=game_id).order_by("position")
         for faction in factions:

--- a/backend/rorapp/helpers/game_data.py
+++ b/backend/rorapp/helpers/game_data.py
@@ -21,6 +21,12 @@ def load_enemy_leaders() -> dict:
         return json.load(f)
 
 
+def load_events() -> dict:
+    path = os.path.join(settings.BASE_DIR, "rorapp", "data", "event.json")
+    with open(path, "r") as f:
+        return json.load(f)
+
+
 def load_land_bills() -> dict:
     path = os.path.join(settings.BASE_DIR, "rorapp", "data", "land_bill.json")
     with open(path, "r") as f:

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -3,13 +3,16 @@ from rorapp.models import Faction, Game, Log
 
 
 def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
-    """Apply the event effect. Returns True if initiative can continue immediately, False if not."""
+    """Apply the event effect. Returns True if the event is implemented, False if not."""
     if event_name == "Allied enthusiasm":
-        return handle_allied_enthusiasm(game, current_faction)
+        handle_allied_enthusiasm(game, current_faction)
+        game.sub_phase = Game.SubPhase.PERSUASION_ATTEMPT
+        game.save()
+        return True
     return False
 
 
-def handle_allied_enthusiasm(game: Game, current_faction: Faction) -> bool:
+def handle_allied_enthusiasm(game: Game, current_faction: Faction):
     level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
         
     if level < 2:
@@ -32,4 +35,3 @@ def handle_allied_enthusiasm(game: Game, current_faction: Faction) -> bool:
             game.id,
             f"{prefix} Rome's allies are already extremely enthusiastic so there is no additional effect.",
         )
-    return True

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -17,7 +17,7 @@ def handle_event(
             bonus = 50 if new_level == 1 else 75
             Log.create_object(
                 game_id,
-                f"{faction_display_name} triggered {card_name}. The State will receive {bonus}T in the next revenue phase.",
+                f"{faction_display_name} drew {card_name}. The State will receive {bonus}T in the next revenue phase.",
             )
         return True
     return False

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -14,11 +14,11 @@ def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
 
 def handle_allied_enthusiasm(game: Game, current_faction: Faction):
     level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
-        
+
     if level < 2:
         game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
         game.save()
-    
+
     prefix = f"{current_faction.display_name} drew allied enthusiasm."
     if level == 0:
         Log.create_object(

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -1,0 +1,23 @@
+from rorapp.classes.game_effect_item import GameEffect
+from rorapp.models import Game, Log
+
+
+def handle_event(
+    game: Game, game_id: int, faction_display_name: str, event_name: str
+) -> bool:
+    """Apply the event effect. Returns True if the event is implemented, False if not."""
+    if event_name == "Allied enthusiasm":
+        level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
+        if level < 2:
+            game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+            new_level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
+            card_name = (
+                "Allied enthusiasm" if new_level == 1 else "Extreme allied enthusiasm"
+            )
+            bonus = 50 if new_level == 1 else 75
+            Log.create_object(
+                game_id,
+                f"{faction_display_name} triggered {card_name}. The State will receive {bonus}T in the next revenue phase.",
+            )
+        return True
+    return False

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -1,23 +1,35 @@
 from rorapp.classes.game_effect_item import GameEffect
-from rorapp.models import Game, Log
+from rorapp.models import Faction, Game, Log
 
 
-def handle_event(
-    game: Game, game_id: int, faction_display_name: str, event_name: str
-) -> bool:
-    """Apply the event effect. Returns True if the event is implemented, False if not."""
+def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
+    """Apply the event effect. Returns True if initiative can continue immediately, False if not."""
     if event_name == "Allied enthusiasm":
-        level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
-        if level < 2:
-            game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
-            new_level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
-            card_name = (
-                "allied enthusiasm" if new_level == 1 else "extreme allied enthusiasm"
-            )
-            bonus = 50 if new_level == 1 else 75
-            Log.create_object(
-                game_id,
-                f"{faction_display_name} drew {card_name}. The State will receive {bonus}T in the next revenue phase.",
-            )
-        return True
+        return handle_allied_enthusiasm(game, current_faction)
     return False
+
+
+def handle_allied_enthusiasm(game: Game, current_faction: Faction) -> bool:
+    level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
+        
+    if level < 2:
+        game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+        game.save()
+    
+    prefix = f"{current_faction.display_name} drew allied enthusiasm."
+    if level == 0:
+        Log.create_object(
+            game.id,
+            f"{prefix} With Rome's allies contributing additional funds, the State will receive 50T in the next revenue phase.",
+        )
+    elif level == 1:
+        Log.create_object(
+            game.id,
+            f"{prefix} With Rome's allies already enthusiastic, they are now extremely enthusiastic. The State will receive 75T in the next revenue phase.",
+        )
+    else:
+        Log.create_object(
+            game.id,
+            f"{prefix} Rome's allies are already extremely enthusiastic so there is no additional effect.",
+        )
+    return True

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -12,7 +12,7 @@ def handle_event(
             game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
             new_level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
             card_name = (
-                "Allied enthusiasm" if new_level == 1 else "Extreme allied enthusiasm"
+                "allied enthusiasm" if new_level == 1 else "extreme allied enthusiasm"
             )
             bonus = 50 if new_level == 1 else 75
             Log.create_object(

--- a/backend/tests/s1_basic_game/s1_06_revenue_phase/s1_06_54_allied_enthusiasm_test.py
+++ b/backend/tests/s1_basic_game/s1_06_revenue_phase/s1_06_54_allied_enthusiasm_test.py
@@ -1,0 +1,50 @@
+import pytest
+from rorapp.classes.game_effect_item import GameEffect
+from rorapp.models import Game
+from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
+
+
+@pytest.mark.django_db
+def test_allied_enthusiasm_grants_50T_to_state(revenue_game: Game):
+    # Arrange
+    game = revenue_game
+    game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+    game.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.state_treasury == 350  # 200 + 100 base + 50 enthusiasm
+
+
+@pytest.mark.django_db
+def test_extreme_allied_enthusiasm_grants_75T_to_state(revenue_game: Game):
+    # Arrange
+    game = revenue_game
+    game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+    game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+    game.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.state_treasury == 375  # 200 + 100 base + 75 enthusiasm
+
+
+@pytest.mark.django_db
+def test_allied_enthusiasm_effect_removed_after_revenue(revenue_game: Game):
+    # Arrange
+    game = revenue_game
+    game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+    game.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.count_effect(GameEffect.ALLIED_ENTHUSIASM) == 0

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
@@ -1,0 +1,111 @@
+import pytest
+from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.classes.game_effect_item import GameEffect
+from rorapp.classes.random_resolver import FakeRandomResolver
+from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
+from rorapp.models import Faction, Game
+
+
+def _setup_initiative_roll(game: Game, faction: Faction) -> None:
+    game.phase = Game.Phase.FORUM
+    game.sub_phase = Game.SubPhase.INITIATIVE_ROLL
+    game.deck = ["senator:18"]
+    game.save()
+    faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
+    faction.save()
+
+
+@pytest.mark.django_db
+def test_rolling_7_on_initiative_triggers_allied_enthusiasm(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 13]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.has_effect(GameEffect.ALLIED_ENTHUSIASM)
+    assert game.count_effect(GameEffect.ALLIED_ENTHUSIASM) == 1
+
+
+@pytest.mark.django_db
+def test_rolling_7_does_not_draw_a_card(basic_game: Game, resolver: FakeRandomResolver):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 13]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert len(game.deck) == 1
+
+
+@pytest.mark.django_db
+def test_drawing_allied_enthusiasm_twice_escalates_to_extreme(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 13]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.count_effect(GameEffect.ALLIED_ENTHUSIASM) == 2
+
+
+@pytest.mark.django_db
+def test_rolling_unimplemented_event_draws_a_card_instead(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [
+        7,
+        12,
+    ]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert len(game.deck) == 0
+
+
+@pytest.mark.django_db
+def test_drawing_allied_enthusiasm_at_max_has_no_effect(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+    game.add_effect(GameEffect.ALLIED_ENTHUSIASM)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 13]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.count_effect(GameEffect.ALLIED_ENTHUSIASM) == 2

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_33_wars_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_33_wars_test.py
@@ -22,6 +22,7 @@ def test_drawing_war_with_no_matching_war_creates_inactive_war(
     game = basic_game
     faction: Faction = game.factions.get(position=1)
     _setup_initiative_roll(game, faction, ["war:1st Punic War"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -39,6 +40,7 @@ def test_drawing_immediately_active_war_creates_active_war(
     game = basic_game
     faction: Faction = game.factions.get(position=1)
     _setup_initiative_roll(game, faction, ["war:2nd Punic War"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -70,6 +72,7 @@ def test_drawing_war_matching_existing_inactive_war_becomes_imminent(
         status=War.Status.INACTIVE,
     )
     _setup_initiative_roll(game, faction, ["war:1st Punic War"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -103,6 +106,7 @@ def test_drawing_war_matching_existing_active_war_becomes_imminent(
         status=War.Status.ACTIVE,
     )
     _setup_initiative_roll(game, faction, ["war:1st Punic War"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -131,6 +135,7 @@ def test_drawing_war_with_inactive_leader_activates_leader(
         active=False,
     )
     _setup_initiative_roll(game, faction, ["war:1st Punic War"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -158,6 +163,7 @@ def test_drawing_immediately_active_war_with_inactive_leader_creates_active_war(
         active=False,
     )
     _setup_initiative_roll(game, faction, ["war:2nd Punic War"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_34_enemy_leaders_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_34_enemy_leaders_test.py
@@ -22,6 +22,7 @@ def test_drawing_leader_with_no_matching_wars_creates_inactive_leader(
     game = basic_game
     faction: Faction = game.factions.get(position=1)
     _setup_initiative_roll(game, faction, ["leader:Hannibal"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -53,6 +54,7 @@ def test_drawing_leader_with_matching_active_war_creates_active_leader(
         status=War.Status.ACTIVE,
     )
     _setup_initiative_roll(game, faction, ["leader:Hannibal"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -84,6 +86,7 @@ def test_drawing_leader_with_matching_inactive_war_activates_war_and_leader(
         status=War.Status.INACTIVE,
     )
     _setup_initiative_roll(game, faction, ["leader:Hannibal"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -117,6 +120,7 @@ def test_drawing_leader_with_only_imminent_matching_war_creates_inactive_leader(
         status=War.Status.IMMINENT,
     )
     _setup_initiative_roll(game, faction, ["leader:Hannibal"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -164,6 +168,7 @@ def test_drawing_leader_with_multiple_inactive_matching_wars_activates_all(
         status=War.Status.INACTIVE,
     )
     _setup_initiative_roll(game, faction, ["leader:Hannibal"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -185,6 +190,7 @@ def test_drawing_leader_uses_correct_stats_from_game_data(
     game = basic_game
     faction: Faction = game.factions.get(position=1)
     _setup_initiative_roll(game, faction, ["leader:Hamilcar"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_3_initiative_roll_era_ends_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_3_initiative_roll_era_ends_test.py
@@ -22,6 +22,7 @@ def test_drawing_era_ends_sets_era_ends_flag(
     game = basic_game
     faction: Faction = game.factions.get(position=1)
     _setup_initiative_roll(game, faction, ["era ends"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -39,6 +40,7 @@ def test_drawing_era_ends_is_not_added_to_faction_hand(
     game = basic_game
     faction: Faction = game.factions.get(position=1)
     _setup_initiative_roll(game, faction, ["era ends"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_3_initiative_roll_senator_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_3_initiative_roll_senator_test.py
@@ -23,6 +23,7 @@ def test_drawing_senator_card_creates_unaligned_senator_when_none_in_play(
     faction: Faction = game.factions.get(position=1)
     Senator.objects.filter(game=game, code="18").delete()
     _setup_initiative_roll(game, faction, ["senator:18"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -56,6 +57,7 @@ def test_drawing_senator_card_gives_statesman_family_support(
     )
     Senator.objects.filter(game=game, code="1", family=True).delete()
     _setup_initiative_roll(game, faction, ["senator:1"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -86,6 +88,7 @@ def test_drawing_senator_card_does_not_create_duplicate_when_statesman_in_play(
     )
     Senator.objects.filter(game=game, code="1", family=True).delete()
     _setup_initiative_roll(game, faction, ["senator:1"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)
@@ -106,6 +109,7 @@ def test_drawing_senator_card_uses_correct_stats_from_game_data(
     faction: Faction = game.factions.get(position=1)
     Senator.objects.filter(game=game, code="18").delete()
     _setup_initiative_roll(game, faction, ["senator:18"])
+    resolver.dice_rolls = [8]
 
     # Act
     execute_effects_and_manage_actions(game.id, resolver)

--- a/frontend/components/GameEffects.tsx
+++ b/frontend/components/GameEffects.tsx
@@ -4,6 +4,11 @@ type EffectFormatter = {
 }
 
 const EFFECT_FORMATTERS: Record<string, EffectFormatter> = {
+  "allied enthusiasm": {
+    label: (level) =>
+      level === 1 ? "Allied enthusiasm" : "Extreme allied enthusiasm",
+    annotation: (level) => `+${level === 1 ? 50 : 75}T at revenue`,
+  },
   "manpower shortage": {
     label: (level) =>
       level === 1 ? "Manpower shortage" : "Increased manpower shortage",


### PR DESCRIPTION
Now at the start of every initiative, there is a small chance of allied enthusiasm. If it happens twice in one turn, it becomes extreme allied enthusiasm. Either way, the State receives some talents (50 or 75) during the next revenue phase.

<img width="475" height="259" alt="image" src="https://github.com/user-attachments/assets/9c9a6c0e-2534-4db9-b25d-5d826a132321" />

### Example logs

**During forum phase**
- _Faction 1 drew allied enthusiasm. With Rome's allies contributing additional funds, the State will receive 50T in the next revenue phase._
- _Faction 1 drew allied enthusiasm. With Rome's allies already enthusiastic, they are now extremely enthusiastic. The State will receive 75T in the next revenue phase._
- _Faction 1 drew allied enthusiasm. Rome's allies are already extremely enthusiastic so there is no additional effect._

**During revenue phase**
- _The State received an additional 50T due to allied enthusiasm._
- _The State received an additional 75T due to extreme allied enthusiasm._
