### PR TITLE
Show concession income details on hover after assignment

### DIFF
--- a/frontend/components/SenatorDisplay.tsx
+++ b/frontend/components/SenatorDisplay.tsx
@@ -1,6 +1,8 @@
 import Senator from "@/classes/Senator"
-import { formatSigned } from "@/helpers/numbers"
+import Popover from "@/components/Popover"
+import { CONCESSION_INCOME } from "@/data/concessions"
 import { STATESMAN_ABILITIES } from "@/data/statesmen"
+import { formatSigned } from "@/helpers/numbers"
 import { toFamilyAdjective } from "@/helpers/text"
 
 interface SenatorDisplayProps {
@@ -39,18 +41,35 @@ const SenatorDisplay = ({ senator }: SenatorDisplayProps) => {
             {senator.concessions.length > 0 && (
               <>
                 {senator.concessions.map(
-                  (concession: string, index: number) => (
-                    <div key={index} className="flex items-center gap-1">
-                      <span className="text-yellow-900 first-letter:uppercase">
-                        {concession}
-                      </span>
-                      {senator.corruptConcessions.includes(concession) && (
-                        <span className="flex text-sm text-red-600">
-                          (corrupt)
-                        </span>
-                      )}
-                    </div>
-                  ),
+                  (concession: string, index: number) => {
+                    const income = CONCESSION_INCOME[concession]
+
+                    return (
+                      <div key={index} className="flex items-center gap-1">
+                        {income ? (
+                          <Popover
+                            className="flex"
+                            trigger={
+                              <span className="text-yellow-900 first-letter:uppercase">
+                                {concession}
+                              </span>
+                            }
+                          >
+                            <span>{income}</span>
+                          </Popover>
+                        ) : (
+                          <span className="text-yellow-900 first-letter:uppercase">
+                            {concession}
+                          </span>
+                        )}
+                        {senator.corruptConcessions.includes(concession) && (
+                          <span className="flex text-sm text-red-600">
+                            (corrupt)
+                          </span>
+                        )}
+                      </div>
+                    )
+                  },
                 )}
               </>
             )}

--- a/frontend/components/SenatorDisplay.tsx
+++ b/frontend/components/SenatorDisplay.tsx
@@ -111,19 +111,27 @@ const SenatorDisplay = ({ senator }: SenatorDisplayProps) => {
         <div className="flex flex-wrap gap-x-4 gap-y-2 text-neutral-600">
           <div>
             <span className="text-sm">Military</span>{" "}
-            <span className="inline-block w-3 tabular-nums">{senator.military}</span>
+            <span className="inline-block w-3 tabular-nums">
+              {senator.military}
+            </span>
           </div>
           <div>
             <span className="text-sm">Oratory</span>{" "}
-            <span className="inline-block w-3 tabular-nums">{senator.oratory}</span>
+            <span className="inline-block w-3 tabular-nums">
+              {senator.oratory}
+            </span>
           </div>
           <div>
             <span className="text-sm">Loyalty</span>{" "}
-            <span className="inline-block w-5 tabular-nums">{senator.loyalty}</span>
+            <span className="inline-block w-5 tabular-nums">
+              {senator.loyalty}
+            </span>
           </div>
           <div>
             <span className="text-sm">Influence</span>{" "}
-            <span className="inline-block w-5 tabular-nums">{senator.influence}</span>
+            <span className="inline-block w-5 tabular-nums">
+              {senator.influence}
+            </span>
           </div>
           <div>
             <span className="text-sm">Popularity</span>{" "}
@@ -133,11 +141,15 @@ const SenatorDisplay = ({ senator }: SenatorDisplayProps) => {
           </div>
           <div>
             <span className="text-sm">Knights</span>{" "}
-            <span className="inline-block w-3 tabular-nums">{senator.knights}</span>
+            <span className="inline-block w-3 tabular-nums">
+              {senator.knights}
+            </span>
           </div>
           <div>
             <span className="text-sm">Votes</span>{" "}
-            <span className="inline-block w-3 tabular-nums">{senator.votes}</span>
+            <span className="inline-block w-3 tabular-nums">
+              {senator.votes}
+            </span>
           </div>
           <div className="w-7 tabular-nums" dir="rtl">
             {senator.talents}T


### PR DESCRIPTION
## Summary

* Show the existing `CONCESSION_INCOME` description when hovering over or focusing an assigned concession in `SenatorDisplay`.
* Reuse the existing `Popover` component.
* Keep assigned concession information visible to every player through the public senator display.
* Preserve the existing `(corrupt)` indicator and private-hand behavior.
* Continue displaying the concession name without an empty popover if no description is available.

## Testing

* `npx prettier --check components/SenatorDisplay.tsx` passed.
* `npx tsc --noEmit` passed.
* `git diff --check` passed.
* Successfully installed and ran the game locally on Windows 10.
* Manually verified the assigned-concession popovers for:

  * **Armaments:** `2T per new legion raised`
  * **Ship Building:** `3T per new fleet raised`
  * **Aegyptian Grain:** `5T at revenue`
  * **Tax Farmer concessions:** `2T at revenue`

* Confirmed that the descriptions appear correctly and that the `(corrupt)` indicator remains correctly displayed.

The production build attempted in the Codex cloud environment was blocked only because that environment could not download the configured Google Fonts from `fonts.gstatic.com`; no TypeScript or application-code error was reported. The application was subsequently run and tested successfully in the local Windows 10 environment.

## Manual test screenshots

**Armaments — `2T per new legion raised`**
<img width="703" height="488" alt="image" src="https://github.com/user-attachments/assets/a519e22f-d0dd-4c28-8583-9f7eaaa1bc11" />



**Ship Building — `3T per new fleet raised`**
<img width="427" height="245" alt="image" src="https://github.com/user-attachments/assets/7f601dac-4317-4dd6-9f04-5b78ff0120dd" />


**Aegyptian Grain — `5T at revenue`**
<img width="238" height="126" alt="image" src="https://github.com/user-attachments/assets/d955117b-4a2b-4c76-b311-1219d8d78f29" />


**Latium Tax Farmer — `2T at revenue`**
<img width="347" height="257" alt="image" src="https://github.com/user-attachments/assets/ba6db285-41c4-432a-871c-553fdc10a81d" />

Closes #812

Related to #775
