### PR TITLE
fix: flaky passage of time test

### DIFF
--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_1_passage_of_time_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_1_passage_of_time_test.py
@@ -1,11 +1,14 @@
 import pytest
 from rorapp.classes.game_effect_item import GameEffect
+from rorapp.classes.random_resolver import FakeRandomResolver
 from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
 from rorapp.models import Game, Senator
 
 
 @pytest.mark.django_db
-def test_effects_are_cleared_at_start_of_forum_phase(basic_game: Game):
+def test_effects_are_cleared_at_start_of_forum_phase(
+    basic_game: Game, resolver: FakeRandomResolver
+):
     # Arrange
     game = basic_game
     game.phase = Game.Phase.FORUM
@@ -18,8 +21,10 @@ def test_effects_are_cleared_at_start_of_forum_phase(basic_game: Game):
     senator.add_title(Senator.Title.HRAO)
     senator.save()
 
+    resolver.dice_rolls = [6]  # Non-7 initiative roll to avoid triggering an event
+
     # Act
-    execute_effects_and_manage_actions(game.id)
+    execute_effects_and_manage_actions(game.id, resolver)
 
     # Assert
     game.refresh_from_db()


### PR DESCRIPTION
The problem was that a real random resolver was used in the test, which could land on 7 and trigger an event. This was solved by using the fake random resolver to set the next dice roll result to 6.