### PR TITLE
chore: add land bill slot counts to game-data

### DIFF
--- a/game-data/components/board.md
+++ b/game-data/components/board.md
@@ -183,9 +183,10 @@ drm: 1 Talent each
 
 ## Land Bills Table {#board-land-bills}
 
-|      | Type I | Type II | Type III |
-| ---- | ------ | ------- | -------- |
-| Cost | 20T    | 5T/year | 10T/year |
+|       | Type I | Type II | Type III |
+| ----- | ------ | ------- | -------- |
+| Slots | 1      | 2       | 3        |
+| Cost  | 20T    | 5T/year | 10T/year |
 
 | Pass                       | Type I | Type II | Type III |
 | -------------------------- | ------ | ------- | -------- |


### PR DESCRIPTION
Closes #794

Note that changes to game-state will only be reflected in rorcli after running `python -m rorcli build`