### PR TITLE
feat: add evil omens event

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ An online adaptation of a board game called [The Republic of Rome](https://board
   - [x] Passage of time
   - [ ] Events
     - [ ] Ally deserts
-    - [ ] Allied enthusiasm
+    - [x] Allied enthusiasm
     - [ ] Barbarian raids
     - [x] Drought
     - [ ] Enemy leader dies
     - [ ] Enemy's ally deserts
     - [ ] Epidemic
-    - [ ] Evil omens
+    - [x] Evil omens
     - [ ] Internal disorder
     - [x] Manpower shortage
     - [ ] New alliance

--- a/backend/rorapp/actions/attempt_assassination.py
+++ b/backend/rorapp/actions/attempt_assassination.py
@@ -17,7 +17,7 @@ _EXCLUDED_SUB_PHASES = {
 
 class AttemptAssassinationAction(ActionBase):
     NAME = "Attempt assassination"
-    POSITION = 9
+    POSITION = 200
 
     def is_allowed(
         self, game_state: GameStateLive | GameStateSnapshot, faction_id: int

--- a/backend/rorapp/actions/attract_knight.py
+++ b/backend/rorapp/actions/attract_knight.py
@@ -2,6 +2,7 @@ import random
 from typing import Any, Dict, Optional, List
 from rorapp.actions.meta.action_base import ActionBase
 from rorapp.actions.meta.execution_result import ExecutionResult
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.game_state.game_state_live import GameStateLive
@@ -33,11 +34,15 @@ class AttractKnightAction(ActionBase):
 
         faction = self.is_allowed(snapshot, faction_id)
         if faction:
+            evil_omens_level = snapshot.game.count_effect(GameEffect.EVIL_OMENS)
             sender_senators = sorted(
                 [
                     s
                     for s in snapshot.senators
-                    if s.faction and s.faction.id == faction.id and s.alive
+                    if s.faction
+                    and s.faction.id == faction.id
+                    and s.alive
+                    and s.talents >= evil_omens_level
                 ],
                 key=lambda s: s.family_name,
             )
@@ -65,7 +70,7 @@ class AttractKnightAction(ActionBase):
                         {
                             "type": "number",
                             "name": "Talents",
-                            "min": [0],
+                            "min": [evil_omens_level],
                             "max": [5, "signal:max_talents"],
                             "signals": {"talents": "VALUE"},
                         },
@@ -74,7 +79,10 @@ class AttractKnightAction(ActionBase):
                             "name": "Chance of success",
                             "dice": 1,
                             "target_min": 6,
-                            "modifiers": ["signal:talents"],
+                            "modifiers": [
+                                "signal:talents",
+                                -evil_omens_level,
+                            ],
                         },
                     ],
                 )
@@ -101,8 +109,10 @@ class AttractKnightAction(ActionBase):
             return ExecutionResult(False, "Not enough talents.")
 
         # Dice roll
+        game = Game.objects.get(id=game_id)
+        evil_omens_level = game.count_effect(GameEffect.EVIL_OMENS)
         dice_roll = random_resolver.roll_dice()
-        modified_dice_roll = dice_roll + talents
+        modified_dice_roll = dice_roll + talents - evil_omens_level
         guaranteed = (modified_dice_roll - dice_roll) + 1 >= 6
 
         if modified_dice_roll >= 6:
@@ -120,7 +130,6 @@ class AttractKnightAction(ActionBase):
         senator.save()
 
         # Progress game
-        game = Game.objects.get(id=game_id)
         game.sub_phase = Game.SubPhase.SPONSOR_GAMES
         game.save()
 

--- a/backend/rorapp/actions/call_popular_appeal.py
+++ b/backend/rorapp/actions/call_popular_appeal.py
@@ -1,6 +1,7 @@
 import math
 from typing import Any, Dict, Optional, List
 from rorapp.actions.meta.action_base import ActionBase
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.helpers.game_data import get_senator_codes
 from rorapp.actions.meta.execution_result import ExecutionResult
 from rorapp.classes.random_resolver import RandomResolver
@@ -121,8 +122,9 @@ class CallPopularAppealAction(ActionBase):
         )
 
         # Roll 2d6 + popularity
+        evil_omens_level = game.count_effect(GameEffect.EVIL_OMENS)
         roll = random_resolver.roll_dice(1) + random_resolver.roll_dice(1)
-        result = roll + accused.popularity
+        result = roll + accused.popularity - evil_omens_level
         table_value = _popular_appeal_table(result)
 
         if table_value == "killed":

--- a/backend/rorapp/actions/give_speech.py
+++ b/backend/rorapp/actions/give_speech.py
@@ -164,7 +164,8 @@ class GiveSpeechAction(ActionBase):
             return ExecutionResult(False, "No HRAO senator found")
 
         dice_result = random_resolver.roll_dice(3)
-        modified_dice_result = dice_result - game.unrest + hrao.popularity
+        evil_omens_level = game.count_effect(GameEffect.EVIL_OMENS)
+        modified_dice_result = dice_result - game.unrest + hrao.popularity - evil_omens_level
         unrest_change = _unrest_change(modified_dice_result)
         adjective = _get_adjective(dice_result)
 

--- a/backend/rorapp/actions/play_influence_peddling.py
+++ b/backend/rorapp/actions/play_influence_peddling.py
@@ -11,7 +11,7 @@ from rorapp.models import AvailableAction, Faction, Game, Log
 
 class PlayInfluencePeddlingAction(ActionBase):
     NAME = "Play influence peddling"
-    POSITION = 200
+    POSITION = 201
 
     def is_allowed(
         self, game_state: GameStateLive | GameStateSnapshot, faction_id: int

--- a/backend/rorapp/actions/pressure_knight.py
+++ b/backend/rorapp/actions/pressure_knight.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, List
 
 from rorapp.actions.meta.action_base import ActionBase
 from rorapp.actions.meta.execution_result import ExecutionResult
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.game_state.game_state_live import GameStateLive
@@ -114,10 +115,11 @@ class PressureKnightAction(ActionBase):
 
         # Perform the pressure: one die roll per pressured knight
         rolls_by_senator: Dict[int, List[int]] = {}
+        evil_omens_level = Game.objects.get(id=game_id).count_effect(GameEffect.EVIL_OMENS)
 
         for sid, num in pressures.items():
             senator = senator_by_id[sid]
-            rolls = [random_resolver.roll_dice() for _ in range(num)]
+            rolls = [max(0, random_resolver.roll_dice() - evil_omens_level) for _ in range(num)]
             rolls_by_senator[sid] = rolls
             senator.talents += sum(rolls)
             senator.knights -= num

--- a/backend/rorapp/classes/game_effect_item.py
+++ b/backend/rorapp/classes/game_effect_item.py
@@ -4,6 +4,7 @@ from enum import Enum
 class GameEffect(Enum):
     ALLIED_ENTHUSIASM = "allied enthusiasm"
     DROUGHT = "drought"
+    EVIL_OMENS = "evil omens"
     MANPOWER_SHORTAGE = "manpower shortage"
     NO_RECRUITMENT = "no recruitment"
     LAND_BILL_1 = "land bill I"

--- a/backend/rorapp/effects/__init__.py
+++ b/backend/rorapp/effects/__init__.py
@@ -45,6 +45,7 @@ from .revolution_phase_end import RevolutionPhaseEndEffect
 from .revolution_phase_start import RevolutionPhaseStartEffect
 from .senate_phase_end import SenatePhaseEndEffect
 from .senate_phase_start import SenatePhaseStartEffect
+from .knight_auto_skip import KnightAutoSkipEffect
 from .sponsor_games_auto_skip import SponsorGamesAutoSkipEffect
 from .roll_assassination_dice import RollAssassinationDiceEffect
 from .bodyguard_catch_reroll import BodyguardCatchRerollEffect

--- a/backend/rorapp/effects/bodyguard_catch_reroll.py
+++ b/backend/rorapp/effects/bodyguard_catch_reroll.py
@@ -1,4 +1,5 @@
 from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
@@ -31,7 +32,7 @@ class BodyguardCatchRerollEffect(EffectBase):
             return True
 
         roll = random_resolver.roll_dice(1)
-        modified = roll + game.assassination_roll_modifier
+        modified = roll + game.assassination_roll_modifier - game.count_effect(GameEffect.EVIL_OMENS)
 
         if modified <= 2:
             assassin.add_status_item(Senator.StatusItem.CAUGHT)

--- a/backend/rorapp/effects/knight_auto_skip.py
+++ b/backend/rorapp/effects/knight_auto_skip.py
@@ -1,0 +1,46 @@
+from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.classes.game_effect_item import GameEffect
+from rorapp.classes.random_resolver import RandomResolver
+from rorapp.effects.meta.effect_base import EffectBase
+from rorapp.game_state.game_state_snapshot import GameStateSnapshot
+from rorapp.models import Game
+
+
+class KnightAutoSkipEffect(EffectBase):
+
+    def validate(self, game_state: GameStateSnapshot) -> bool:
+        if not (
+            game_state.game.phase == Game.Phase.FORUM
+            and game_state.game.sub_phase == Game.SubPhase.ATTRACT_KNIGHT
+        ):
+            return False
+
+        evil_omens_level = game_state.game.count_effect(GameEffect.EVIL_OMENS)
+        if evil_omens_level == 0:
+            return False
+
+        current_faction = next(
+            (
+                f
+                for f in game_state.factions
+                if f.has_status_item(FactionStatusItem.CURRENT_INITIATIVE)
+            ),
+            None,
+        )
+        if not current_faction:
+            return False
+
+        faction_senators = [
+            s
+            for s in game_state.senators
+            if s.faction and s.faction.id == current_faction.id and s.alive
+        ]
+        if any(s.talents >= evil_omens_level for s in faction_senators):
+            return False
+        return not any(s.knights > 0 for s in faction_senators)
+
+    def execute(self, game_id: int, random_resolver: RandomResolver) -> bool:
+        game = Game.objects.get(id=game_id)
+        game.sub_phase = Game.SubPhase.SPONSOR_GAMES
+        game.save()
+        return True

--- a/backend/rorapp/effects/meta/registry.py
+++ b/backend/rorapp/effects/meta/registry.py
@@ -53,6 +53,7 @@ effect_registry: List[Type[EffectBase]] = [
     RevolutionPhaseEndEffect,
     SenatePhaseEndEffect,
     SenatePhaseStartEffect,
+    KnightAutoSkipEffect,
     SponsorGamesAutoSkipEffect,
     RollAssassinationDiceEffect,
     BodyguardCatchRerollEffect,

--- a/backend/rorapp/effects/putting_rome_in_order.py
+++ b/backend/rorapp/effects/putting_rome_in_order.py
@@ -1,3 +1,4 @@
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
@@ -15,13 +16,14 @@ class PuttingRomeInOrderEffect(EffectBase):
 
     def execute(self, game_id: int, random_resolver: RandomResolver) -> bool:
         game = Game.objects.get(id=game_id)
+        evil_omens_level = game.count_effect(GameEffect.EVIL_OMENS)
 
         dead_senator_list = list(
             Senator.objects.filter(game=game_id, alive=False, family=True)
         )
 
         for senator in dead_senator_list:
-            roll = random_resolver.roll_dice()
+            roll = random_resolver.roll_dice() - evil_omens_level
             if roll >= 5:
                 previous_name = (
                     f"{senator.display_name}'"
@@ -39,7 +41,7 @@ class PuttingRomeInOrderEffect(EffectBase):
         inactive_leaders = list(EnemyLeader.objects.filter(game=game_id, active=False))
         dead_leaders = []
         for leader in inactive_leaders:
-            roll = random_resolver.roll_dice()
+            roll = random_resolver.roll_dice() - evil_omens_level
             if roll >= 5:
                 dead_leaders.append(leader.name)
                 leader.delete()

--- a/backend/rorapp/effects/revenue.py
+++ b/backend/rorapp/effects/revenue.py
@@ -77,6 +77,14 @@ class RevenueEffect(EffectBase):
                 text=f"The State received an additional {enthusiasm_bonus}T due to {'extreme ' if allied_enthusiasm_level >= 2 else ''}allied enthusiasm.",
             )
 
+        evil_omens_level = game.count_effect(GameEffect.EVIL_OMENS)
+        if evil_omens_level > 0:
+            game.state_treasury -= evil_omens_level
+            Log.create_object(
+                game_id=game.id,
+                text=f"Evil omens reduced the State's income by {evil_omens_level}T.",
+            )
+
         # Senators earn personal revenue
         factions = Faction.objects.filter(game=game_id).order_by("position")
         for faction in factions:

--- a/backend/rorapp/effects/roll_assassination_dice.py
+++ b/backend/rorapp/effects/roll_assassination_dice.py
@@ -1,4 +1,5 @@
 from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
@@ -23,7 +24,7 @@ class RollAssassinationDiceEffect(EffectBase):
             return False
 
         roll = random_resolver.roll_dice(1)
-        modified = roll + game.assassination_roll_modifier
+        modified = roll + game.assassination_roll_modifier - game.count_effect(GameEffect.EVIL_OMENS)
 
         # Store the modifier-adjusted result; bodyguard cards may subtract from it later
         game.assassination_roll_result = modified

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -8,6 +8,8 @@ def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
         advances = handle_allied_enthusiasm(game, current_faction)
     elif event_name == "Drought":
         advances = handle_drought(game, current_faction)
+    elif event_name == "Evil Omens":
+        advances = handle_evil_omens(game, current_faction)
     elif event_name == "Manpower Shortage":
         advances = handle_manpower_shortage(game, current_faction)
     else:
@@ -16,6 +18,27 @@ def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
     if advances:
         game.sub_phase = Game.SubPhase.PERSUASION_ATTEMPT
         game.save()
+    return True
+
+
+def handle_evil_omens(game: Game, current_faction: Faction) -> bool:
+    level = game.count_effect(GameEffect.EVIL_OMENS)
+    if level == 0:
+        game.state_treasury -= 20
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+
+    prefix = f"{current_faction.display_name} drew evil omens."
+    if level == 0:
+        Log.create_object(
+            game.id,
+            f"{prefix} The State paid 20T for sacrifices and temple repair. The omens make military campaigns more perilous and senators more susceptible to persuasion.",
+        )
+    else:
+        Log.create_object(
+            game.id,
+            f"{prefix} With Rome already afflicted by evil omens, further omens make military campaigns even more perilous and senators even more susceptible to persuasion.",
+        )
     return True
 
 

--- a/backend/rorapp/helpers/resolve_combat.py
+++ b/backend/rorapp/helpers/resolve_combat.py
@@ -1,5 +1,6 @@
 import math
 from typing import List
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.helpers.game_data import get_senator_codes, load_statesmen
 from rorapp.helpers.kill_senator import CauseOfDeath, kill_senator
@@ -72,7 +73,8 @@ def resolve_combat(
             war.land_strength * matching_war_multiplier + leader_strength
         )
         war.fought_land_battle = True
-    modifier = positive_modifier - negative_modifier
+    evil_omens_level = Game.objects.get(id=game_id).count_effect(GameEffect.EVIL_OMENS)
+    modifier = positive_modifier - negative_modifier - evil_omens_level
     modified_result = unmodified_result + modifier
 
     # Check if the commander is a statesman who nullifies disaster/standoff for this war's series

--- a/backend/rorapp/helpers/resolve_persuasion.py
+++ b/backend/rorapp/helpers/resolve_persuasion.py
@@ -1,4 +1,5 @@
 from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.models import Faction, Game, Log, Senator
 
@@ -23,6 +24,7 @@ def resolve_persuasion(
         persuading_senator.oratory
         + persuading_senator.influence
         + 2 * total_bribe
+        + game.count_effect(GameEffect.EVIL_OMENS)
         - target.loyalty
         - target.talents
         - (7 if target.faction_id else 0)

--- a/backend/rorapp/migrations/0055_add_evil_omens_to_combat_calculation.py
+++ b/backend/rorapp/migrations/0055_add_evil_omens_to_combat_calculation.py
@@ -1,0 +1,23 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("rorapp", "0054_rename_schema_to_field_descriptors"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="combatcalculation",
+            name="evil_omens",
+            field=models.IntegerField(
+                default=0,
+                validators=[
+                    django.core.validators.MinValueValidator(0),
+                    django.core.validators.MaxValueValidator(10),
+                ],
+            ),
+        ),
+    ]

--- a/backend/rorapp/models/combat_calculation.py
+++ b/backend/rorapp/models/combat_calculation.py
@@ -34,6 +34,9 @@ class CombatCalculation(models.Model):
     fleets = models.IntegerField(
         default=0, validators=[MinValueValidator(0), MaxValueValidator(25)]
     )
+    evil_omens = models.IntegerField(
+        default=0, validators=[MinValueValidator(0), MaxValueValidator(10)]
+    )
     is_dictator = models.BooleanField(default=False)
     master_of_horse = models.ForeignKey(
         Senator,

--- a/backend/rorapp/serializers/combat_calculation.py
+++ b/backend/rorapp/serializers/combat_calculation.py
@@ -16,6 +16,7 @@ class CombatCalculationSerializer(serializers.ModelSerializer):
             "regular_legions",
             "veteran_legions",
             "fleets",
+            "evil_omens",
             "is_dictator",
             "master_of_horse",
         ]

--- a/backend/tests/s1_basic_game/s1_06_revenue_phase/s1_06_55_evil_omens_test.py
+++ b/backend/tests/s1_basic_game/s1_06_revenue_phase/s1_06_55_evil_omens_test.py
@@ -1,0 +1,19 @@
+import pytest
+from rorapp.classes.game_effect_item import GameEffect
+from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
+from rorapp.models import Game
+
+
+@pytest.mark.django_db
+def test_evil_omens_reduces_state_income_by_1T(revenue_game: Game):
+    # Arrange
+    game = revenue_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.state_treasury == 299

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
@@ -91,6 +91,87 @@ def test_rolling_unimplemented_event_draws_a_card_instead(
 
 
 @pytest.mark.django_db
+def test_rolling_7_with_evil_omens_event_roll_adds_effect(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 6]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.has_effect(GameEffect.EVIL_OMENS)
+    assert game.count_effect(GameEffect.EVIL_OMENS) == 1
+
+
+@pytest.mark.django_db
+def test_evil_omens_costs_20T_on_first_draw(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.state_treasury = 100
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 6]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.state_treasury == 80
+
+
+@pytest.mark.django_db
+def test_evil_omens_second_draw_does_not_cost_additional_20T(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.state_treasury = 100
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 6]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.state_treasury == 100
+
+
+
+@pytest.mark.django_db
+def test_evil_omens_does_not_affect_initiative_roll(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 13]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.has_effect(GameEffect.ALLIED_ENTHUSIASM)
+
+
+@pytest.mark.django_db
 def test_rolling_7_on_initiative_triggers_drought(
     basic_game: Game, resolver: FakeRandomResolver
 ):

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_4_persuasion_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_4_persuasion_test.py
@@ -9,6 +9,7 @@ from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actio
 from rorapp.effects.persuasion_counter_bribe_first import (
     PersuasionCounterBribeFirstEffect,
 )
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.models import Faction, Game, Senator
 
 
@@ -879,3 +880,39 @@ def test_persuasion_not_auto_skipped_when_success_possible(
     # Assert
     game.refresh_from_db()
     assert game.sub_phase == Game.SubPhase.PERSUASION_ATTEMPT
+
+
+@pytest.mark.django_db
+def test_evil_omens_grants_bonus_to_persuasion(
+    forum_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = forum_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction1, persuader, target = _setup_persuasion_attempt(game)
+    resolver.dice_rolls = [3]
+
+    # Act
+    _reach_persuasion_decision(game, faction1, persuader, target, resolver)
+
+    # Assert
+    target.refresh_from_db()
+    assert target.faction_id == faction1.id
+
+
+@pytest.mark.django_db
+def test_without_evil_omens_same_roll_fails_persuasion(
+    forum_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = forum_game
+    faction1, persuader, target = _setup_persuasion_attempt(game)
+    resolver.dice_rolls = [3]
+
+    # Act
+    _reach_persuasion_decision(game, faction1, persuader, target, resolver)
+
+    # Assert
+    target.refresh_from_db()
+    assert target.faction_id is None

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_5_knights_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_5_knights_test.py
@@ -100,6 +100,7 @@ def test_attract_knight_not_autoskipped_when_faction_has_knights_to_pressure(
     faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
     faction.save()
     senator = faction.senators.filter(alive=True).first()
+    assert senator is not None
     senator.talents = 0
     senator.knights = 1
     senator.save()

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_5_knights_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_5_knights_test.py
@@ -1,9 +1,11 @@
 import pytest
 from rorapp.actions.attract_knight import AttractKnightAction
 from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.classes.game_effect_item import GameEffect
 from rorapp.classes.random_resolver import FakeRandomResolver
 from rorapp.models import Faction, Game
 from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
+from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 
 
 @pytest.mark.django_db
@@ -35,3 +37,131 @@ def test_knight_not_attracted_on_low_roll(forum_game: Game, resolver: FakeRandom
     assert result.success
     senator.refresh_from_db()
     assert senator.knights == 0
+
+
+@pytest.mark.django_db
+def test_attract_knight_autoskipped_when_all_senators_lack_talents_for_evil_omens(
+    forum_game: Game,
+):
+    # Arrange
+    game = forum_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
+    faction.save()
+    for senator in faction.senators.filter(alive=True):
+        senator.talents = 0
+        senator.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.sub_phase != Game.SubPhase.ATTRACT_KNIGHT
+
+
+@pytest.mark.django_db
+def test_attract_knight_not_autoskipped_when_any_senator_has_enough_talents(
+    forum_game: Game,
+):
+    # Arrange
+    game = forum_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
+    faction.save()
+    senators = list(faction.senators.filter(alive=True))
+    for senator in senators[:-1]:
+        senator.talents = 0
+        senator.save()
+    senators[-1].talents = 1
+    senators[-1].save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.sub_phase == Game.SubPhase.ATTRACT_KNIGHT
+
+
+@pytest.mark.django_db
+def test_attract_knight_not_autoskipped_when_faction_has_knights_to_pressure(
+    forum_game: Game,
+):
+    # Arrange
+    game = forum_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
+    faction.save()
+    senator = faction.senators.filter(alive=True).first()
+    senator.talents = 0
+    senator.knights = 1
+    senator.save()
+
+    # Act
+    execute_effects_and_manage_actions(game.id)
+
+    # Assert
+    game.refresh_from_db()
+    assert game.sub_phase == Game.SubPhase.ATTRACT_KNIGHT
+
+
+@pytest.mark.django_db
+def test_get_schema_excludes_senators_with_insufficient_talents_under_evil_omens(
+    forum_game: Game,
+):
+    # Arrange
+    game = forum_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
+    faction.save()
+    senators = list(faction.senators.filter(alive=True))
+    poor_senator = senators[0]
+    poor_senator.talents = 0
+    poor_senator.save()
+    rich_senator = senators[1]
+    rich_senator.talents = 2
+    rich_senator.save()
+
+    # Act
+    actions = AttractKnightAction().get_schema(GameStateSnapshot(game.id), faction.id)
+
+    # Assert
+    assert len(actions) == 1
+    senator_options = actions[0].field_descriptors[0]["options"]
+    option_ids = [o["id"] for o in senator_options]
+    assert poor_senator.id not in option_ids
+    assert rich_senator.id in option_ids
+
+
+@pytest.mark.django_db
+def test_get_schema_sets_min_talents_to_evil_omens_level(
+    forum_game: Game,
+):
+    # Arrange
+    game = forum_game
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.add_effect(GameEffect.EVIL_OMENS)
+    game.save()
+    faction: Faction = game.factions.get(position=1)
+    faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
+    faction.save()
+    for senator in faction.senators.filter(alive=True):
+        senator.talents = 5
+        senator.save()
+
+    # Act
+    actions = AttractKnightAction().get_schema(GameStateSnapshot(game.id), faction.id)
+
+    # Assert
+    assert len(actions) == 1
+    talents_descriptor = actions[0].field_descriptors[1]
+    assert talents_descriptor["min"] == [2]

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import useWebSocket from "react-use-websocket"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
 
 import { DebouncedFunc, debounce } from "lodash"
 import Link from "next/link"
@@ -242,6 +243,7 @@ const GamePage = () => {
         regular_legions: c.regularLegions,
         veteran_legions: c.veteranLegions,
         fleets: c.fleets,
+        evil_omens: c.evilOmens,
         is_dictator: c.isDictator,
         master_of_horse: c.masterOfHorse,
       }))
@@ -270,29 +272,52 @@ const GamePage = () => {
   }
 
   // Auto-switch naval calculations to land when a war's naval strength reaches 0
+  // Auto-clamp evil omens to the actual game level
   useEffect(() => {
     if (!publicGameState) return
+    const actualEvilOmensLevel = getEvilOmensLevel(publicGameState.game?.effects ?? [])
     setCombatCalculations((prev) => {
       let changed = false
       const updated = prev.map((calc) => {
-        if (calc.battle !== "naval" || calc.war === null) return calc
+        let next = calc
         const war = publicGameState.wars.find((w) => w.id === calc.war)
-        if (war && war.navalStrength === 0) {
+        if (calc.battle === "naval" && calc.war !== null && war && war.navalStrength === 0) {
           changed = true
-          return new CombatCalculation({
-            id: calc.id as number | null,
-            game: calc.game,
-            name: calc.name,
-            commander: calc.commander,
-            war: calc.war,
+          next = new CombatCalculation({
+            id: next.id as number | null,
+            game: next.game,
+            name: next.name,
+            commander: next.commander,
+            war: next.war,
             land_battle: true,
-            regular_legions: calc.regularLegions,
-            veteran_legions: calc.veteranLegions,
-            fleets: calc.fleets,
-            auto_transformed: calc.autoTransformed,
+            regular_legions: next.regularLegions,
+            veteran_legions: next.veteranLegions,
+            fleets: next.fleets,
+            evil_omens: next.evilOmens,
+            auto_transformed: next.autoTransformed,
+            is_dictator: next.isDictator,
+            master_of_horse: next.masterOfHorse,
           })
         }
-        return calc
+        if (next.evilOmens > actualEvilOmensLevel) {
+          changed = true
+          next = new CombatCalculation({
+            id: next.id as number | null,
+            game: next.game,
+            name: next.name,
+            commander: next.commander,
+            war: next.war,
+            land_battle: next.battle === "land",
+            regular_legions: next.regularLegions,
+            veteran_legions: next.veteranLegions,
+            fleets: next.fleets,
+            evil_omens: actualEvilOmensLevel,
+            auto_transformed: next.autoTransformed,
+            is_dictator: next.isDictator,
+            master_of_horse: next.masterOfHorse,
+          })
+        }
+        return next
       })
       if (changed) {
         latestCalculationsRef.current = updated

--- a/frontend/classes/CombatCalculation.ts
+++ b/frontend/classes/CombatCalculation.ts
@@ -8,6 +8,7 @@ export interface CombatCalculationData {
   regular_legions: number
   veteran_legions: number
   fleets: number
+  evil_omens?: number
   auto_transformed?: boolean
   is_dictator?: boolean
   master_of_horse?: number | null
@@ -23,6 +24,7 @@ class CombatCalculation {
   regularLegions: number
   veteranLegions: number
   fleets: number
+  evilOmens: number
   autoTransformed: boolean
   isDictator: boolean
   masterOfHorse: number | null
@@ -37,6 +39,7 @@ class CombatCalculation {
     this.regularLegions = data.regular_legions
     this.veteranLegions = data.veteran_legions
     this.fleets = data.fleets
+    this.evilOmens = data.evil_omens ?? 0
     this.autoTransformed = data.auto_transformed ?? false
     this.isDictator = data.is_dictator ?? false
     this.masterOfHorse = data.master_of_horse ?? null

--- a/frontend/components/CombatCalculator.tsx
+++ b/frontend/components/CombatCalculator.tsx
@@ -3,6 +3,7 @@ import React from "react"
 
 import { SelectField } from "@/classes/AvailableAction"
 import CombatCalculation from "@/classes/CombatCalculation"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
 import PrivateGameState from "@/classes/PrivateGameState"
 import PublicGameState from "@/classes/PublicGameState"
 import { useAppContext } from "@/contexts/AppContext"
@@ -114,6 +115,7 @@ const CombatCalculator = ({
 
   const addTab = useCallback(() => {
     if (!publicGameState.game) return
+    const evilOmensLevel = getEvilOmensLevel(publicGameState.game.effects ?? [])
     const newCalculation = new CombatCalculation({
       id: null,
       game: publicGameState.game.id,
@@ -124,6 +126,7 @@ const CombatCalculator = ({
       regular_legions: 0,
       veteran_legions: 0,
       fleets: 0,
+      evil_omens: evilOmensLevel,
     })
 
     const updatedCalculations = [...combatCalculations, newCalculation]

--- a/frontend/components/CombatCalculatorItem.tsx
+++ b/frontend/components/CombatCalculatorItem.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react"
 import CombatCalculation from "@/classes/CombatCalculation"
 import EnemyLeader from "@/classes/EnemyLeader"
 import PublicGameState from "@/classes/PublicGameState"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
 import Senator from "@/classes/Senator"
 import War from "@/classes/War"
 import getDiceProbability from "@/helpers/dice"
@@ -31,7 +32,11 @@ const CombatCalculatorItem = ({
         combatCalculation.masterOfHorse === commander
           ? null
           : combatCalculation.masterOfHorse
-      updateCombatCalculation({ ...combatCalculation, commander, masterOfHorse })
+      updateCombatCalculation({
+        ...combatCalculation,
+        commander,
+        masterOfHorse,
+      })
     }
   }
 
@@ -132,7 +137,17 @@ const CombatCalculatorItem = ({
       : war?.navalStrength) ?? 0
   const leaderStrength = enemyLeaders.reduce((sum, l) => sum + l.strength, 0)
   const warStrength = baseWarStrength * matchingWarMultiplier + leaderStrength
-  const modifier = forceStrength - warStrength
+  const evilOmensLevel = combatCalculation.evilOmens ?? 0
+
+  const actualEvilOmensLevel = getEvilOmensLevel(publicGameState.game?.effects ?? [])
+
+  const setEvilOmens = (value: number) => {
+    if (combatCalculation.evilOmens !== value) {
+      updateCombatCalculation({ ...combatCalculation, evilOmens: value })
+    }
+  }
+
+  const modifier = forceStrength - warStrength - evilOmensLevel
 
   const disastersNullified =
     !!commander?.statesmanName &&
@@ -172,9 +187,9 @@ const CombatCalculatorItem = ({
     name: string,
     value: number,
     updateValue: (newValue: number) => void,
+    max = 25,
   ) => {
     const min = 0
-    const max = 25
     return (
       <div className="flex max-w-[350px] flex-col gap-1">
         <label htmlFor={name} className="font-semibold">
@@ -392,6 +407,13 @@ const CombatCalculatorItem = ({
           setVeteranLegions,
         )}
         {renderNumberField("Fleets", combatCalculation.fleets, setFleets)}
+        {actualEvilOmensLevel > 0 &&
+          renderNumberField(
+            "Evil omens",
+            combatCalculation.evilOmens,
+            setEvilOmens,
+            actualEvilOmensLevel,
+          )}
       </div>
       <div className="flex max-w-[350px] flex-col items-start gap-6">
         <div className="flex flex-col items-start gap-1">
@@ -427,7 +449,9 @@ const CombatCalculatorItem = ({
         )}
         {((combatCalculation.battle === "land" &&
           (war?.fleetSupport ?? 0) > combatCalculation.fleets) ||
-          modifier < 0) && (
+          (modifier < 0 &&
+            combatCalculation.commander !== null &&
+            combatCalculation.war !== null)) && (
           <div className="flex flex-col gap-1">
             <div className="font-semibold">Issues</div>
             <div className="flex flex-col gap-2 text-sm">
@@ -443,15 +467,17 @@ const CombatCalculatorItem = ({
                     </div>
                   </>
                 )}
-              {modifier < 0 && (
-                <>
-                  <div className="rounded-md bg-red-50 px-2 py-1 text-red-600">
-                    <strong className="font-semibold">Risky command</strong>:
-                    commander consent is required for such a dangerous
-                    deployment
-                  </div>
-                </>
-              )}
+              {modifier < 0 &&
+                combatCalculation.commander !== null &&
+                combatCalculation.war !== null && (
+                  <>
+                    <div className="rounded-md bg-red-50 px-2 py-1 text-red-600">
+                      <strong className="font-semibold">Risky command</strong>:
+                      commander consent is required for such a dangerous
+                      deployment
+                    </div>
+                  </>
+                )}
             </div>
           </div>
         )}

--- a/frontend/components/GameEffects.tsx
+++ b/frontend/components/GameEffects.tsx
@@ -4,6 +4,10 @@ type EffectFormatter = {
 }
 
 const EFFECT_FORMATTERS: Record<string, EffectFormatter> = {
+  "evil omens": {
+    label: (level) => (level === 1 ? "Evil omens" : `Evil omens ×${level}`),
+    annotation: (level) => "harder military campaigns, easier persuasions",
+  },
   "allied enthusiasm": {
     label: (level) =>
       level === 1 ? "Allied enthusiasm" : "Extreme allied enthusiasm",

--- a/frontend/components/customActionForms/AttemptAssassinationForm.tsx
+++ b/frontend/components/customActionForms/AttemptAssassinationForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Senator from "@/classes/Senator"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
 import useCustomActionForm from "@/hooks/useCustomActionForm"
 
 import ActionDescription from "../ActionDescription"
@@ -123,7 +124,9 @@ const AttemptAssassinationForm = ({
     }))
   }
 
-  const modifier = assassinCards
+  const evilOmensLevel = getEvilOmensLevel(publicGameState.game?.effects ?? [])
+
+  const modifier = assassinCards - evilOmensLevel
 
   const targetSenator = targetId
     ? publicGameState.senators.find((s: Senator) => String(s.id) === targetId)
@@ -308,9 +311,10 @@ const AttemptAssassinationForm = ({
             <div className="flex flex-col gap-1">
               <p className="font-semibold">
                 Assassination table
-                {modifier > 0 && (
+                {modifier !== 0 && (
                   <span className="ml-1 font-normal text-neutral-500">
-                    (+{modifier} modifier)
+                    ({modifier > 0 ? "+" : ""}
+                    {modifier} modifier)
                   </span>
                 )}
               </p>

--- a/frontend/components/customActionForms/AttemptPersuasionForm.tsx
+++ b/frontend/components/customActionForms/AttemptPersuasionForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react"
 
 import Senator from "@/classes/Senator"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
 import useCustomActionForm from "@/hooks/useCustomActionForm"
 
 import { CustomActionFormProps } from "../ActionDispatcher"
@@ -74,10 +75,13 @@ const AttemptPersuasionForm = ({
     )
     .sort((a, b) => a.familyName.localeCompare(b.familyName))
 
+  const evilOmensLevel = getEvilOmensLevel(publicGameState.game?.effects ?? [])
+
   const isPossible = (persuader: Senator, target: Senator) =>
     persuader.oratory +
       persuader.influence +
-      persuader.talents -
+      persuader.talents +
+      evilOmensLevel -
       target.loyalty -
       target.talents -
       (target.faction ? 7 : 0) >=
@@ -101,7 +105,8 @@ const AttemptPersuasionForm = ({
     persuader && target
       ? persuader.oratory +
         persuader.influence +
-        talents -
+        talents +
+        evilOmensLevel -
         target.loyalty -
         target.talents -
         (target.faction ? 7 : 0)

--- a/frontend/components/customActionForms/PressureKnightsForm.tsx
+++ b/frontend/components/customActionForms/PressureKnightsForm.tsx
@@ -2,6 +2,7 @@
 
 import Senator from "@/classes/Senator"
 import useCustomActionForm from "@/hooks/useCustomActionForm"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
 import ActionDescription from "../ActionDescription"
 
 import { CustomActionFormProps } from "../ActionDispatcher"
@@ -33,6 +34,8 @@ const PressureKnightsForm = ({
   })
 
   const factionId = availableAction.faction
+
+  const evilOmensLevel = getEvilOmensLevel(publicGameState.game?.effects ?? [])
 
   const ownSenators: Senator[] = publicGameState.senators
     .filter((s) => s.faction === factionId && s.alive && s.knights > 0)
@@ -102,7 +105,9 @@ const PressureKnightsForm = ({
             />
             <p className="text-sm text-neutral-600">
               Choose how many knights to pressure under each of your senators.
-              You will receive up to 6 talents per pressured knight.
+              Each pressured knight yields up to{" "}
+              {Math.max(0, 6 - evilOmensLevel)} talents
+              {evilOmensLevel > 0 ? " (reduced by evil omens)" : ""}.
             </p>
           </div>
 

--- a/frontend/helpers/gameEffects.ts
+++ b/frontend/helpers/gameEffects.ts
@@ -1,0 +1,25 @@
+/**
+ * Parses a game effect string of the form "effect name" or "effect name:level"
+ * and returns the base name and level.
+ */
+export const parseEffectString = (
+  effect: string,
+): { baseName: string; level: number } => {
+  const colonIndex = effect.indexOf(":")
+  return {
+    baseName: colonIndex >= 0 ? effect.slice(0, colonIndex) : effect,
+    level: colonIndex >= 0 ? parseInt(effect.slice(colonIndex + 1), 10) : 1,
+  }
+}
+
+/**
+ * Returns the current evil omens level from a game effects array.
+ * Returns 0 if evil omens is not active.
+ */
+export const getEvilOmensLevel = (effects: string[]): number => {
+  for (const effect of effects) {
+    const { baseName, level } = parseEffectString(effect)
+    if (baseName === "evil omens") return level
+  }
+  return 0
+}


### PR DESCRIPTION
Add the **evil omens** event, which has wide-ranging mechanical consequences across the game.

## New behaviours

**When drawn:**

- The State pays 20T for sacrifices and temple repair (first time only)
- Each subsequent drawing stacks the evil omens level higher

**Each level of evil omens:**

- Reduces the State's income by 1T per level during the revenue phase
- Makes persuasion easier - the evil omens level is added to the persuasion roll
- Makes attracting knights harder - senators must spend at least as many talents as the evil omens level to attempt it, and the modifier is applied negatively to the roll; senators without sufficient talents are skipped automatically
- Makes pressuring knights less rewarding - the evil omens level is subtracted from each die roll when pressuring
- Makes popular appeals more likely to fail - the evil omens level is subtracted from the roll
- Makes State of the Republic" speeches harder - the evil omens level is subtracted from the roll
- Makes military campaigns more perilous - the evil omens level is subtracted from the combat roll
- Makes assassination attempts more likely to fail - the evil omens level is subtracted from the assassination dice roll (and bodyguard catch reroll), making a kill less likely and being caught more likely
- Makes putting Rome in order less effective - the evil omens level is subtracted from each senator revival and enemy leader death roll

## New log examples

**During the forum phase:**

- _Faction 1 drew evil omens. The State paid 20T for sacrifices and temple repair. The omens make military campaigns more perilous and senators more susceptible to persuasion._
- _Faction 2 drew evil omens. With Rome already afflicted by evil omens, further omens make military campaigns even more perilous and senators even more susceptible to persuasion._

**During the revenue phase:**

- _Evil omens reduced the State's income by 2T._

## UI changes

Combat calculator has an evil omens field now.
- It's capped at and defaulted to the current evil omens level.
- It's only visible if there are evil omens.
<img width="809" height="841" alt="image" src="https://github.com/user-attachments/assets/21e16253-6501-4482-a0ba-7c7bc50d9cb2" />

The evil omens level is visible alonside other effects.
<img width="523" height="357" alt="image" src="https://github.com/user-attachments/assets/fc9cb5c1-4999-42e4-85da-38ba82e00cb8" />

