### PR TITLE
fix: return fleets to reserve after a fleet-only naval victory

### DIFF
--- a/backend/rorapp/helpers/resolve_combat.py
+++ b/backend/rorapp/helpers/resolve_combat.py
@@ -409,10 +409,29 @@ def resolve_combat(
             commander.location = "Rome"
             commander.remove_title(Senator.Title.PROCONSUL)
             commander.save()
+            returning_senators = [commander]
             if master_of_horse and not master_of_horse_killed:
                 master_of_horse = Senator.objects.get(id=master_of_horse.id)
                 master_of_horse.location = "Rome"
                 master_of_horse.save()
+                returning_senators.append(master_of_horse)
+
+            # The force has no legions left to fight on, so the surviving
+            # fleets return home with the commander
+            for fleet in surviving_fleets:
+                fleet.campaign = None
+            Fleet.objects.bulk_update(surviving_fleets, ["campaign"])
+
+            return_log_text = (
+                f"{format_list([s.display_name for s in returning_senators])} "
+                "returned to Rome because no legions were present for the "
+                "land battle."
+            )
+            if surviving_fleets:
+                return_log_text += f" {unit_list_to_string([], surviving_fleets)} returned to the reserve forces."
+            Log.create_object(game_id, return_log_text)
+
+            campaign.delete()
         elif not commander_killed and legion_survivals > 0:
             if fleet_survivals >= war.fleet_support and war.land_strength > 0:
                 commander.add_status_item(Senator.StatusItem.CONSIDERING_LAND_BATTLE)

--- a/backend/tests/s1_basic_game/s1_10_combat_phase/s1_10_12_naval_battles_test.py
+++ b/backend/tests/s1_basic_game/s1_10_combat_phase/s1_10_12_naval_battles_test.py
@@ -3,7 +3,7 @@ from rorapp.actions.fight_land_battle import FightLandBattleAction
 from rorapp.actions.halt_after_naval_victory import HaltAfterNavalVictoryAction
 from rorapp.classes.random_resolver import FakeRandomResolver
 from rorapp.effects.meta.effect_executor import execute_effects_and_manage_actions
-from rorapp.models import Campaign, Fleet, Game, Legion, Senator, War
+from rorapp.models import Campaign, Fleet, Game, Legion, Log, Senator, War
 
 
 @pytest.mark.django_db
@@ -115,3 +115,87 @@ def test_naval_victory_without_surviving_fleet_support_does_not_offer_land_battl
     # Assert
     commander.refresh_from_db()
     assert not commander.has_status_item(Senator.StatusItem.CONSIDERING_LAND_BATTLE)
+
+
+@pytest.mark.django_db
+def test_naval_victory_by_fleet_only_force_returns_fleets_to_the_reserve(
+    naval_campaign: Campaign,
+):
+    # Arrange — a fleet-only force, so there are no legions left to fight on
+    game = naval_campaign.game
+    commander = naval_campaign.commander
+    assert commander is not None
+    for i in range(1, 11):
+        Fleet.objects.create(game=game, number=i, campaign=naval_campaign)
+    resolver = FakeRandomResolver()
+    resolver.dice_rolls = [18]
+    resolver.casualty_order = []
+    resolver.mortality_chits = []
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    commander.refresh_from_db()
+    assert commander.location == "Rome"
+    assert Fleet.objects.filter(game=game).count() == 10
+    assert not Fleet.objects.filter(game=game, campaign__isnull=False).exists()
+    assert not Campaign.objects.filter(game=game).exists()
+    war = War.objects.get(game=game)
+    assert war.naval_strength == 0
+
+
+@pytest.mark.django_db
+def test_naval_victory_by_fleet_only_force_logs_the_return(naval_campaign: Campaign):
+    # Arrange
+    game = naval_campaign.game
+    commander = naval_campaign.commander
+    assert commander is not None
+    for i in range(1, 11):
+        Fleet.objects.create(game=game, number=i, campaign=naval_campaign)
+    resolver = FakeRandomResolver()
+    resolver.dice_rolls = [18]
+    resolver.casualty_order = []
+    resolver.mortality_chits = []
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    log_texts = list(Log.objects.filter(game=game).values_list("text", flat=True))
+    assert (
+        f"{commander.display_name} returned to Rome because no legions were "
+        "present for the land battle. "
+        "10 fleets (I–X) returned to the reserve forces." in log_texts
+    )
+
+
+@pytest.mark.django_db
+def test_naval_victory_that_destroys_every_fleet_still_logs_the_return(
+    naval_campaign: Campaign,
+):
+    # Arrange — only 3 fleets against naval_strength=10, so a narrow victory
+    # destroys all of them and there is nothing to return to the reserve
+    game = naval_campaign.game
+    commander = naval_campaign.commander
+    assert commander is not None
+    for i in range(1, 4):
+        Fleet.objects.create(game=game, number=i, campaign=naval_campaign)
+    resolver = FakeRandomResolver()
+    resolver.dice_rolls = [18]
+    resolver.casualty_order = []
+    resolver.mortality_chits = []
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    commander.refresh_from_db()
+    assert commander.location == "Rome"
+    assert not Fleet.objects.filter(game=game).exists()
+    assert not Campaign.objects.filter(game=game).exists()
+    log_texts = list(Log.objects.filter(game=game).values_list("text", flat=True))
+    assert (
+        f"{commander.display_name} returned to Rome because no legions were "
+        "present for the land battle." in log_texts
+    )


### PR DESCRIPTION
Fixes #751 -> When a force with no surviving legions won a naval battle that did not end the war, the commander was sent back to Rome but the surviving fleets stayed attached to the campaign, which was left commanderless.

Nothing was leaked permanently, the next senate phase eventually swept the campaign up. This will release the surviving fleets back to the reserve forces, delete the now-empty campaign, and log the return along with the reason for it. I reuse the phrasing the senate phase already used for the same cause, but that's easy to tweak if you fancy.

<img width="3200" height="2000" alt="issue-751-3-with-fix" src="https://github.com/user-attachments/assets/8c2cbbfc-17f8-4b49-967b-fcf784af07db" />

