### PR TITLE
feat: include vote counts in motion passed/defeated logs

### DIFF
--- a/backend/rorapp/effects/elect_censor.py
+++ b/backend/rorapp/effects/elect_censor.py
@@ -3,6 +3,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Senator
 from rorapp.models.log import Log
@@ -37,7 +38,7 @@ class ElectCensorEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed - elect the censor
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             if censor:
                 # Remove PM from whoever currently holds it
@@ -72,10 +73,7 @@ class ElectCensorEffect(EffectBase):
             # Proposal failed
             if game.current_proposal:
                 game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             game.save()
             handle_unanimous_defeat(game_id)
             clear_proposal_state(game_id)

--- a/backend/rorapp/effects/elect_consuls.py
+++ b/backend/rorapp/effects/elect_consuls.py
@@ -3,9 +3,9 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Senator
-from rorapp.models.log import Log
 
 
 class ElectConsulsEffect(EffectBase):
@@ -33,7 +33,7 @@ class ElectConsulsEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
             consul_names = game.current_proposal[len("Elect consuls ") :].split(" and ")
             senators = Senator.objects.filter(game=game, alive=True)
             consuls = [s for s in senators if s.display_name in consul_names]
@@ -46,10 +46,7 @@ class ElectConsulsEffect(EffectBase):
 
             # Proposal failed
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         game.save()

--- a/backend/rorapp/effects/elect_dictator.py
+++ b/backend/rorapp/effects/elect_dictator.py
@@ -4,9 +4,9 @@ from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.dictator_appointment import appoint_dictator
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Senator
-from rorapp.models.log import Log
 
 
 class ElectDictatorEffect(EffectBase):
@@ -36,16 +36,13 @@ class ElectDictatorEffect(EffectBase):
         )
 
         if game.votes_yea > game.votes_nay:
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
             clear_proposal_state(game_id)
             if dictator_candidate:
                 appoint_dictator(game_id, dictator_candidate.id)
         else:
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             game.save()
             handle_unanimous_defeat(game_id)
             clear_proposal_state(game_id)

--- a/backend/rorapp/effects/proposal_award_concession.py
+++ b/backend/rorapp/effects/proposal_award_concession.py
@@ -4,6 +4,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Log, Senator
 
@@ -33,7 +34,7 @@ class ProposalAwardConcessionEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             # Parse proposal: "Award the {concession} concession to {senator_name}"
             after_award = game.current_proposal[len("Award the ") :]
@@ -68,10 +69,7 @@ class ProposalAwardConcessionEffect(EffectBase):
 
             # Proposal failed
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         game.save()

--- a/backend/rorapp/effects/proposal_deploy_forces.py
+++ b/backend/rorapp/effects/proposal_deploy_forces.py
@@ -5,6 +5,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.text import format_list
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.hrao import set_hrao
@@ -39,7 +40,7 @@ class ProposalDeployForcesEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             senators = Senator.objects.filter(game=game, alive=True)
 
@@ -170,10 +171,7 @@ class ProposalDeployForcesEffect(EffectBase):
 
             # Proposal failed
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         game.save()

--- a/backend/rorapp/effects/proposal_pass_land_bill.py
+++ b/backend/rorapp/effects/proposal_pass_land_bill.py
@@ -4,6 +4,7 @@ from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.game_data import load_land_bills
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.proposal_available import LAND_BILL_EFFECT
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Log, Senator
@@ -37,7 +38,7 @@ class ProposalLandBillEffect(EffectBase):
         bill_type = after_type.split(" ")[0]  # "I", "II", or "III"
 
         if game.votes_yea > game.votes_nay:
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             # Parse sponsor and co-sponsor names
             senators = list(Senator.objects.filter(game=game, alive=True))
@@ -100,7 +101,7 @@ class ProposalLandBillEffect(EffectBase):
 
         else:
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(game_id, f"Motion defeated: {game.current_proposal}.")
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         # Record so the same type cannot be proposed again this turn (pass or fail)

--- a/backend/rorapp/effects/proposal_raise_forces.py
+++ b/backend/rorapp/effects/proposal_raise_forces.py
@@ -6,6 +6,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.text import format_list
 from rorapp.helpers.unit_lists import unit_list_to_string
@@ -37,7 +38,7 @@ class ProposalRaiseForcesEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
             unit_amounts = game.current_proposal[len("Raise ") :].split(" and ")
             legions_to_raise = 0
             fleets_to_raise = 0
@@ -138,10 +139,7 @@ class ProposalRaiseForcesEffect(EffectBase):
 
             # Proposal failed
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         game.save()

--- a/backend/rorapp/effects/proposal_recall_forces.py
+++ b/backend/rorapp/effects/proposal_recall_forces.py
@@ -5,6 +5,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.unit_lists import string_to_unit_list, unit_list_to_string
 from rorapp.models import Campaign, Fleet, Game, Legion, Log, Senator, War
@@ -35,7 +36,7 @@ class ProposalRecallForcesEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             senators = Senator.objects.filter(game=game, alive=True)
             commander_name_and_more = game.current_proposal[len("Recall ") :]
@@ -132,10 +133,7 @@ class ProposalRecallForcesEffect(EffectBase):
 
             # Proposal failed
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         game.save()

--- a/backend/rorapp/effects/proposal_reinforce_proconsul.py
+++ b/backend/rorapp/effects/proposal_reinforce_proconsul.py
@@ -5,6 +5,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.helpers.unit_lists import string_to_unit_list, unit_list_to_string
 from rorapp.models import Campaign, Fleet, Game, Legion, Log, War
@@ -35,7 +36,7 @@ class ProposalReinforceProconsulEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             # Parse the campaign from the proposal
             campaigns = Campaign.objects.filter(game=game)
@@ -133,10 +134,7 @@ class ProposalReinforceProconsulEffect(EffectBase):
 
             # Proposal failed
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         game.save()

--- a/backend/rorapp/effects/proposal_repeal_land_bill.py
+++ b/backend/rorapp/effects/proposal_repeal_land_bill.py
@@ -4,6 +4,7 @@ from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
 from rorapp.helpers.game_data import load_land_bills
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.proposal_available import LAND_BILL_EFFECT
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Game, Log, Senator
@@ -37,7 +38,7 @@ class ProposalLandBillRepealEffect(EffectBase):
         bill_type = after_type.split(" ")[0]  # "II" or "III"
 
         if game.votes_yea > game.votes_nay:
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             # Parse sponsor name
             sponsored_by = " sponsored by "
@@ -75,7 +76,7 @@ class ProposalLandBillRepealEffect(EffectBase):
 
         else:
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(game_id, f"Motion defeated: {game.current_proposal}.")
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         # Record so a second repeal cannot be attempted this turn

--- a/backend/rorapp/effects/proposal_replace_proconsul.py
+++ b/backend/rorapp/effects/proposal_replace_proconsul.py
@@ -3,6 +3,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.clear_proposal_state import clear_proposal_state
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.proposal_parsing import extract_master_of_horse
 from rorapp.helpers.unanimous_defeat import handle_unanimous_defeat
 from rorapp.models import Campaign, Game, Log, Senator, War
@@ -33,7 +34,7 @@ class ProposalReplaceProconsulEffect(EffectBase):
         if game.votes_yea > game.votes_nay:
 
             # Proposal passed
-            Log.create_object(game.id, f"Motion passed: {game.current_proposal}.")
+            log_motion_result(game, passed=True)
 
             senators = Senator.objects.filter(game=game, alive=True)
 
@@ -131,10 +132,7 @@ class ProposalReplaceProconsulEffect(EffectBase):
 
             # Proposal failed
             game.add_defeated_proposal(game.current_proposal)
-            Log.create_object(
-                game_id,
-                f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             handle_unanimous_defeat(game_id)
 
         game.save()

--- a/backend/rorapp/effects/resolve_prosecution.py
+++ b/backend/rorapp/effects/resolve_prosecution.py
@@ -6,6 +6,7 @@ from rorapp.effects.meta.effect_base import EffectBase
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.finish_prosecution import finish_prosecution
 from rorapp.helpers.kill_senator import kill_senator
+from rorapp.helpers.motion_result import log_motion_result
 from rorapp.helpers.text import format_list
 from rorapp.models import Game, Log, Senator
 
@@ -119,10 +120,7 @@ class ResolveProsecutionEffect(EffectBase):
                 concession = Concession(reason[len("corruption via ") : -len(" concession")])
                 accused.remove_corrupt_concession(concession)
                 accused.save()
-            Log.create_object(
-                game_id=game.id,
-                text=f"Motion defeated: {game.current_proposal}.",
-            )
+            log_motion_result(game, passed=False)
             game.save()
             finish_prosecution(game_id, is_major, guilty=False)
 

--- a/backend/rorapp/helpers/motion_result.py
+++ b/backend/rorapp/helpers/motion_result.py
@@ -1,0 +1,12 @@
+from rorapp.models import Game, Log
+
+
+def log_motion_result(game: Game, passed: bool) -> None:
+    """Log the outcome of a motion, including the vote counts that decided it."""
+
+    outcome = "passed" if passed else "defeated"
+    Log.create_object(
+        game.id,
+        f"Motion {outcome}: {game.current_proposal}"
+        f" ({game.votes_yea} yea, {game.votes_nay} nay).",
+    )


### PR DESCRIPTION
Resolves #750.

Every proposal outcome log now reports the yea/nay totals that decided it, e.g. "Motion passed: Raise 4 legions and 2 fleets (12 yea, 7 nay)."

The text was duplicated across 12 effects, so I moved it into a single log_motion_result helper.

<img width="600" height="935" alt="issue-750-log-panel" src="https://github.com/user-attachments/assets/4ffdc506-9c0f-4d57-be67-fafedb134b27" />
