### PR TITLE
fix: simplify the proposal state cleardown process

### DIFF
--- a/backend/rorapp/actions/refuse_land_bill_sponsorship.py
+++ b/backend/rorapp/actions/refuse_land_bill_sponsorship.py
@@ -5,7 +5,7 @@ from rorapp.actions.meta.execution_result import ExecutionResult
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.game_state.game_state_live import GameStateLive
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.models import AvailableAction, Faction, Game, Log, Senator
 
 
@@ -73,5 +73,5 @@ class RefuseLandBillSponsorshipAction(ActionBase):
                 senator.save()
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return ExecutionResult(True)

--- a/backend/rorapp/actions/refuse_prosecutor_role.py
+++ b/backend/rorapp/actions/refuse_prosecutor_role.py
@@ -4,7 +4,7 @@ from rorapp.actions.meta.execution_result import ExecutionResult
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.game_state.game_state_live import GameStateLive
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.models import AvailableAction, Faction, Game, Senator, Log
 
 
@@ -74,22 +74,11 @@ class RefuseProsecutorRoleAction(ActionBase):
         if not prosecutor:
             return ExecutionResult(False)
 
-        prosecutor.remove_status_item(Senator.StatusItem.CONSENT_REQUIRED)
-        prosecutor.save()
-
-        accused = next(
-            (s for s in senators if s.has_status_item(Senator.StatusItem.ACCUSED)),
-            None,
-        )
-        if accused:
-            accused.remove_status_item(Senator.StatusItem.ACCUSED)
-            accused.save()
-
         Log.create_object(
             game_id,
             f"{prosecutor.display_name} refused the role of prosecutor.",
         )
 
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
 
         return ExecutionResult(True)

--- a/backend/rorapp/actions/refuse_risky_command.py
+++ b/backend/rorapp/actions/refuse_risky_command.py
@@ -4,7 +4,7 @@ from rorapp.actions.meta.execution_result import ExecutionResult
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.game_state.game_state_live import GameStateLive
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.models import AvailableAction, Faction, Game, Senator, Log
 
 
@@ -74,6 +74,6 @@ class RefuseRiskyCommandAction(ActionBase):
                 )
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
 
         return ExecutionResult(True)

--- a/backend/rorapp/actions/veto_with_tribune.py
+++ b/backend/rorapp/actions/veto_with_tribune.py
@@ -5,6 +5,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.classes.random_resolver import RandomResolver
 from rorapp.game_state.game_state_live import GameStateLive
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.end_prosecutions import end_prosecutions
 from rorapp.helpers.tribune import faction_has_tribune, spend_tribune
 from rorapp.models import AvailableAction, Faction, Game, Log, Senator
@@ -91,9 +92,6 @@ class VetoWithTribuneAction(ActionBase):
         # Record the veto
         vetoed_proposal = game.current_proposal
         game.add_defeated_proposal(vetoed_proposal)
-        game.current_proposal = None
-        game.votes_yea = 0
-        game.votes_nay = 0
 
         if is_prosecution:
             is_major = vetoed_proposal.endswith("major corruption in office")
@@ -104,33 +102,13 @@ class VetoWithTribuneAction(ActionBase):
 
         game.save()
 
-        # Clear faction statuses
+        # Clear remaining faction statuses not handled by the helper
         factions = list(Faction.objects.filter(game=game_id))
         for f in factions:
-            f.remove_status_item(FactionStatusItem.DONE)
             f.remove_status_item(FactionStatusItem.CALLED_TO_VOTE)
-            f.remove_status_item(FactionStatusItem.PROPOSED_VIA_TRIBUNE)
         Faction.objects.bulk_update(factions, ["status_items"])
 
-        # Clear senator statuses
-        senator_fields_to_clear = [
-            Senator.StatusItem.VOTED_YEA,
-            Senator.StatusItem.VOTED_NAY,
-            Senator.StatusItem.ABSTAINED,
-            Senator.StatusItem.CONSENT_REQUIRED,
-        ]
-        if is_prosecution:
-            senator_fields_to_clear += [
-                Senator.StatusItem.ACCUSED,
-                Senator.StatusItem.PROSECUTOR,
-                Senator.StatusItem.APPEALED_TO_PEOPLE,
-            ]
-
-        senators = list(Senator.objects.filter(game=game_id))
-        for senator in senators:
-            for item in senator_fields_to_clear:
-                senator.remove_status_item(item)
-        Senator.objects.bulk_update(senators, ["status_items"])
+        clear_proposal_state(game_id)
 
         Log.create_object(
             game_id,

--- a/backend/rorapp/effects/elect_censor.py
+++ b/backend/rorapp/effects/elect_censor.py
@@ -2,7 +2,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Senator
 from rorapp.models.log import Log
@@ -67,7 +67,7 @@ class ElectCensorEffect(EffectBase):
                 )
 
             game.clear_senate_sub_phase_proposals()
-            clear_proposal_and_votes(game_id)
+            clear_proposal_state(game_id)
             game = Game.objects.get(id=game_id)
             game.sub_phase = Game.SubPhase.PROSECUTION
             game.prosecutions_remaining = 2
@@ -84,6 +84,6 @@ class ElectCensorEffect(EffectBase):
             )
             game.save()
             handle_unanimous_defeat(game_id)
-            clear_proposal_and_votes(game_id)
+            clear_proposal_state(game_id)
 
         return True

--- a/backend/rorapp/effects/elect_consuls.py
+++ b/backend/rorapp/effects/elect_consuls.py
@@ -2,7 +2,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Senator
 from rorapp.models.log import Log
@@ -53,5 +53,5 @@ class ElectConsulsEffect(EffectBase):
             handle_unanimous_defeat(game_id)
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/elect_dictator.py
+++ b/backend/rorapp/effects/elect_dictator.py
@@ -3,7 +3,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.dictator_appointment import appoint_dictator
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Senator
 from rorapp.models.log import Log
@@ -37,7 +37,7 @@ class ElectDictatorEffect(EffectBase):
 
         if game.votes_yea > game.votes_nay:
             Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
-            clear_proposal_and_votes(game_id)
+            clear_proposal_state(game_id)
             if dictator_candidate:
                 appoint_dictator(game_id, dictator_candidate.id)
         else:
@@ -48,6 +48,6 @@ class ElectDictatorEffect(EffectBase):
             )
             game.save()
             handle_unanimous_defeat(game_id)
-            clear_proposal_and_votes(game_id)
+            clear_proposal_state(game_id)
 
         return True

--- a/backend/rorapp/effects/proposal_award_concession.py
+++ b/backend/rorapp/effects/proposal_award_concession.py
@@ -3,7 +3,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Log, Senator
 
@@ -75,5 +75,5 @@ class ProposalAwardConcessionEffect(EffectBase):
             handle_unanimous_defeat(game_id)
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/proposal_deploy_forces.py
+++ b/backend/rorapp/effects/proposal_deploy_forces.py
@@ -4,7 +4,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.text import format_list
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.hrao import set_hrao
@@ -177,5 +177,5 @@ class ProposalDeployForcesEffect(EffectBase):
             handle_unanimous_defeat(game_id)
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/proposal_pass_land_bill.py
+++ b/backend/rorapp/effects/proposal_pass_land_bill.py
@@ -2,7 +2,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.game_data import load_land_bills
 from rorapp.helpers.proposal_available import LAND_BILL_EFFECT
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
@@ -107,5 +107,5 @@ class ProposalLandBillEffect(EffectBase):
         game.add_unavailable_proposal(f"pass type {bill_type} land bill")
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/proposal_raise_forces.py
+++ b/backend/rorapp/effects/proposal_raise_forces.py
@@ -5,7 +5,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.text import format_list
 from rorapp.helpers.unit_lists import unit_list_to_string
@@ -145,5 +145,5 @@ class ProposalRaiseForcesEffect(EffectBase):
             handle_unanimous_defeat(game_id)
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/proposal_recall_forces.py
+++ b/backend/rorapp/effects/proposal_recall_forces.py
@@ -4,7 +4,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.unit_lists import string_to_unit_list, unit_list_to_string
 from rorapp.models import Campaign, Fleet, Game, Legion, Log, Senator, War
@@ -75,7 +75,7 @@ class ProposalRecallForcesEffect(EffectBase):
                     f"Cannot recall forces from a campaign that was recently deployed or reinforced.",
                 )
                 game.save()
-                clear_proposal_and_votes(game_id)
+                clear_proposal_state(game_id)
                 return True
 
             legion_pattern = (
@@ -139,5 +139,5 @@ class ProposalRecallForcesEffect(EffectBase):
             handle_unanimous_defeat(game_id)
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/proposal_reinforce_proconsul.py
+++ b/backend/rorapp/effects/proposal_reinforce_proconsul.py
@@ -4,7 +4,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.unit_lists import string_to_unit_list, unit_list_to_string
 from rorapp.models import Campaign, Fleet, Game, Legion, Log, War
@@ -60,7 +60,7 @@ class ProposalReinforceProconsulEffect(EffectBase):
                     f"Reinforcement failed: campaign has no commander.",
                 )
                 game.save()
-                clear_proposal_and_votes(game_id)
+                clear_proposal_state(game_id)
                 return True
 
             if campaign.recently_deployed:
@@ -69,7 +69,7 @@ class ProposalReinforceProconsulEffect(EffectBase):
                     f"Reinforcement failed: campaign was recently deployed.",
                 )
                 game.save()
-                clear_proposal_and_votes(game_id)
+                clear_proposal_state(game_id)
                 return True
 
             wars = War.objects.filter(game=game)
@@ -140,5 +140,5 @@ class ProposalReinforceProconsulEffect(EffectBase):
             handle_unanimous_defeat(game_id)
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/proposal_repeal_land_bill.py
+++ b/backend/rorapp/effects/proposal_repeal_land_bill.py
@@ -2,7 +2,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.game_data import load_land_bills
 from rorapp.helpers.proposal_available import LAND_BILL_EFFECT
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
@@ -82,5 +82,5 @@ class ProposalLandBillRepealEffect(EffectBase):
         game.add_unavailable_proposal(f"repeal type {bill_type} land bill")
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/effects/proposal_replace_proconsul.py
+++ b/backend/rorapp/effects/proposal_replace_proconsul.py
@@ -2,7 +2,7 @@ from rorapp.classes.random_resolver import RandomResolver
 from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.proposal_parsing import extract_master_of_horse
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Campaign, Game, Log, Senator, War
@@ -97,7 +97,7 @@ class ProposalReplaceProconsulEffect(EffectBase):
                     f"Cannot replace commander of a campaign that was recently deployed or reinforced.",
                 )
                 game.save()
-                clear_proposal_and_votes(game_id)
+                clear_proposal_state(game_id)
                 return True
 
             # Update campaign commander (and Master of Horse if Dictator)
@@ -138,5 +138,5 @@ class ProposalReplaceProconsulEffect(EffectBase):
             handle_unanimous_defeat(game_id)
 
         game.save()
-        clear_proposal_and_votes(game_id)
+        clear_proposal_state(game_id)
         return True

--- a/backend/rorapp/helpers/assassination_proposal_consequences.py
+++ b/backend/rorapp/helpers/assassination_proposal_consequences.py
@@ -1,4 +1,4 @@
-from rorapp.helpers.clear_proposal_and_votes import clear_proposal_and_votes
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.models import Game, Senator
 
 
@@ -22,7 +22,7 @@ def handle_proposal_consequences(
     # §1.09.721: If the Censor dies during the Prosecution step, the current
     # Prosecution is cancelled and no more Prosecutions are possible.
     if was_censor and sub_phase == Game.SubPhase.PROSECUTION:
-        clear_proposal_and_votes(game.id)
+        clear_proposal_state(game.id)
         game.refresh_from_db()
         game.prosecutions_remaining = 0
         game.save()
@@ -38,7 +38,7 @@ def handle_proposal_consequences(
 
     if sub_phase == Game.SubPhase.PROSECUTION:
         # Cancel prosecution; it still counts toward the Censor's limit
-        clear_proposal_and_votes(game.id)
+        clear_proposal_state(game.id)
         game.refresh_from_db()
         game.prosecutions_remaining -= 1
         game.save()
@@ -49,7 +49,7 @@ def handle_proposal_consequences(
         Game.SubPhase.DICTATOR_ELECTION,
     ):
         # Cancel proposal — PM can re-propose with a different nominee
-        clear_proposal_and_votes(game.id)
+        clear_proposal_state(game.id)
 
     elif sub_phase == Game.SubPhase.OTHER_BUSINESS:
         proposal = game.current_proposal or ""
@@ -60,7 +60,7 @@ def handle_proposal_consequences(
             # Concession award: once per turn, cannot be re-proposed
             game.add_unavailable_proposal(proposal)
             game.save()
-            clear_proposal_and_votes(game.id)
+            clear_proposal_state(game.id)
         else:
             # Deploy forces / replace proconsul: PM can re-propose
-            clear_proposal_and_votes(game.id)
+            clear_proposal_state(game.id)

--- a/backend/rorapp/helpers/clear_proposal_state.py
+++ b/backend/rorapp/helpers/clear_proposal_state.py
@@ -2,7 +2,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.models import Faction, Game, Senator
 
 
-def clear_proposal_and_votes(game_id: int):
+def clear_proposal_state(game_id: int):
 
     game = Game.objects.get(id=game_id)
     game.current_proposal = None
@@ -18,8 +18,12 @@ def clear_proposal_and_votes(game_id: int):
 
     senators = list(Senator.objects.filter(game=game_id))
     for senator in senators:
+        senator.remove_status_item(Senator.StatusItem.ACCUSED)
+        senator.remove_status_item(Senator.StatusItem.APPEALED_TO_PEOPLE)
+        senator.remove_status_item(Senator.StatusItem.CONSENT_REQUIRED)
+        senator.remove_status_item(Senator.StatusItem.NAMED_IN_PROPOSAL)
+        senator.remove_status_item(Senator.StatusItem.PROSECUTOR)
         senator.remove_status_item(Senator.StatusItem.VOTED_NAY)
         senator.remove_status_item(Senator.StatusItem.VOTED_YEA)
         senator.remove_status_item(Senator.StatusItem.ABSTAINED)
-        senator.remove_status_item(Senator.StatusItem.NAMED_IN_PROPOSAL)
     Senator.objects.bulk_update(senators, ["status_items"])

--- a/backend/rorapp/helpers/finish_prosecution.py
+++ b/backend/rorapp/helpers/finish_prosecution.py
@@ -1,6 +1,6 @@
-from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.end_prosecutions import end_prosecutions
-from rorapp.models import Faction, Game, Senator
+from rorapp.models import Game
 
 
 def finish_prosecution(game_id: int, is_major: bool, guilty: bool) -> None:
@@ -9,26 +9,9 @@ def finish_prosecution(game_id: int, is_major: bool, guilty: bool) -> None:
         game.prosecutions_remaining = 0
     else:
         game.prosecutions_remaining = max(0, game.prosecutions_remaining - 1)
-    game.current_proposal = None
-    game.votes_yea = 0
-    game.votes_nay = 0
     game.save()
 
-    factions = list(Faction.objects.filter(game=game_id))
-    for faction in factions:
-        faction.remove_status_item(FactionStatusItem.DONE)
-    Faction.objects.bulk_update(factions, ["status_items"])
-
-    all_senators = list(Senator.objects.filter(game=game_id))
-    for senator in all_senators:
-        senator.remove_status_item(Senator.StatusItem.ACCUSED)
-        senator.remove_status_item(Senator.StatusItem.APPEALED_TO_PEOPLE)
-        senator.remove_status_item(Senator.StatusItem.NAMED_IN_PROPOSAL)
-        senator.remove_status_item(Senator.StatusItem.PROSECUTOR)
-        senator.remove_status_item(Senator.StatusItem.VOTED_NAY)
-        senator.remove_status_item(Senator.StatusItem.VOTED_YEA)
-        senator.remove_status_item(Senator.StatusItem.ABSTAINED)
-    Senator.objects.bulk_update(all_senators, ["status_items"])
+    clear_proposal_state(game_id)
 
     game = Game.objects.get(id=game_id)
     if game.prosecutions_remaining == 0:

--- a/backend/tests/s1_basic_game/s1_09_senate_phase/s1_09_152_tribune_veto_test.py
+++ b/backend/tests/s1_basic_game/s1_09_senate_phase/s1_09_152_tribune_veto_test.py
@@ -271,6 +271,37 @@ def test_faction_can_veto_while_called_to_vote(
 
 
 @pytest.mark.django_db
+def test_veto_clears_named_in_proposal_status(
+    senate_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = senate_game
+    game.current_proposal = "Elect consuls Julius and Cornelius"
+    game.save()
+    factions = list(Faction.objects.filter(game=game))
+    non_pm_faction = next(
+        f
+        for f in factions
+        if not any(
+            s.has_title(Senator.Title.PRESIDING_MAGISTRATE) for s in f.senators.all()
+        )
+    )
+    non_pm_faction.cards = ["tribune"]
+    non_pm_faction.save()
+    named_senator = Senator.objects.filter(game=game).first()
+    assert named_senator is not None
+    named_senator.add_status_item(Senator.StatusItem.NAMED_IN_PROPOSAL)
+    named_senator.save()
+
+    # Act
+    VetoWithTribuneAction().execute(game.id, non_pm_faction.id, {}, resolver)
+
+    # Assert
+    named_senator.refresh_from_db()
+    assert not named_senator.has_status_item(Senator.StatusItem.NAMED_IN_PROPOSAL)
+
+
+@pytest.mark.django_db
 def test_veto_with_free_tribune_removes_status_not_card(
     senate_game: Game, resolver: FakeRandomResolver
 ):


### PR DESCRIPTION
Closes #715 by making sure all proposal-related state is cleared after a proposal is vetoed.

Also rename `clear_proposal_and_votes()` to `clear_proposal_state()` to reflect it's broader scope.