### PR TITLE
fix: log mob deaths during a popular appeal as such (§1.09.421)

### DIFF
--- a/backend/rorapp/actions/call_popular_appeal.py
+++ b/backend/rorapp/actions/call_popular_appeal.py
@@ -9,7 +9,7 @@ from rorapp.classes.faction_status_item import FactionStatusItem
 from rorapp.game_state.game_state_live import GameStateLive
 from rorapp.game_state.game_state_snapshot import GameStateSnapshot
 from rorapp.helpers.finish_prosecution import finish_prosecution
-from rorapp.helpers.kill_senator import kill_senator, kill_senators
+from rorapp.helpers.kill_senator import CauseOfDeath, kill_senator, kill_senators
 from rorapp.helpers.text import pluralize
 from rorapp.models import AvailableAction, Faction, Game, Senator, Log
 
@@ -130,12 +130,12 @@ class CallPopularAppealAction(ActionBase):
         if table_value == "killed":
             Log.create_object(
                 game_id,
-                f"{accused.display_name} called a popular appeal but the mob turned on him. He was killed.",
+                f"{accused.display_name} called a popular appeal but the mob turned on him.",
             )
 
             accused_had_prior_consul = accused.has_title(Senator.Title.PRIOR_CONSUL)
             accused_influence_before = accused.influence
-            kill_senator(accused)
+            kill_senator(accused, CauseOfDeath.MOB)
 
             prosecutor = Senator.objects.get(id=prosecutor.id)
             if accused_had_prior_consul:
@@ -171,7 +171,7 @@ class CallPopularAppealAction(ActionBase):
                     and senator.alive
                     and get_senator_codes(senator.code)[0] in chits
                 ]
-                kill_senators(victims)
+                kill_senators(victims, CauseOfDeath.MOB)
 
             assert game.current_proposal is not None
             game.add_defeated_proposal(game.current_proposal)


### PR DESCRIPTION
Closes #800 in a nice three-liner!

A senator killed by the mob during a popular appeal was logged as having died of natural causes.

> "Accused Killed" means the populace is so disgusted by the self-serving rhetoric of the Accused that they kill him themselves. [...] In addition, one Mortality Chit is drawn for each number which exceeds 11 on the modified roll in order to see if either the Censor and/or the Prosecutor (the only two vulnerable to the chit draw) is killed by a mob enraged over this obvious frame-up. (§1.09.421)

Both deaths a popular appeal can cause are mob killings, and neither call site in `call_popular_appeal.py` passed a cause of death, so both fell back to the `CauseOfDeath.NATURAL` default.

### Behaviour

Deaths from a popular appeal are now logged as mob killings, matching the mob violence event and the state of the republic speech, which already pass `CauseOfDeath.MOB`. Nothing else about the resolution changes: the prior consul marker, the half influence transfer and the acquittal path are untouched.

### New log examples

On a result of 0 or less, the mob kills the Accused:

> Fabius called a popular appeal but the mob turned on him.
> Fabius of Faction 1 was killed by the mob.

On a result above 11, chits are drawn for the frame-up:

> Fabius called a popular appeal and was freed by the crowd.
> Valerius of Faction 1 was killed by the mob.

The Accused's summary line lost its trailing "He was killed.", which now only repeats the death line beneath it.

### Out of scope

Two things noticed while reading the file, both worth their own issue rather than being folded in here:

- The frame-up chit draw treats the Accused and the Prosecutor as vulnerable, but §1.09.421 names the Censor and the Prosecutor.
- A senator executed after a guilty verdict for major corruption is still logged as dying of natural causes. `CauseOfDeath.EXECUTION` exists but its wording is specific to attempted murder, so it needs a new cause rather than a one-word change.

### Testing

`pytest` passes at 567 tests, `mypy .` is clean across 422 source files. Didn't want to bloat the test file by adding a test for this specific fix, just shout if you'd rather have one though. Seems to work though!