### PR TITLE
feat: add the epidemic event (§1.07.21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The checklist below tracks implementation of the **early republic scenario** —
     - [x] Drought
     - [ ] Enemy leader dies
     - [ ] Enemy's ally deserts
-    - [ ] Epidemic
+    - [x] Epidemic
+      - [ ] Foreign epidemic
     - [x] Evil omens
     - [x] Manpower shortage
     - [ ] New alliance

--- a/backend/rorapp/effects/initiative_roll.py
+++ b/backend/rorapp/effects/initiative_roll.py
@@ -44,7 +44,7 @@ class InitiativeRollEffect(EffectBase):
             event_roll = random_resolver.roll_dice(count=3)
             events = load_events()
             event_name = events["early_republic"].get(str(event_roll), "Unknown Event")
-            if handle_event(game, current_faction, event_name):
+            if handle_event(game, current_faction, event_name, random_resolver):
                 return True
 
         next_card = game.draw_card()

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -134,20 +134,15 @@ def handle_epidemic(
     ]
 
     prefix = f"{current_faction.display_name} drew epidemic."
-    if len(victims) >= 2:
+    if victims:
         Log.create_object(
             game.id,
-            f"{prefix} A plague swept through Rome, killing {len(victims)} senators.",
-        )
-    elif victims:
-        Log.create_object(
-            game.id,
-            f"{prefix} A plague swept through Rome, killing a senator.",
+            f"{prefix} A plague swept through Rome.",
         )
     else:
         Log.create_object(
             game.id,
-            f"{prefix} A plague swept through Rome, but every senator in Rome survived.",
+            f"{prefix} A plague swept through Rome, but every senator survived.",
         )
 
     for victim in victims:

--- a/backend/rorapp/helpers/handle_event.py
+++ b/backend/rorapp/helpers/handle_event.py
@@ -1,13 +1,23 @@
 from rorapp.classes.game_effect_item import GameEffect
-from rorapp.models import Faction, Game, Log
+from rorapp.classes.random_resolver import RandomResolver
+from rorapp.helpers.game_data import get_senator_codes
+from rorapp.helpers.kill_senator import CauseOfDeath, kill_senator
+from rorapp.models import Faction, Game, Log, Senator
 
 
-def handle_event(game: Game, current_faction: Faction, event_name: str) -> bool:
+def handle_event(
+    game: Game,
+    current_faction: Faction,
+    event_name: str,
+    random_resolver: RandomResolver,
+) -> bool:
     """Apply the event effect. Returns True if the event is implemented, False if not."""
     if event_name == "Allied enthusiasm":
         advances = handle_allied_enthusiasm(game, current_faction)
     elif event_name == "Drought":
         advances = handle_drought(game, current_faction)
+    elif event_name == "Epidemic":
+        advances = handle_epidemic(game, current_faction, random_resolver)
     elif event_name == "Evil Omens":
         advances = handle_evil_omens(game, current_faction)
     elif event_name == "Manpower Shortage":
@@ -109,4 +119,40 @@ def handle_allied_enthusiasm(game: Game, current_faction: Faction) -> bool:
             game.id,
             f"{prefix} Rome's allies are already extremely enthusiastic so there is no additional effect.",
         )
+    return True
+
+
+def handle_epidemic(
+    game: Game, current_faction: Faction, random_resolver: RandomResolver
+) -> bool:
+    codes = set(random_resolver.draw_mortality_chits(6))
+    senators = Senator.objects.filter(game=game.id, alive=True)
+    victims = [
+        s
+        for s in senators
+        if s.location == "Rome" and get_senator_codes(s.code)[0] in codes
+    ]
+
+    prefix = f"{current_faction.display_name} drew epidemic."
+    if len(victims) >= 2:
+        Log.create_object(
+            game.id,
+            f"{prefix} A plague swept through Rome, killing {len(victims)} senators.",
+        )
+    elif victims:
+        Log.create_object(
+            game.id,
+            f"{prefix} A plague swept through Rome, killing a senator.",
+        )
+    else:
+        Log.create_object(
+            game.id,
+            f"{prefix} A plague swept through Rome, but every senator in Rome survived.",
+        )
+
+    for victim in victims:
+        kill_senator(victim, CauseOfDeath.EPIDEMIC)
+
+    # Reload the game, since deaths may have released concessions to the forum
+    game.refresh_from_db()
     return True

--- a/backend/rorapp/helpers/kill_senator.py
+++ b/backend/rorapp/helpers/kill_senator.py
@@ -12,6 +12,7 @@ from rorapp.models import Campaign, Faction, Fleet, Game, Legion, Log, Senator
 class CauseOfDeath(Enum):
     NATURAL = "natural"
     BATTLE = "battle"
+    EPIDEMIC = "epidemic"
     MOB = "mob"
     ASSASSINATION = "assassination"
     EXECUTION = "execution"
@@ -114,6 +115,8 @@ def kill_senator(senator: Senator, cause_of_death: CauseOfDeath = CauseOfDeath.N
 
     if cause_of_death == CauseOfDeath.BATTLE:
         log_text += " was killed in battle."
+    elif cause_of_death == CauseOfDeath.EPIDEMIC:
+        log_text += " died in the epidemic."
     elif cause_of_death == CauseOfDeath.MOB:
         log_text += " was killed by the mob."
     elif cause_of_death == CauseOfDeath.ASSASSINATION:

--- a/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
+++ b/backend/tests/s1_basic_game/s1_07_forum_phase/s1_07_21_events_test.py
@@ -267,3 +267,104 @@ def test_drawing_allied_enthusiasm_at_max_has_no_effect(
     # Assert
     game.refresh_from_db()
     assert game.count_effect(GameEffect.ALLIED_ENTHUSIASM) == 2
+
+
+@pytest.mark.django_db
+def test_rolling_7_on_initiative_triggers_epidemic(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 8]
+    resolver.mortality_chits = ["1"]
+    victim = game.senators.get(code="1")
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    victim.refresh_from_db()
+    assert victim.alive == False
+
+
+@pytest.mark.django_db
+def test_epidemic_kills_every_senator_in_rome_that_is_drawn(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 8]
+    resolver.mortality_chits = ["1", "5"]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    assert game.senators.filter(code="1", alive=True).count() == 0
+    assert game.senators.filter(code="5", alive=True).count() == 0
+
+
+@pytest.mark.django_db
+def test_epidemic_does_not_kill_senators_away_from_rome(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    commander = game.senators.get(code="1")
+    commander.location = "Sicilia"
+    commander.save()
+    resolver.dice_rolls = [7, 8]
+    resolver.mortality_chits = ["1"]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    commander.refresh_from_db()
+    assert commander.alive == True
+
+
+@pytest.mark.django_db
+def test_epidemic_draws_six_mortality_chits(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 8]
+
+    # The sixth chit matches a senator, the seventh should never be drawn
+    resolver.mortality_chits = ["21", "22", "23", "24", "25", "1", "2"]
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    assert game.senators.filter(code="1", alive=True).count() == 0
+    assert game.senators.filter(code="2", alive=True).count() == 1
+
+
+@pytest.mark.django_db
+def test_epidemic_without_matching_chits_kills_nobody(
+    basic_game: Game, resolver: FakeRandomResolver
+):
+    # Arrange
+    game = basic_game
+    faction: Faction = game.factions.get(position=1)
+    _setup_initiative_roll(game, faction)
+    resolver.dice_rolls = [7, 8]
+    resolver.mortality_chits = ["21", "22", "23", "24", "25", "26"]
+    senator_count = game.senators.filter(alive=True).count()
+
+    # Act
+    execute_effects_and_manage_actions(game.id, resolver)
+
+    # Assert
+    assert game.senators.filter(alive=True).count() == senator_count


### PR DESCRIPTION
Adds the **epidemic** event (a roll of 8 on the events table), implementing rule §1.07.21.

> Draw six Mortality Chits. Only those Senators currently in Rome can be killed.

### Behaviour

When a faction rolls 7 for initiative and then 8 on the events table:

- Six mortality chits are drawn through the existing draw logic, so "draw 2" chits and an exhausted bag behave exactly as they do in the mortality phase.
- Every living senator **in Rome** whose family code was drawn dies, unaligned senators in the forum included.
- Senators outside Rome (currently just commanders deployed to a war, but governors etc in future) are immune.
- As with the other events, no card is drawn and play moves straight on to persuasion attempts.

### New log examples

- _Faction 1 drew epidemic. A plague swept through Rome, killing 2 senators._
- _Faction 2 drew epidemic. A plague swept through Rome, killing a senator._
- _Faction 3 drew epidemic. A plague swept through Rome, but every senator in Rome survived._
- _Fabius of Faction 1 died in the epidemic._

`CauseOfDeath.EPIDEMIC` is new, so victims read as having "died in the epidemic" rather than of natural causes.

### Implementation notes

- `handle_event` now takes the `RandomResolver`. This is the first event needing randomness beyond the event roll itself.
- `handle_epidemic` reloads the game before returning. Deaths can release concessions back to the forum via `kill_senator`, which saves its own `Game` instance, and without the reload the sub-phase save in `handle_event` would clobber them.
- No new `GameEffect`. An epidemic leaves nothing behind, so there is nothing to render in the effects list and no frontend change. The deaths surface through the log.
- This touches `kill_senator.py`, as I'm also doing in #769, but in a different part of the file. The two merge cleanly in either order.

### Out of scope

Foreign epidemic, the dark blue side of this event. Foreign epidemic kills the first Governor, Proconsul, Captive or Rebel drawn who is away from Rome, and of those four only proconsuls exist so far. Repeat draws currently resolve as another epidemic. Added to the README checklist as a sub-item so we don't forget to add that.

### Testing

- 5 new tests in `s1_07_21_events_test.py`: a drawn senator dies, several drawn senators die, a senator away from Rome survives, exactly six chits are drawn (the sixth kills, the seventh is never reached), and no matches kills nobody
- Full backend suite: 452 passed
- mypy: clean on 284 source files
- Verified in the running app, forcing the event with a scripted resolver

### A good day for Faction 3

<img width="2880" height="1800" alt="epidemic-event" src="https://github.com/user-attachments/assets/8057d091-2255-448a-a933-ef57912bd214" />
