### PR TITLE
feat: add drought event

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An online adaptation of a board game called [The Republic of Rome](https://board
     - [ ] Ally deserts
     - [ ] Allied enthusiasm
     - [ ] Barbarian raids
-    - [ ] Drought
+    - [x] Drought
     - [ ] Enemy leader dies
     - [ ] Enemy's ally deserts
     - [ ] Epidemic

--- a/backend/rorapp/classes/game_effect_item.py
+++ b/backend/rorapp/classes/game_effect_item.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class GameEffect(Enum):
     ALLIED_ENTHUSIASM = "allied enthusiasm"
+    DROUGHT = "drought"
     MANPOWER_SHORTAGE = "manpower shortage"
     NO_RECRUITMENT = "no recruitment"
     LAND_BILL_1 = "land bill I"

--- a/backend/rorapp/effects/population.py
+++ b/backend/rorapp/effects/population.py
@@ -21,7 +21,7 @@ class PopulationEffect(EffectBase):
         unprosecuted_war_count = War.objects.filter(
             game=game_id, unprosecuted=True
         ).count()
-        famine_severity = War.objects.filter(game=game_id, famine=True).count()
+        famine_severity = game.famine_severity
         unrest_increase = unprosecuted_war_count + famine_severity
         reasons = []
         game.unrest += unrest_increase

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -5,14 +5,43 @@ from rorapp.models import Faction, Game, Log
 def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
     """Apply the event effect. Returns True if the event is implemented, False if not."""
     if event_name == "Allied enthusiasm":
-        handle_allied_enthusiasm(game, current_faction)
+        advances = handle_allied_enthusiasm(game, current_faction)
+    elif event_name == "Drought":
+        advances = handle_drought(game, current_faction)
+    else:
+        return False
+
+    if advances:
         game.sub_phase = Game.SubPhase.PERSUASION_ATTEMPT
         game.save()
-        return True
-    return False
+    return True
 
 
-def handle_allied_enthusiasm(game: Game, current_faction: Faction):
+def handle_drought(game: Game, current_faction: Faction) -> bool:
+    level = game.count_effect(GameEffect.DROUGHT)
+    game.add_effect(GameEffect.DROUGHT)
+    game.save()
+
+    prefix = f"{current_faction.display_name} drew drought."
+    if level == 0:
+        Log.create_object(
+            game.id,
+            f"{prefix} Famine severity has increased.",
+        )
+    elif level == 1:
+        Log.create_object(
+            game.id,
+            f"{prefix} Drought conditions have worsened to a severe drought, increasing famine severity further.",
+        )
+    else:
+        Log.create_object(
+            game.id,
+            f"{prefix} The severe drought has worsened, increasing famine severity further.",
+        )
+    return True
+
+
+def handle_allied_enthusiasm(game: Game, current_faction: Faction) -> bool:
     level = game.count_effect(GameEffect.ALLIED_ENTHUSIASM)
 
     if level < 2:
@@ -35,3 +64,4 @@ def handle_allied_enthusiasm(game: Game, current_faction: Faction):
             game.id,
             f"{prefix} Rome's allies are already extremely enthusiastic so there is no additional effect.",
         )
+    return True

--- a/backend/rorapp/models/game.py
+++ b/backend/rorapp/models/game.py
@@ -129,7 +129,7 @@ class Game(models.Model):
 
     @property
     def famine_severity(self: "Game") -> int:
-        return self.wars.filter(famine=True).count()
+        return self.wars.filter(famine=True).count() + self.count_effect(GameEffect.DROUGHT)
 
     @property
     def unprosecuted_wars(self: "Game") -> int:

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
@@ -91,6 +91,45 @@ def test_rolling_unimplemented_event_draws_a_card_instead(
 
 
 @pytest.mark.django_db
+def test_rolling_7_on_initiative_triggers_drought(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 9]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.count_effect(GameEffect.DROUGHT) == 1
+
+
+@pytest.mark.django_db
+def test_drawing_drought_beyond_severe_still_increases_famine(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.add_effect(GameEffect.DROUGHT)
+    game.add_effect(GameEffect.DROUGHT)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 9]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.count_effect(GameEffect.DROUGHT) == 3
+
+
+@pytest.mark.django_db
 def test_drawing_allied_enthusiasm_at_max_has_no_effect(
     basic_game: Game, resolver: FakeRandomResolver
 ):

--- a/backend/tests/s1_basic_game/s1_08_population_phase/s1_08_12_drought_effects_test.py
+++ b/backend/tests/s1_basic_game/s1_08_population_phase/s1_08_12_drought_effects_test.py
@@ -1,0 +1,44 @@
+import pytest
+from rorapp.classes.game_effect_item import GameEffect
+from rorapp.classes.random_resolver import FakeRandomResolver
+from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
+from rorapp.models import Game
+
+
+@pytest.mark.django_db
+def test_drought_increases_unrest_in_population_phase(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.phase = Game.Phase.POPULATION
+    game.sub_phase = Game.SubPhase.START
+    game.add_effect(GameEffect.DROUGHT)
+    game.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.unrest == 1
+
+
+@pytest.mark.django_db
+def test_multiple_drought_effects_each_increase_unrest(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.phase = Game.Phase.POPULATION
+    game.sub_phase = Game.SubPhase.START
+    game.add_effect(GameEffect.DROUGHT)
+    game.add_effect(GameEffect.DROUGHT)
+    game.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.unrest == 2

--- a/frontend/components/GameContainer.tsx
+++ b/frontend/components/GameContainer.tsx
@@ -531,7 +531,7 @@ const GameContainer = ({
                                 )}
                                 {war.famine && (
                                   <div className="flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-center text-sm text-purple-600">
-                                    Increases famine
+                                    Famine severity +1
                                   </div>
                                 )}
                                 {war.navalStrength > 0 && (

--- a/frontend/components/GameEffects.tsx
+++ b/frontend/components/GameEffects.tsx
@@ -28,6 +28,10 @@ const EFFECT_FORMATTERS: Record<string, EffectFormatter> = {
       level === 1 ? "Type III land bill" : `Type III land bill ×${level}`,
     annotation: (level) => `costs ${level * 10}T/turn`,
   },
+  drought: {
+    label: (level) => (level === 1 ? "Drought" : "Severe drought"),
+    annotation: (level) => `famine severity +${level}`,
+  },
 }
 
 const parseEffect = (


### PR DESCRIPTION
Add the **drought** event, which contibutes towards the **famine severity** (alongside famine-increasing wars), which in turn increases **unrest** (alongside unprosecuted wars and poor state of the republic speeches).

I made a design decision some time ago to split what the rulebook calls "drought" into two separate terms:
- drought (poor food supply caused by bad weather)
- famine (poor food supply caused by drought and/or war)

## Example logs

**During the forum phase:**

- _Faction 1 drew drought. Famine severity has increased._
- _Faction 2 drew drought. Drought conditions have worsened to a severe drought, increasing famine severity further._
- _Faction 3 drew drought. The severe drought has worsened, increasing famine severity further._

(crazy bad luck)

**At the start of the following forum phase:**

- _The drought has ended._

## Screenshots

<img width="765" height="336" alt="image" src="https://github.com/user-attachments/assets/237a8c05-d3df-4e9c-b2e8-ff9e2f86753c" />

<img width="619" height="247" alt="image" src="https://github.com/user-attachments/assets/1cd055b0-c855-46ac-a591-679cf042f716" />

As shown in this example, a famine-increasing war increases famine severity even when inactive.

The two occurances of "Famine severity +1" are styled inconsistently, but I prefer to ignore this for now. These design problems will be addressed in the eventual UI overhaul.
