### PR TITLE
feat: show base strength and individual modifiers for wars (§1.07.332, §1.07.342)

### DIFF
--- a/frontend/components/CombatCalculatorItem.tsx
+++ b/frontend/components/CombatCalculatorItem.tsx
@@ -1,14 +1,18 @@
 import { useCallback } from "react"
 
 import CombatCalculation from "@/classes/CombatCalculation"
-import EnemyLeader from "@/classes/EnemyLeader"
 import PublicGameState from "@/classes/PublicGameState"
-import { getEvilOmensLevel } from "@/helpers/gameEffects"
 import Senator from "@/classes/Senator"
 import War from "@/classes/War"
-import getDiceProbability from "@/helpers/dice"
+import WarStrength from "@/components/WarStrength"
 import { SERIES_NULLIFIERS } from "@/data/statesmen"
-import { compareWars } from "@/helpers/wars"
+import getDiceProbability from "@/helpers/dice"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
+import {
+  compareWars,
+  getActiveLeaders,
+  getWarStrengthBreakdown,
+} from "@/helpers/wars"
 
 interface CombatCalculatorItemProps {
   publicGameState: PublicGameState
@@ -45,9 +49,9 @@ const CombatCalculatorItem = ({
     (war: War) => war.id === combatCalculation.war,
   )
 
-  const enemyLeaders = publicGameState.enemyLeaders.filter(
-    (leader: EnemyLeader) => leader.seriesName === war?.seriesName,
-  )
+  const enemyLeaders = war
+    ? getActiveLeaders(war, publicGameState.enemyLeaders)
+    : []
 
   const setWar = (warId: number | null) => {
     if (combatCalculation.war !== warId) {
@@ -124,23 +128,20 @@ const CombatCalculatorItem = ({
   const combinedMilitary =
     (commander?.military ?? 0) + (mohSenator?.military ?? 0)
   forceStrength += Math.min(combinedMilitary, forceStrength)
-  const matchingWarMultiplier = war?.seriesName
-    ? Math.max(
-        1,
-        publicGameState.wars.filter(
-          (w) => w.seriesName === war.seriesName && w.status === "active",
-        ).length,
+  const warStrengthBreakdown = war
+    ? getWarStrengthBreakdown(
+        war,
+        combatCalculation.battle,
+        publicGameState.wars,
+        publicGameState.enemyLeaders,
       )
-    : 1
-  const baseWarStrength =
-    (combatCalculation.battle === "land"
-      ? war?.landStrength
-      : war?.navalStrength) ?? 0
-  const leaderStrength = enemyLeaders.reduce((sum, l) => sum + l.strength, 0)
-  const warStrength = baseWarStrength * matchingWarMultiplier + leaderStrength
+    : null
+  const warStrength = warStrengthBreakdown?.total ?? 0
   const evilOmensLevel = combatCalculation.evilOmens ?? 0
 
-  const actualEvilOmensLevel = getEvilOmensLevel(publicGameState.game?.effects ?? [])
+  const actualEvilOmensLevel = getEvilOmensLevel(
+    publicGameState.game?.effects ?? [],
+  )
 
   const setEvilOmens = (value: number) => {
     if (combatCalculation.evilOmens !== value) {
@@ -423,7 +424,19 @@ const CombatCalculatorItem = ({
         <div className="flex flex-col items-start gap-1">
           <div className="font-semibold">Strengths</div>
           <div>Roman force strength: {forceStrength}</div>
-          {warStrength > 0 && <div>War strength: {warStrength}</div>}
+          {warStrengthBreakdown && warStrength > 0 && (
+            <div className="flex items-baseline gap-1">
+              <span>War strength:</span>
+              <WarStrength
+                label={
+                  combatCalculation.battle === "land"
+                    ? "Land strength"
+                    : "Naval strength"
+                }
+                breakdown={warStrengthBreakdown}
+              />
+            </div>
+          )}
         </div>
         {warStrength > 0 && (
           <div className="flex flex-col items-start gap-1">

--- a/frontend/components/GameMain.tsx
+++ b/frontend/components/GameMain.tsx
@@ -8,11 +8,12 @@ import Senator from "@/classes/Senator"
 import War from "@/classes/War"
 import Popover from "@/components/Popover"
 import SenatorDisplay from "@/components/SenatorDisplay"
+import WarStrength from "@/components/WarStrength"
 import { CONCESSION_INCOME } from "@/data/concessions"
 import getDiceProbability from "@/helpers/dice"
 import { forceListToString } from "@/helpers/forceLists"
 import { toFamilyAdjective, toSentenceCase } from "@/helpers/text"
-import { compareWars } from "@/helpers/wars"
+import { compareWars, getWarStrengthBreakdown } from "@/helpers/wars"
 
 interface Props {
   publicGameState: PublicGameState
@@ -228,25 +229,18 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
               .slice()
               .sort(compareWars)
               .map((war: War) => {
-                const matchingWarMultiplier = war.seriesName
-                  ? Math.max(
-                      1,
-                      publicGameState.wars.filter(
-                        (w) =>
-                          w.seriesName === war.seriesName &&
-                          w.status === "active",
-                      ).length,
-                    )
-                  : 1
-                const leaderStrength = war.seriesName
-                  ? publicGameState.enemyLeaders
-                      .filter((l) => l.seriesName === war.seriesName)
-                      .reduce((sum, l) => sum + l.strength, 0)
-                  : 0
-                const effectiveLandStrength =
-                  war.landStrength * matchingWarMultiplier + leaderStrength
-                const effectiveNavalStrength =
-                  war.navalStrength * matchingWarMultiplier + leaderStrength
+                const landStrength = getWarStrengthBreakdown(
+                  war,
+                  "land",
+                  publicGameState.wars,
+                  publicGameState.enemyLeaders,
+                )
+                const navalStrength = getWarStrengthBreakdown(
+                  war,
+                  "naval",
+                  publicGameState.wars,
+                  publicGameState.enemyLeaders,
+                )
                 return (
                   <div
                     key={war.id}
@@ -299,11 +293,14 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
                     {war.seriesName && <div>Series: {war.seriesName} Wars</div>}
                     <div className="grid grid-cols-2">
                       <div className="flex flex-col gap-1">
-                        <div>
+                        <div className="flex items-baseline gap-1">
                           <span className="text-sm text-neutral-600">
                             Land strength
-                          </span>{" "}
-                          {effectiveLandStrength}
+                          </span>
+                          <WarStrength
+                            label="Land strength"
+                            breakdown={landStrength}
+                          />
                         </div>
                         {war.fleetSupport > 0 && (
                           <div>
@@ -314,11 +311,14 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
                           </div>
                         )}
                         {war.navalStrength > 0 && (
-                          <div>
+                          <div className="flex items-baseline gap-1">
                             <span className="text-sm text-neutral-600">
                               Naval strength
-                            </span>{" "}
-                            {effectiveNavalStrength}
+                            </span>
+                            <WarStrength
+                              label="Naval strength"
+                              breakdown={navalStrength}
+                            />
                           </div>
                         )}
                       </div>

--- a/frontend/components/Popover.tsx
+++ b/frontend/components/Popover.tsx
@@ -67,7 +67,9 @@ const Popover = ({ trigger, children, className, triggerClassName }: Props) => {
             <div
               ref={refs.setFloating}
               style={floatingStyles}
-              className="z-50"
+              // Above the combat calculator (z-index 1000), so popovers
+              // triggered from inside it aren't hidden behind it
+              className="z-[1100]"
               {...getFloatingProps()}
             >
               <div className="w-max rounded border border-neutral-300 bg-white p-4 shadow-lg">

--- a/frontend/components/WarStrength.tsx
+++ b/frontend/components/WarStrength.tsx
@@ -1,0 +1,63 @@
+import Popover from "@/components/Popover"
+import { WarStrengthBreakdown } from "@/helpers/wars"
+
+interface Props {
+  label: string
+  breakdown: WarStrengthBreakdown
+}
+
+const Row = ({ text, value }: { text: string; value: string }) => (
+  <div className="flex justify-between gap-6">
+    <span>{text}</span>
+    <span className="tabular-nums">{value}</span>
+  </div>
+)
+
+// Shows the strength a war fights at, with a breakdown of the modifiers behind
+// it when matching wars (§1.07.332) or enemy leaders (§1.07.342) have changed it
+const WarStrength = ({ label, breakdown }: Props) => {
+  if (!breakdown.isModified)
+    return <span className="tabular-nums">{breakdown.total}</span>
+
+  return (
+    <Popover
+      className="inline-block"
+      triggerClassName="tabular-nums underline decoration-dotted decoration-neutral-400 underline-offset-4"
+      trigger={<>{breakdown.total}</>}
+    >
+      <div className="flex flex-col gap-1">
+        <div className="font-semibold">{label}</div>
+        <Row text="Base" value={`${breakdown.base}`} />
+        {breakdown.multiplier > 1 && (
+          <>
+            <Row
+              text={`${breakdown.matchingWars.length} matching wars (\u00d7${breakdown.multiplier})`}
+              value={`+${breakdown.base * (breakdown.multiplier - 1)}`}
+            />
+            <ul className="flex flex-col">
+              {breakdown.matchingWars.map((war) => (
+                <li
+                  key={war.id}
+                  className="ml-6 list-disc text-sm text-neutral-600"
+                >
+                  {war.name}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+        {breakdown.leaders.map((leader) => (
+          <Row
+            key={leader.id}
+            text={leader.name}
+            value={`+${leader.strength}`}
+          />
+        ))}
+        <hr className="-mx-4 border-neutral-300" />
+        <Row text="Total" value={`${breakdown.total}`} />
+      </div>
+    </Popover>
+  )
+}
+
+export default WarStrength

--- a/frontend/helpers/wars.ts
+++ b/frontend/helpers/wars.ts
@@ -1,3 +1,4 @@
+import EnemyLeader from "@/classes/EnemyLeader"
 import War from "@/classes/War"
 
 // Wars are ordered by how much attention they demand, so that the ones
@@ -11,4 +12,60 @@ const STATUS_ORDER: Record<War["status"], number> = {
 
 export function compareWars(a: War, b: War): number {
   return STATUS_ORDER[a.status] - STATUS_ORDER[b.status] || a.id - b.id
+}
+
+// Every active war in the same numbered series, including the war itself.
+// Matching wars multiply each other's strength (§1.07.332)
+export function getMatchingWars(war: War, wars: War[]): War[] {
+  if (!war.seriesName) return []
+  return wars
+    .filter((w) => w.seriesName === war.seriesName && w.status === "active")
+    .sort((a, b) => a.index - b.index)
+}
+
+// Only active leaders add their strength to a war (§1.07.342). A leader drawn
+// while no matching war is active waits in the Forum, and leaders withdraw once
+// their last matching war is defeated
+export function getActiveLeaders(
+  war: War,
+  enemyLeaders: EnemyLeader[],
+): EnemyLeader[] {
+  if (!war.seriesName) return []
+  return enemyLeaders.filter((l) => l.active && l.seriesName === war.seriesName)
+}
+
+export interface WarStrengthBreakdown {
+  // The unmodified strength printed on the war card
+  base: number
+  // 1 to 4, from the number of active matching wars (§1.07.332)
+  multiplier: number
+  matchingWars: War[]
+  leaders: EnemyLeader[]
+  leaderStrength: number
+  total: number
+  isModified: boolean
+}
+
+// Land and fleet strength are multiplied by matching wars and then increased by
+// leader strength (§1.07.342). Fleet support is never modified
+export function getWarStrengthBreakdown(
+  war: War,
+  battle: "land" | "naval",
+  wars: War[],
+  enemyLeaders: EnemyLeader[],
+): WarStrengthBreakdown {
+  const base = battle === "land" ? war.landStrength : war.navalStrength
+  const matchingWars = getMatchingWars(war, wars)
+  const multiplier = Math.max(1, matchingWars.length)
+  const leaders = getActiveLeaders(war, enemyLeaders)
+  const leaderStrength = leaders.reduce((sum, l) => sum + l.strength, 0)
+  return {
+    base,
+    multiplier,
+    matchingWars,
+    leaders,
+    leaderStrength,
+    total: base * multiplier + leaderStrength,
+    isModified: multiplier > 1 || leaderStrength > 0,
+  }
 }


### PR DESCRIPTION
Addresses #744.

When a war is multiplied by Matching Wars or joined by an enemy Leader, the UI showed only the resulting number, with nothing to say where it came from.

> **§1.07.332 MATCHING WARS** - Whenever two Wars of the same type are active (e.g., two Punic Wars or two Cilician Pirates), the Land and Fleet Strength (but not Fleet Support) of each are doubled as long as the two remain active. If a third Matching War is active, the Strength numbers of all three are tripled. If all four Macedonian War cards are active at the same time, their Strength is quadrupled.

> **§1.07.342 LEADER STRENGTH** - While a Leader is active and matched with the War(s), the Land and Fleet Strength (not Fleet Support) number(s) of the War(s) are increased by his value, after any relevant doubling, tripling, or quadrupling for Matching Wars.

### Behaviour

A modified Land or Naval strength is now a hover/focus target that opens a breakdown naming every contributor: the base, the matching wars driving the multiplier, and each active leader. Unmodified strengths render as before, as a plain number with no hover. If you reckon I should include the hover there too, I can do that - but I figured it'd waste people's time hovering over it.

The same breakdown appears wherever the modified figure is shown: on the war cards and beside `War strength` in the combat calculator. Fleet Support is never modified, so it is left alone.

### Implementation notes

The `base × matchingWarMultiplier + leaderStrength` calculation was duplicated between `GameMain` and `CombatCalculatorItem`. It now lives in one place, `getWarStrengthBreakdown` in `frontend/helpers/wars.ts`, which returns the total along with the parts that produced it; `WarStrength` renders that through the existing `Popover`. No backend changes there, the serializer already sends the unmodified strengths.

Caught a couple bugs while putting this one together:
- **Inactive leaders were being counted.** Both call sites filtered enemy leaders on `series_name` alone, ignoring `active`. A leader drawn while no matching war is active, or one that withdrew after a Roman victory, was inflating the displayed strength even though `resolve_combat` ignores it. With an inactive Hamilcar (Punic, +3) in the Forum, the 1st Punic War now shows 27 rather than 30. The same filter now also feeds the calculator's disaster/standoff probabilities, which had the same problem. I fixed it here, and as such you will see me fumble with the labels for this PR.
- **Popovers were painting behind the combat calculator.** The calculator sits at `z-index: 1000` and `Popover` portalled at `z-50`, so a breakdown opened inside the calculator was invisible. The popover portal now sits above it.

<img width="1700" height="1000" alt="744-b-land-strength-popover" src="https://github.com/user-attachments/assets/6c5d815d-d333-437b-b4c5-4a6974659835" />
<img width="1630" height="1524" alt="744-c-calculator-popover" src="https://github.com/user-attachments/assets/96f1f021-3c13-4d0b-84de-2d658e57da8f" />

### Testing

- `npx tsc --noEmit` and `eslint` clean on the changed files. (`npm run lint` is broken repo-wide on `main` — `next lint` was removed in Next 16 - so eslint was run directly.)
- Backend suite unaffected and still green: **447 passed** (`pytest`).
- Checked in a test game with two active Punic Wars, an active Hannibal (+7) and an inactive Hamilcar (+3): 1st Punic land 10×2+7 = 27, naval 10×2+7 = 27, fleet support unchanged at 5; 2nd Punic land 15×2+7 = 37; 1st Gallic 10 with no popover.
