### PR TITLE
fix: rank the Master of Horse in the HRAO order (§1.09.11)

### DIFF
--- a/backend/rorapp/helpers/hrao.py
+++ b/backend/rorapp/helpers/hrao.py
@@ -7,8 +7,9 @@ MAJOR_OFFICES = [
     Senator.Title.DICTATOR,
     Senator.Title.ROME_CONSUL,
     Senator.Title.FIELD_CONSUL,
-    Senator.Title.PROCONSUL,
     Senator.Title.CENSOR,
+    Senator.Title.MASTER_OF_HORSE,
+    Senator.Title.PROCONSUL,
 ]
 
 

--- a/backend/tests/s1_basic_game/s1_09_senate_phase/s1_09_11_hrao_test.py
+++ b/backend/tests/s1_basic_game/s1_09_senate_phase/s1_09_11_hrao_test.py
@@ -1,0 +1,43 @@
+import pytest
+from rorapp.helpers.hrao import set_hrao
+from rorapp.models import Game, Senator
+
+
+# The order of officials given in 1.09.11, most senior first. A senator holding
+# no office at all comes last, ranked only by influence.
+HRAO_ORDER = [
+    Senator.Title.DICTATOR,
+    Senator.Title.ROME_CONSUL,
+    Senator.Title.FIELD_CONSUL,
+    Senator.Title.CENSOR,
+    Senator.Title.MASTER_OF_HORSE,
+    None,
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "senior_title, junior_title", list(zip(HRAO_ORDER, HRAO_ORDER[1:]))
+)
+def test_hrao_follows_the_order_of_offices(
+    basic_game: Game,
+    senior_title: Senator.Title,
+    junior_title: Senator.Title | None,
+):
+    # Arrange
+    game = basic_game
+    senior = Senator.objects.get(game=game, family_name="Aurelius")
+    senior.add_title(senior_title)
+    senior.save()
+    junior = Senator.objects.get(game=game, family_name="Junius")
+    if junior_title:
+        junior.add_title(junior_title)
+    junior.influence = 20
+    junior.save()
+
+    # Act
+    set_hrao(game.id)
+
+    # Assert
+    senior.refresh_from_db()
+    assert senior.has_title(Senator.Title.HRAO)


### PR DESCRIPTION
The Master of Horse was missing from the HRAO ranking, so he was treated as a senator holding no office at all.

> **§1.09.11** - The first official on the following list present in Rome: Dictator, Rome Consul, Field Consul, Censor, Master of Horse, Pontifex Maximus, and followed by any Senator in Rome with the most Influence.

### Behaviour

`MAJOR_OFFICES` stopped at Censor, so a Master of Horse wasn't considered in the HRAO chain.

### Implementation notes

- Master of Horse sits below Censor, as the glossary has it, and above Proconsul.
- Proconsul moves to the end. It isn't in the rulebook's HRAO list at all and never decides an HRAO in practice, since a Proconsul is by definition away from Rome and both `set_hrao` and the step-down path filter on location. Last is also the better answer for the one thing its position does affect: `kill_senators` orders victims by rank so the HRAO's successor dies last, and a Proconsul can never be that successor.

### Out of scope

- Pontifex Maximus follows Master of Horse in the glossary's list, but it's an Advanced Rule (§2.01) and isn't a title yet, so there's nothing to slot in. I may add that soon.

### Tests
541 pass, including a new more general succession test.