### PR TITLE
feat: allow events to trigger manpower shortages

### DIFF
--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -8,6 +8,8 @@ def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
         advances = handle_allied_enthusiasm(game, current_faction)
     elif event_name == "Drought":
         advances = handle_drought(game, current_faction)
+    elif event_name == "Manpower Shortage":
+        advances = handle_manpower_shortage(game, current_faction)
     else:
         return False
 
@@ -37,6 +39,26 @@ def handle_drought(game: Game, current_faction: Faction) -> bool:
         Log.create_object(
             game.id,
             f"{prefix} The severe drought has worsened, increasing famine severity further.",
+        )
+    return True
+
+
+def handle_manpower_shortage(game: Game, current_faction: Faction) -> bool:
+    level = game.count_effect(GameEffect.MANPOWER_SHORTAGE)
+    game.add_effect(GameEffect.MANPOWER_SHORTAGE)
+    game.save()
+
+    prefix = f"{current_faction.display_name} drew manpower shortage."
+    if level == 0:
+        Log.create_object(
+            game.id,
+            f"{prefix} Recruitment costs have increased to 20T per unit.",
+        )
+    else:
+        cost = 10 * (level + 2)
+        Log.create_object(
+            game.id,
+            f"{prefix} The manpower shortage has worsened, increasing recruitment costs to {cost}T per unit.",
         )
     return True
 

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
@@ -79,7 +79,7 @@ def test_rolling_unimplemented_event_draws_a_card_instead(
     _setup_initiative_roll(game, faction)
     resolver.dice_rolls = [
         7,
-        12,
+        11,
     ]
 
     # Act
@@ -127,6 +127,44 @@ def test_drawing_drought_beyond_severe_still_increases_famine(
     # Assert
     game.refresh_from_db()
     assert game.count_effect(GameEffect.DROUGHT) == 3
+
+
+@pytest.mark.django_db
+def test_rolling_7_on_initiative_triggers_manpower_shortage(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 12]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.count_effect(GameEffect.MANPOWER_SHORTAGE) == 1
+
+
+@pytest.mark.django_db
+def test_drawing_manpower_shortage_twice_stacks(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.add_effect(GameEffect.MANPOWER_SHORTAGE)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 12]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.count_effect(GameEffect.MANPOWER_SHORTAGE) == 2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This was easy to implement because manpower shortage was mostly implemented already. It could already be triggered by wars, but now random events can also trigger it.

## New log examples

- _Faction 1 drew manpower shortage. Recruitment costs have increased to 20T per unit._
- _Faction 2 drew manpower shortage. The manpower shortage has worsened, increasing recruitment costs to 30T per unit._