### PR TITLE
feat: implement compareWars function for sorting wars

### DIFF
--- a/frontend/components/CombatCalculatorItem.tsx
+++ b/frontend/components/CombatCalculatorItem.tsx
@@ -8,6 +8,7 @@ import Senator from "@/classes/Senator"
 import War from "@/classes/War"
 import getDiceProbability from "@/helpers/dice"
 import { SERIES_NULLIFIERS } from "@/data/statesmen"
+import { compareWars } from "@/helpers/wars"
 
 interface CombatCalculatorItemProps {
   publicGameState: PublicGameState
@@ -363,11 +364,14 @@ const CombatCalculatorItem = ({
             className="rounded-md border border-blue-600 p-1 disabled:cursor-not-allowed disabled:bg-neutral-100"
           >
             <option value="">-- select an option --</option>
-            {publicGameState.wars?.map((war: War, index: number) => (
-              <option key={index} value={war.id}>
-                <>{war?.name}</>
-              </option>
-            ))}
+            {publicGameState.wars
+              ?.slice()
+              .sort(compareWars)
+              .map((war: War) => (
+                <option key={war.id} value={war.id}>
+                  <>{war?.name}</>
+                </option>
+              ))}
           </select>
         </div>
         <div className="flex gap-2">

--- a/frontend/components/GameMain.tsx
+++ b/frontend/components/GameMain.tsx
@@ -12,6 +12,7 @@ import { CONCESSION_INCOME } from "@/data/concessions"
 import getDiceProbability from "@/helpers/dice"
 import { forceListToString } from "@/helpers/forceLists"
 import { toFamilyAdjective, toSentenceCase } from "@/helpers/text"
+import { compareWars } from "@/helpers/wars"
 
 interface Props {
   publicGameState: PublicGameState
@@ -228,8 +229,9 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
           </div>
           <div className="grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-4">
             {publicGameState.wars
-              .sort((a, b) => a.id - b.id)
-              .map((war: War, index: number) => {
+              .slice()
+              .sort(compareWars)
+              .map((war: War) => {
                 const matchingWarMultiplier = war.seriesName
                   ? Math.max(
                       1,
@@ -251,7 +253,7 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
                   war.navalStrength * matchingWarMultiplier + leaderStrength
                 return (
                   <div
-                    key={index}
+                    key={war.id}
                     className="flex flex-col gap-4 rounded border border-neutral-400 px-6 py-4"
                   >
                     <div className="flex w-full justify-between gap-4">

--- a/frontend/components/customActionForms/ProposeDeployingForcesForm.tsx
+++ b/frontend/components/customActionForms/ProposeDeployingForcesForm.tsx
@@ -5,6 +5,7 @@ import Legion from "@/classes/Legion"
 import Senator from "@/classes/Senator"
 import War from "@/classes/War"
 import { toSentenceCase } from "@/helpers/text"
+import { compareWars } from "@/helpers/wars"
 import useCustomActionForm from "@/hooks/useCustomActionForm"
 
 import { CustomActionFormProps } from "../ActionBar"
@@ -69,9 +70,7 @@ const ProposeDeployingForcesForm = ({
     .filter((f: Fleet) => f.campaign === null)
     .sort((a: Fleet, b: Fleet) => a.number - b.number)
 
-  const wars: War[] = [...publicGameState.wars].sort(
-    (a: War, b: War) => a.id - b.id,
-  )
+  const wars: War[] = [...publicGameState.wars].sort(compareWars)
 
   const selectedCommanderId = selection["Commander"]
     ? Number(selection["Commander"])

--- a/frontend/helpers/wars.ts
+++ b/frontend/helpers/wars.ts
@@ -1,0 +1,14 @@
+import War from "@/classes/War"
+
+// Wars are ordered by how much attention they demand, so that the ones
+// threatening Rome right now appear before the ones that don't
+const STATUS_ORDER: Record<War["status"], number> = {
+  active: 0,
+  imminent: 1,
+  inactive: 2,
+  defeated: 3,
+}
+
+export function compareWars(a: War, b: War): number {
+  return STATUS_ORDER[a.status] - STATUS_ORDER[b.status] || a.id - b.id
+}


### PR DESCRIPTION
Resolves #752. 

Wars are now sorted Active -> Imminent -> Inactive. Also updates relevant components!

**Before**
<img width="1400" height="743" alt="752-before" src="https://github.com/user-attachments/assets/f6c6ccbc-15c2-4dbe-beed-1926c88a6106" />

**After**
<img width="1400" height="743" alt="752-after" src="https://github.com/user-attachments/assets/35a0a3b1-69b6-480a-a33b-601a428d5c15" />
