### PR TITLE
fix: add Next.js allowed dev origin

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: ["127.0.0.1"],
 }
 
 export default nextConfig


### PR DESCRIPTION
Fixed a dev environment issue I was getting where Next.js was blocking requests to the backend server at 127.0.0.1 because it only trusted `localhost`. This prevented the frontend from recieving any data from the backend. The frontend logs had this warning:

```
⚠ Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "127.0.0.1".
Cross-origin access to Next.js dev resources is blocked by default for safety.

To allow this host in development, add it to "allowedDevOrigins" in next.config.js and restart the dev server:

// next.config.js
module.exports = {
  allowedDevOrigins: ['127.0.0.1'],
}
```

I followed this suggestion and it started working again.

A recent Next.js release added the cross-origin blocking "patch", and I ran into this problem when updating packages (package.json allows any version of Next.js greater than or equal to 16.2.6). I guess they consider it non-breaking because it only breaks development environments, and the fix is quite easy.