### PR TITLE
fix: correct counter-bribe recipient text

### DIFF
--- a/frontend/components/customActionForms/CounterBribeForm.tsx
+++ b/frontend/components/customActionForms/CounterBribeForm.tsx
@@ -87,7 +87,7 @@ const CounterBribeForm = ({
             <h3 className="text-xl">Counter-bribe</h3>
             <p>
               Prevent persuasion by transferring talents from your faction
-              treasury to {persuader?.displayName} as a counter-bribe.
+              treasury to {target?.displayName} as a counter-bribe.
             </p>
           </div>
           {feedback && (


### PR DESCRIPTION
Closes #825

The counter-bribe dialog incorrectly stated that Talents were transferred to the persuading Senator. It now correctly identifies the target Senator as the recipient.

The backend already transfers the Talents to the target correctly, so no game logic has been changed.

## Testing

- Prettier check
- `git diff --check`
- Frontend production build completed successfully in a separate environment