### PR TITLE
feat: add preset system for dev game state setup

### DIFF
--- a/backend/rorapp/data/presets/base.json
+++ b/backend/rorapp/data/presets/base.json
@@ -1,0 +1,127 @@
+{
+  "game": {
+    "turn": 1,
+    "step": 1,
+    "state_treasury": 100,
+    "unrest": 0,
+    "deck": []
+  },
+  "senators": [
+    {
+      "family_name": "Cornelius",
+      "code": "1",
+      "faction_position": 1,
+      "military": 4,
+      "oratory": 3,
+      "loyalty": 9,
+      "influence": 10,
+      "knights": 0,
+      "titles": ["FACTION_LEADER", "ROME_CONSUL", "HRAO"]
+    },
+    {
+      "family_name": "Fabius",
+      "code": "2",
+      "faction_position": 1,
+      "military": 4,
+      "oratory": 2,
+      "loyalty": 9,
+      "influence": 5,
+      "knights": 0,
+      "titles": []
+    },
+    {
+      "family_name": "Valerius",
+      "code": "3",
+      "faction_position": 1,
+      "military": 1,
+      "oratory": 2,
+      "loyalty": 10,
+      "influence": 5,
+      "knights": 0,
+      "titles": []
+    },
+    {
+      "family_name": "Julius",
+      "code": "4",
+      "faction_position": 2,
+      "military": 4,
+      "oratory": 3,
+      "loyalty": 9,
+      "influence": 4,
+      "knights": 0,
+      "titles": ["FACTION_LEADER"]
+    },
+    {
+      "family_name": "Claudius",
+      "code": "5",
+      "faction_position": 2,
+      "military": 2,
+      "oratory": 3,
+      "loyalty": 7,
+      "influence": 4,
+      "knights": 0,
+      "titles": []
+    },
+    {
+      "family_name": "Manlius",
+      "code": "6",
+      "faction_position": 2,
+      "military": 3,
+      "oratory": 2,
+      "loyalty": 7,
+      "influence": 4,
+      "knights": 0,
+      "titles": []
+    },
+    {
+      "family_name": "Fulvius",
+      "code": "7",
+      "faction_position": 3,
+      "military": 2,
+      "oratory": 2,
+      "loyalty": 8,
+      "influence": 4,
+      "knights": 0,
+      "titles": ["FACTION_LEADER"]
+    },
+    {
+      "family_name": "Furius",
+      "code": "8",
+      "faction_position": 3,
+      "military": 3,
+      "oratory": 3,
+      "loyalty": 8,
+      "influence": 3,
+      "knights": 0,
+      "titles": []
+    },
+    {
+      "family_name": "Aurelius",
+      "code": "9",
+      "faction_position": 3,
+      "military": 2,
+      "oratory": 3,
+      "loyalty": 7,
+      "influence": 3,
+      "knights": 0,
+      "titles": []
+    }
+  ],
+  "wars": [
+    {
+      "name": "1st Punic War",
+      "series_name": "Punic",
+      "index": 0,
+      "land_strength": 10,
+      "fleet_support": 5,
+      "naval_strength": 10,
+      "disaster_numbers": [13],
+      "standoff_numbers": [11, 14],
+      "spoils": 35,
+      "famine": false,
+      "location": "Sicilia",
+      "status": "inactive"
+    }
+  ],
+  "legions": [1, 2, 3, 4]
+}

--- a/backend/rorapp/data/presets/forum__attract_knight.json
+++ b/backend/rorapp/data/presets/forum__attract_knight.json
@@ -1,5 +1,5 @@
 {
-  "label": "Forum — Attract Knight",
+  "label": "Forum - Attract Knight",
   "extends": "base",
   "game": {
     "phase": "forum",

--- a/backend/rorapp/data/presets/forum__attract_knight.json
+++ b/backend/rorapp/data/presets/forum__attract_knight.json
@@ -1,0 +1,20 @@
+{
+  "label": "Forum — Attract Knight",
+  "extends": "base",
+  "game": {
+    "phase": "forum",
+    "sub_phase": "attract knight"
+  },
+  "factions": [
+    {
+      "position": 1,
+      "status_items": ["CURRENT_INITIATIVE"]
+    }
+  ],
+  "senators": [
+    {
+      "code": "1",
+      "knights": 2
+    }
+  ]
+}

--- a/backend/rorapp/data/presets/mortality.json
+++ b/backend/rorapp/data/presets/mortality.json
@@ -1,0 +1,7 @@
+{
+  "label": "Mortality",
+  "extends": "base",
+  "game": {
+    "phase": "mortality"
+  }
+}

--- a/backend/rorapp/data/presets/mortality__provinces.json
+++ b/backend/rorapp/data/presets/mortality__provinces.json
@@ -1,0 +1,8 @@
+{
+  "label": "Mortality — Provinces",
+  "extends": "mortality",
+  "provinces": [
+    { "name": "Sicilia", "developed": false },
+    { "name": "Macedonia", "developed": true }
+  ]
+}

--- a/backend/rorapp/data/presets/mortality__provinces.json
+++ b/backend/rorapp/data/presets/mortality__provinces.json
@@ -1,5 +1,5 @@
 {
-  "label": "Mortality — Provinces",
+  "label": "Mortality - Provinces",
   "extends": "mortality",
   "provinces": [
     { "name": "Sicilia", "developed": false },

--- a/backend/rorapp/data/presets/revenue.json
+++ b/backend/rorapp/data/presets/revenue.json
@@ -1,0 +1,8 @@
+{
+  "label": "Revenue",
+  "extends": "base",
+  "game": {
+    "phase": "revenue",
+    "step": 2
+  }
+}

--- a/backend/rorapp/helpers/preset_loader.py
+++ b/backend/rorapp/helpers/preset_loader.py
@@ -1,0 +1,126 @@
+import json
+import os
+
+from django.conf import settings
+from django.utils.timezone import now
+
+from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
+from rorapp.game_state.send_game_state import send_game_state
+from rorapp.helpers.provinces import province_static_fields
+from rorapp.models import Faction, Game, Legion, Province, Senator, War
+
+PRESETS_DIR = os.path.join(settings.BASE_DIR, "rorapp", "data", "presets")
+
+
+def _load_preset_file(name: str) -> dict:
+    path = os.path.join(PRESETS_DIR, f"{name}.json")
+    with open(path) as f:
+        return json.load(f)
+
+
+def resolve_preset(name: str) -> dict:
+    data = _load_preset_file(name)
+    if "extends" not in data:
+        return data
+    base = resolve_preset(data["extends"])
+    merged = {**base}
+    for key, value in data.items():
+        if key == "extends":
+            continue
+        if key == "game" and "game" in base:
+            merged["game"] = {**base["game"], **value}
+        elif key == "senators" and "senators" in base:
+            base_senators = {s["code"]: s for s in base["senators"]}
+            for s in value:
+                code = s["code"]
+                base_senators[code] = {**base_senators[code], **s} if code in base_senators else s
+            merged["senators"] = list(base_senators.values())
+        else:
+            merged[key] = value
+    return merged
+
+
+def list_presets() -> list[dict]:
+    presets = []
+    for filename in sorted(os.listdir(PRESETS_DIR)):
+        if not filename.endswith(".json"):
+            continue
+        name = filename[:-5]
+        data = _load_preset_file(name)
+        if "label" in data:
+            presets.append({"name": name, "label": data["label"]})
+    return presets
+
+
+def load_preset(game: Game, preset_data: dict) -> None:
+    factions = {f.position: f for f in Faction.objects.filter(game=game)}
+
+    game_fields = preset_data["game"]
+    game.phase = game_fields["phase"]
+    game.sub_phase = game_fields.get("sub_phase", Game.SubPhase.START)
+    game.turn = game_fields.get("turn", 1)
+    game.step = game_fields.get("step", 1)
+    game.state_treasury = game_fields.get("state_treasury", 100)
+    game.unrest = game_fields.get("unrest", 0)
+    game.deck = game_fields.get("deck", [])
+    game.started_on = now()
+    game.save()
+
+    for f in preset_data.get("factions", []):
+        faction = factions.get(f["position"])
+        if faction is None:
+            continue
+        faction.clear_status_items()
+        for item_name in f.get("status_items", []):
+            faction.add_status_item(FactionStatusItem[item_name])
+        faction.save()
+
+    for s in preset_data.get("senators", []):
+        senator = Senator.objects.create(
+            family_name=s["family_name"],
+            game=game,
+            code=str(s["code"]),
+            faction=factions.get(s["faction_position"]),
+            military=s["military"],
+            oratory=s["oratory"],
+            loyalty=s["loyalty"],
+            influence=s["influence"],
+            knights=s.get("knights", 0),
+        )
+        for title_name in s.get("titles", []):
+            senator.add_title(Senator.Title[title_name])
+        senator.save()
+
+    for w in preset_data.get("wars", []):
+        war = War(
+            game=game,
+            name=w["name"],
+            index=w["index"],
+            land_strength=w["land_strength"],
+            fleet_support=w["fleet_support"],
+            naval_strength=w["naval_strength"],
+            disaster_numbers=w["disaster_numbers"],
+            standoff_numbers=w["standoff_numbers"],
+            spoils=w["spoils"],
+            famine=w["famine"],
+            location=w["location"],
+            status=w["status"],
+        )
+        if "series_name" in w:
+            war.series_name = w["series_name"]
+        war.save()
+
+    for num in preset_data.get("legions", []):
+        Legion.objects.create(game=game, number=num)
+
+    for p in preset_data.get("provinces", []):
+        Province.objects.create(
+            game=game,
+            name=p["name"],
+            developed=p["developed"],
+            **province_static_fields(p["name"]),
+        )
+
+    execute_effects_and_manage_actions(game.id)
+    send_game_state(game.id)

--- a/backend/rorapp/serializers/game.py
+++ b/backend/rorapp/serializers/game.py
@@ -15,7 +15,7 @@ class FactionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Faction
-        fields = ["player"]
+        fields = ["id", "position", "player"]
 
 
 class SimpleGameSerializer(serializers.ModelSerializer):

--- a/backend/rorapp/urls.py
+++ b/backend/rorapp/urls.py
@@ -27,35 +27,24 @@ urlpatterns = [
     ),
 ]
 
+
 if settings.TEST_ENDPOINTS_ENABLED:
     from rorapp.views.test_helpers import (
-        test_create_forum_provinces,
-        test_enter_attract_knight_with_initiative,
-        test_give_knights,
+        test_list_presets,
+        test_load_preset,
         test_login,
-        test_skip_to_next_phase,
     )
 
     urlpatterns += [
         path("api/test/login/", test_login, name="test_login"),
         path(
-            "api/test/skip-to-next-phase/<int:game_id>/",
-            test_skip_to_next_phase,
-            name="test_skip_to_next_phase",
+            "api/test/presets/",
+            test_list_presets,
+            name="test_list_presets",
         ),
         path(
-            "api/test/give-knights/<int:game_id>/",
-            test_give_knights,
-            name="test_give_knights",
-        ),
-        path(
-            "api/test/enter-attract-knight-with-initiative/<int:game_id>/",
-            test_enter_attract_knight_with_initiative,
-            name="test_enter_attract_knight_with_initiative",
-        ),
-        path(
-            "api/test/create-forum-provinces/<int:game_id>/",
-            test_create_forum_provinces,
-            name="test_create_forum_provinces",
+            "api/test/load-preset/<int:game_id>/",
+            test_load_preset,
+            name="test_load_preset",
         ),
     ]

--- a/backend/rorapp/views/test_helpers.py
+++ b/backend/rorapp/views/test_helpers.py
@@ -5,19 +5,14 @@ __test__ = False
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.models import User
+from django.db import transaction
 from django.http import JsonResponse
 from django.middleware.csrf import get_token
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from rorapp.helpers.phase_transition import advance_to_next_phase
-from rorapp.helpers.provinces import province_static_fields
-from rorapp.game_state.send_game_state import send_game_state
-from rorapp.game_state.game_state_snapshot import GameStateSnapshot
-from rorapp.actions.attract_knight import AttractKnightAction
-from rorapp.actions.pressure_knight import PressureKnightAction
-from rorapp.models import AvailableAction, Faction, Game, Province, Senator
-from rorapp.classes.faction_status_item import FactionStatusItem
+from rorapp.helpers.preset_loader import list_presets, load_preset, resolve_preset
+from rorapp.models import Faction, Game
 
 
 @csrf_exempt
@@ -40,199 +35,47 @@ def test_login(request):
 
 
 @csrf_exempt
-@require_POST
-def test_skip_to_next_phase(request, game_id: int):
+def test_list_presets(request):
     if not settings.TEST_ENDPOINTS_ENABLED:
         return JsonResponse({}, status=403)
 
-    game, _ = advance_to_next_phase(game_id)
-    return JsonResponse({"phase": game.phase, "sub_phase": game.sub_phase})
+    return JsonResponse({"presets": list_presets()})
 
 
 @csrf_exempt
 @require_POST
-def test_give_knights(request, game_id: int):
+def test_load_preset(request, game_id: int):
     if not settings.TEST_ENDPOINTS_ENABLED:
         return JsonResponse({}, status=403)
 
     try:
         data = json.loads(request.body)
-        knights_to_add = int(data.get("knights", 1))
-    except (ValueError, TypeError, json.JSONDecodeError):
-        return JsonResponse({"detail": "Invalid payload"}, status=400)
+        preset = data["preset"]
+    except (KeyError, json.JSONDecodeError):
+        return JsonResponse({"detail": "preset field required"}, status=400)
 
-    senator = None
-    if "senator_id" in data:
-        try:
-            senator_id = int(data["senator_id"])
-            senator = Senator.objects.get(id=senator_id, game_id=game_id, alive=True)
-        except (ValueError, TypeError, Senator.DoesNotExist):
-            return JsonResponse({"detail": "Senator not found or not alive in this game"}, status=404)
-    elif "faction_position" in data:
-        try:
-            faction_position = int(data["faction_position"])
-            faction = Faction.objects.get(game_id=game_id, position=faction_position)
-            senator = Senator.objects.filter(
-                game_id=game_id, faction=faction, alive=True
-            ).order_by("id").first()
-            if not senator:
-                return JsonResponse({"detail": "No alive senator found for faction"}, status=404)
-        except (ValueError, TypeError, Faction.DoesNotExist):
-            return JsonResponse({"detail": "Faction not found for given position"}, status=404)
-    else:
-        return JsonResponse({"detail": "Provide either senator_id or faction_position"}, status=400)
-
-    senator.knights += knights_to_add
-    senator.save()
-
-    send_game_state(game_id)
-
-    return JsonResponse({
-        "senator_id": senator.id,
-        "knights": senator.knights,
-    })
-
-
-@csrf_exempt
-@require_POST
-def test_enter_attract_knight_with_initiative(request, game_id: int):
-    """
-    Test-only helper for E2E: Force the game into the exact state needed
-    for the Pressure Knight action (and Attract Knight) to be available.
-
-    Sets phase=forum + sub_phase=attract knight, gives CURRENT_INITIATIVE
-    to the requested faction (by position), optionally seeds knights on one
-    of its senators, directly creates the relevant AvailableAction rows,
-    and pushes state. The test then does a page reload to observe the UI.
-    """
-    if not settings.TEST_ENDPOINTS_ENABLED:
-        return JsonResponse({}, status=403)
-
-    try:
-        data = json.loads(request.body)
-        faction_position = int(data["faction_position"])
-        knights = int(data.get("knights", 0))
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError):
-        return JsonResponse({"detail": "Invalid payload: faction_position (int) required"}, status=400)
+    available = [p["name"] for p in list_presets()]
+    if preset not in available:
+        return JsonResponse(
+            {"detail": f"Unknown preset '{preset}'. Available: {available}"},
+            status=400,
+        )
 
     try:
         game = Game.objects.get(id=game_id)
-        faction = Faction.objects.get(game_id=game_id, position=faction_position)
-    except (Game.DoesNotExist, Faction.DoesNotExist):
-        return JsonResponse({"detail": "Game or faction not found"}, status=404)
-
-    try:
-        # Force the precise sub-phase state required by PressureKnightAction.is_allowed
-        game.phase = Game.Phase.FORUM
-        game.sub_phase = Game.SubPhase.ATTRACT_KNIGHT
-        game.save()
-
-        # Clear initiative/status from everyone, then give it only to the target
-        for f in Faction.objects.filter(game_id=game_id):
-            f.clear_status_items()
-            f.save()
-        faction.add_status_item(FactionStatusItem.CURRENT_INITIATIVE)
-        faction.save()
-
-        # Optionally seed knights on one of the faction's senators
-        if knights > 0:
-            senator = Senator.objects.filter(
-                game_id=game_id, faction=faction, alive=True
-            ).order_by("id").first()
-            if senator:
-                senator.knights += knights
-                senator.save()
-
-        # Create exactly the actions needed for this sub-phase (Pressure + Attract for the
-        # current initiative holder). We deliberately avoid the full effect executor here
-        # because jumping a fresh game straight into ATTRACT_KNIGHT can trigger unrelated
-        # effects that aren't prepared for the artificial state.
-        AvailableAction.objects.filter(game=game).delete()
-
-        snapshot = GameStateSnapshot(game_id)
-        # These will only create AvailableAction rows for factions where is_allowed passes.
-        PressureKnightAction().get_schema(snapshot, faction.id)
-        AttractKnightAction().get_schema(snapshot, faction.id)
-
-        # The WS push can sometimes fail in test environments (channel layer / Redis
-        # connectivity from the WSGI process, or no active consumers). Since the
-        # E2E test immediately does a page.reload() afterward, we treat the push
-        # as best-effort so we don't turn a successful state mutation into a 500.
-        try:
-            send_game_state(game_id)
-        except Exception:
-            # Best effort only — the reload will fetch fresh state via normal paths.
-            pass
-
-        return JsonResponse({
-            "phase": game.phase,
-            "sub_phase": game.sub_phase,
-            "faction_position": faction_position,
-            "has_current_initiative": faction.has_status_item(FactionStatusItem.CURRENT_INITIATIVE),
-        })
-    except Exception:
-        # Return JSON instead of letting Django render a debug HTML page in the test env.
-        return JsonResponse(
-            {"detail": "Internal error while preparing attract knight state"},
-            status=500,
-        )
-
-
-@csrf_exempt
-@require_POST
-def test_create_forum_provinces(request, game_id: int):
-    if not settings.TEST_ENDPOINTS_ENABLED:
-        return JsonResponse({}, status=403)
-
-    try:
-        data = json.loads(request.body)
-        provinces = data["provinces"]
-    except (KeyError, TypeError, json.JSONDecodeError):
-        return JsonResponse(
-            {"detail": "Invalid payload: provinces (list) required"},
-            status=400,
-        )
-
-    if not isinstance(provinces, list) or not provinces:
-        return JsonResponse(
-            {"detail": "provinces must be a non-empty list"},
-            status=400,
-        )
-
-    try:
-        Game.objects.get(id=game_id)
     except Game.DoesNotExist:
         return JsonResponse({"detail": "Game not found"}, status=404)
 
-    created = []
-    for entry in provinces:
-        if not isinstance(entry, dict) or "name" not in entry:
-            return JsonResponse(
-                {"detail": "Each province entry must include a name"},
-                status=400,
-            )
-        name = entry["name"]
-        developed = bool(entry.get("developed", False))
-        if Province.objects.filter(game_id=game_id, name=name).exists():
-            return JsonResponse(
-                {"detail": f"Province already exists: {name}"},
-                status=400,
-            )
-        province = Province.objects.create(
-            game_id=game_id,
-            name=name,
-            developed=developed,
-            **province_static_fields(name),
-        )
-        created.append(
-            {
-                "id": province.id,
-                "name": province.name,
-                "developed": province.developed,
-                "frontier": province.frontier,
-            }
+    if Faction.objects.filter(game=game).count() < 3:
+        return JsonResponse(
+            {"detail": "At least 3 players must join before loading a preset"},
+            status=400,
         )
 
-    send_game_state(game_id)
-
-    return JsonResponse({"provinces": created})
+    try:
+        with transaction.atomic():
+            preset_data = resolve_preset(preset)
+            load_preset(game, preset_data)
+        return JsonResponse({"game_id": game_id, "preset": preset})
+    except Exception as e:
+        return JsonResponse({"detail": str(e)}, status=500)

--- a/frontend/app/(protected)/games/[id]/page.tsx
+++ b/frontend/app/(protected)/games/[id]/page.tsx
@@ -28,12 +28,28 @@ const GamePage = () => {
   const [password, setPassword] = useState<string>("")
   const [loading, setLoading] = useState<boolean>(false)
   const [errors, setErrors] = useState<JoinError>({})
+  const [devPresets, setDevPresets] = useState<
+    { name: string; label: string }[]
+  >([])
+  const [selectedPreset, setSelectedPreset] = useState("")
+  const [loadingPreset, setLoadingPreset] = useState<string | null>(null)
 
   useEffect(() => {
     if (publicGameState?.game && publicGameState.game.status !== "pending") {
       router.replace(`/games/${params.id}/live`)
     }
   }, [publicGameState, params.id, router])
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_BACKEND_ORIGIN}/api/test/presets/`, {
+      credentials: "include",
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.presets) setDevPresets(data.presets)
+      })
+      .catch(() => {})
+  }, [])
 
   if (publicGameState?.game && publicGameState.game.status !== "pending") {
     return null
@@ -115,6 +131,20 @@ const GamePage = () => {
     if (response.ok) toast.success("You've left this game")
   }
 
+  const handleLoadPreset = async (preset: string) => {
+    setLoadingPreset(preset)
+    await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_ORIGIN}/api/test/load-preset/${game?.id}/`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ preset }),
+      },
+    )
+    setLoadingPreset(null)
+  }
+
   const handleStartClick = async () => {
     const userConfirmed = window.confirm(
       "Are you sure you want to start this game?",
@@ -172,7 +202,10 @@ const GamePage = () => {
                       (f) => f.position === position,
                     )
                     return (
-                      <li key={position} className="flex min-h-[28px] flex-wrap">
+                      <li
+                        key={position}
+                        className="flex min-h-[28px] flex-wrap"
+                      >
                         <span>Faction {position}</span>
                         {faction && (
                           <span className="ml-4 inline-block">
@@ -230,6 +263,39 @@ const GamePage = () => {
                 )}
               </div>
             )}
+            {devPresets.length > 0 &&
+              user &&
+              game.host.id === user.id &&
+              publicGameState.factions.length >= 3 && (
+                <div className="flex flex-col gap-2 pt-4">
+                  <p className="text-sm text-neutral-500">Load preset</p>
+                  <div className="flex items-center gap-2">
+                    <select
+                      value={selectedPreset}
+                      onChange={(e) => setSelectedPreset(e.target.value)}
+                      className="rounded-md border border-neutral-400 px-2 py-1 text-neutral-600"
+                    >
+                      <option value="" disabled>
+                        Select preset
+                      </option>
+                      {devPresets.map(({ name, label }) => (
+                        <option key={name} value={name}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      onClick={() => {
+                        if (selectedPreset) handleLoadPreset(selectedPreset)
+                      }}
+                      disabled={!selectedPreset || loadingPreset !== null}
+                      className="rounded-md border border-neutral-400 px-4 py-1 text-neutral-600 hover:bg-neutral-100 disabled:border-neutral-300 disabled:text-neutral-400 disabled:hover:bg-transparent"
+                    >
+                      {loadingPreset !== null ? "Loading…" : "Load"}
+                    </button>
+                  </div>
+                </div>
+              )}
           </div>
         )}
         <dialog

--- a/frontend/tests/helpers/game.ts
+++ b/frontend/tests/helpers/game.ts
@@ -15,6 +15,7 @@ export async function deleteGame(
 
 export async function setupGame(
   request: APIRequest,
+  preset?: string,
 ): Promise<{ gameId: number; players: Player[] }> {
   const utilCtx = await request.newContext()
   await Promise.all(PLAYER_USERNAMES.map((u) => ensureUser(utilCtx, u)))
@@ -47,9 +48,13 @@ export async function setupGame(
     }),
   ])
 
-  expect(
-    (await hostApi.post(`${BACKEND}/api/games/${gameId}/start-game/`)).ok(),
-  ).toBeTruthy()
+  if (preset) {
+    await loadPreset(hostApi, gameId, preset)
+  } else {
+    expect(
+      (await hostApi.post(`${BACKEND}/api/games/${gameId}/start-game/`)).ok(),
+    ).toBeTruthy()
+  }
 
   return {
     gameId,
@@ -60,45 +65,14 @@ export async function setupGame(
   }
 }
 
-export async function skipToNextPhase(
+export async function loadPreset(
   context: APIRequestContext,
   gameId: number,
-): Promise<{ phase: string; subPhase: string }> {
-  const response = await context.post(
-    `${BACKEND}/api/test/skip-to-next-phase/${gameId}/`,
-  )
-  expect(response.ok()).toBeTruthy()
-  const { phase, sub_phase: subPhase } = await response.json()
-  return { phase, subPhase }
-}
-
-export interface ForumProvinceSeed {
-  name: string
-  developed?: boolean
-}
-
-export async function createForumProvinces(
-  context: APIRequestContext,
-  gameId: number,
-  provinces: ForumProvinceSeed[],
+  preset: string,
 ): Promise<void> {
   const response = await context.post(
-    `${BACKEND}/api/test/create-forum-provinces/${gameId}/`,
-    { data: { provinces } },
+    `${BACKEND}/api/test/load-preset/${gameId}/`,
+    { data: { preset } },
   )
   expect(response.ok()).toBeTruthy()
-}
-
-export async function enterAttractKnightWithInitiative(
-  context: APIRequestContext,
-  gameId: number,
-  factionPosition = 1,
-  knights = 2,
-): Promise<{ phase: string; sub_phase: string; faction_position: number }> {
-  const response = await context.post(
-    `${BACKEND}/api/test/enter-attract-knight-with-initiative/${gameId}/`,
-    { data: { faction_position: factionPosition, knights } },
-  )
-  expect(response.ok()).toBeTruthy()
-  return await response.json()
 }

--- a/frontend/tests/pressureKnights.spec.ts
+++ b/frontend/tests/pressureKnights.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test"
 
 import { Player } from "./helpers/auth"
-import { deleteGame, setupGame, enterAttractKnightWithInitiative } from "./helpers/game"
+import { deleteGame, setupGame } from "./helpers/game"
 import { loginAsBrowserUser } from "./helpers/auth"
 
 const TIMEOUT = 15000
@@ -11,7 +11,7 @@ test.describe("pressure knights (forum phase)", () => {
   let players: Player[]
 
   test.beforeEach(async ({ playwright }) => {
-    const result = await setupGame(playwright.request)
+    const result = await setupGame(playwright.request, "forum__attract_knight")
     gameId = result.gameId
     players = result.players
   })
@@ -32,19 +32,8 @@ test.describe("pressure knights (forum phase)", () => {
     page,
     playwright,
   }) => {
-    // Log the host (faction position 1) into the browser and load the game
     await loginAsBrowserUser(playwright.request, page.context(), players[0].username)
     await page.goto(`/games/${gameId}`)
-
-    // Directly force the exact game state required for Pressure Knight to be offered:
-    // - forum + attract knight sub-phase
-    // - host faction holds CURRENT_INITIATIVE
-    // - host faction has knights on at least one senator
-    // - relevant AvailableAction rows created so the button is offered
-    await enterAttractKnightWithInitiative(players[0].api, gameId, 1, 2)
-
-    // The pushed game state + reload should make the action button appear immediately
-    await page.reload()
 
     const pressureButton = page
       .getByRole("button", { name: "Pressure knight..." })

--- a/frontend/tests/provinces.spec.ts
+++ b/frontend/tests/provinces.spec.ts
@@ -1,7 +1,7 @@
 import { expect, Page, test } from "@playwright/test"
 
 import { Player, loginAsBrowserUser } from "./helpers/auth"
-import { createForumProvinces, deleteGame, setupGame } from "./helpers/game"
+import { deleteGame, setupGame } from "./helpers/game"
 
 const TIMEOUT = 15000
 
@@ -14,12 +14,6 @@ function provinceCard(page: Page, name: string) {
 test.describe("provinces", () => {
   let gameId: number
   let players: Player[]
-
-  test.beforeEach(async ({ playwright }) => {
-    const result = await setupGame(playwright.request)
-    gameId = result.gameId
-    players = result.players
-  })
 
   test.afterEach(async () => {
     if (!gameId) return
@@ -38,10 +32,7 @@ test.describe("provinces", () => {
     playwright,
   }) => {
     // Arrange
-    await createForumProvinces(players[0].api, gameId, [
-      { name: "Sicilia", developed: false },
-      { name: "Macedonia", developed: true },
-    ])
+    ;({ gameId, players } = await setupGame(playwright.request, "mortality__provinces"))
     await loginAsBrowserUser(
       playwright.request,
       page.context(),
@@ -70,6 +61,10 @@ test.describe("provinces", () => {
     playwright,
   }) => {
     // Arrange
+    ;({ gameId, players } = await setupGame(
+      playwright.request,
+      "mortality",
+    ))
     await loginAsBrowserUser(
       playwright.request,
       page.context(),

--- a/frontend/tests/revenuePhase.spec.ts
+++ b/frontend/tests/revenuePhase.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test"
 
 import { Player, loginPlayers } from "./helpers/auth"
-import { deleteGame, setupGame, skipToNextPhase } from "./helpers/game"
+import { deleteGame, setupGame } from "./helpers/game"
 
 const WHOLE_NUMBER_REGEX = /^\d+$/
 const TIMEOUT = 10000
@@ -11,13 +11,9 @@ test.describe("revenue phase tests", () => {
   let players: Player[]
 
   test.beforeEach(async ({ playwright }) => {
-    const result = await setupGame(playwright.request)
+    const result = await setupGame(playwright.request, "revenue")
     gameId = result.gameId
     players = result.players
-
-    const { phase, subPhase } = await skipToNextPhase(players[0].api, gameId)
-    expect(phase).toBe("revenue")
-    expect(subPhase).toBe("redistribution")
   })
 
   test.afterEach(async () => {


### PR DESCRIPTION
Adds a preset system for loading predefined game states in dev environments. Presets are JSON files that declaratively describe game objects (senators, wars, legions, provinces, faction status) and support inheritance. They are available as a dropdown on the game lobby page for manual testing, and are used by the frontend tests to set up game state.

### Screenshot

<img width="1337" height="961" alt="image" src="https://github.com/user-attachments/assets/57c61e78-51fa-4c73-abf6-75abee02b84b" />

The load preset dropdown only appears when at least one preset is available. Presets are only available if `TEST_ENDPOINTS_ENABLED` is set.