### PR TITLE
ci: speed up backend CI

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -28,20 +28,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
 
-      - name: Start services
-        run: docker compose -f backend/docker-compose.test.yml up -d
-
-      - name: Wait for services to start
-        run: sleep 10s
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install -r requirements.txt
 
       - name: Check types
-        run: docker compose -f backend/docker-compose.test.yml run --rm web mypy .
+        working-directory: backend
+        run: mypy .
 
       - name: Run tests
-        run: docker compose -f backend/docker-compose.test.yml run --rm web pytest
-
-      - name: Stop services
-        run: docker compose -f backend/docker-compose.test.yml down
+        working-directory: backend
+        env:
+          SECRET_KEY: ci-secret-key
+          FRONTEND_ORIGIN: http://localhost:3000
+        run: pytest

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -45,7 +45,4 @@ jobs:
 
       - name: Run tests
         working-directory: backend
-        env:
-          SECRET_KEY: ci-secret-key
-          FRONTEND_ORIGIN: http://localhost:3000
         run: pytest

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -25,6 +25,31 @@ jobs:
     if: needs.ci_backend_filter.outputs.file_changes == 'true'
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+
+    env:
+      SECRET_KEY: ci-secret-key
+      FRONTEND_ORIGIN: http://localhost:3000
+      RDS_USERNAME: postgres
+      RDS_PASSWORD: postgres
+      RDS_HOSTNAME: localhost
+      RDS_PORT: 5432
+      RDS_NAME: postgres
+      REDIS_HOSTNAME: localhost
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -32,6 +32,8 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -39,6 +41,8 @@ jobs:
           --health-retries 5
       redis:
         image: redis:7
+        ports:
+          - 6379:6379
 
     env:
       SECRET_KEY: ci-secret-key

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=rorsite.settings
+DJANGO_SETTINGS_MODULE=rorsite.settings_test
 python_files=test_*.py *_test.py
-addopts = --reuse-db
+addopts = -n auto

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,5 +14,6 @@ psycopg2-binary==2.9.9
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-django==4.8.0
+pytest-xdist==3.6.1
 python-dotenv==1.2.2
 roman==5.0

--- a/backend/rorsite/settings.py
+++ b/backend/rorsite/settings.py
@@ -102,11 +102,11 @@ WSGI_APPLICATION = "rorsite.wsgi.application"
 DATABASES = {
     "default": dj_database_url.config(
         default="postgres://{}:{}@{}:{}/{}".format(
-            os.getenv("RDS_USERNAME"),
-            os.getenv("RDS_PASSWORD"),
-            os.getenv("RDS_HOSTNAME"),
-            os.getenv("RDS_PORT"),
-            os.getenv("RDS_NAME"),
+            os.getenv("RDS_USERNAME", ""),
+            os.getenv("RDS_PASSWORD", ""),
+            os.getenv("RDS_HOSTNAME", "localhost"),
+            os.getenv("RDS_PORT", "5432"),
+            os.getenv("RDS_NAME", ""),
         )
     )
 }

--- a/backend/rorsite/settings_test.py
+++ b/backend/rorsite/settings_test.py
@@ -1,14 +1,5 @@
 from .settings import *  # noqa: F401, F403
 
-SECRET_KEY = "test-secret-key-not-for-production"
-
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
-    }
-}
-
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels.layers.InMemoryChannelLayer",

--- a/backend/rorsite/settings_test.py
+++ b/backend/rorsite/settings_test.py
@@ -1,4 +1,4 @@
-from .settings import *
+from .settings import *  # noqa: F401, F403
 
 SECRET_KEY = "test-secret-key-not-for-production"
 

--- a/backend/rorsite/settings_test.py
+++ b/backend/rorsite/settings_test.py
@@ -1,0 +1,16 @@
+from .settings import *
+
+SECRET_KEY = "test-secret-key-not-for-production"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels.layers.InMemoryChannelLayer",
+    }
+}


### PR DESCRIPTION
- use pytest-xdist parallelism
- use native runner instead of Docker Compose

Result: backend CI run dropped from 10 to 5 ish minutes