### PR TITLE
Functional prototype: private persuasion calculator

### DIFF
--- a/frontend/app/(protected)/games/[id]/live/page.tsx
+++ b/frontend/app/(protected)/games/[id]/live/page.tsx
@@ -18,6 +18,9 @@ import GameBar from "@/components/GameBar"
 import GameMain from "@/components/GameMain"
 import { ActionSelection } from "@/components/GenericActionForm"
 import LogList from "@/components/LogList"
+import PersuasionCalculator, {
+  PersuasionCalculatorHandle,
+} from "@/components/PersuasionCalculator"
 import SenateBar from "@/components/SenateBar"
 import { useGameContext } from "@/contexts/GameContext"
 import { getDeployedForces } from "@/helpers/deploymentProposal"
@@ -282,7 +285,10 @@ const LiveGamePage = () => {
   }
 
   const combatCalculatorRef = useRef<CombatCalculatorHandle>(null)
-  const [topPanel, setTopPanel] = useState<"combat" | "debug">("combat")
+  const persuasionCalculatorRef = useRef<PersuasionCalculatorHandle>(null)
+  const [topPanel, setTopPanel] = useState<"combat" | "persuasion" | "debug">(
+    "combat",
+  )
 
   const handleActionSubmitSuccess = useCallback((id: string) => {
     setSelectionMap((prev) => ({ ...prev, [id]: {} }))
@@ -426,6 +432,14 @@ const LiveGamePage = () => {
             combatCalculatorRef.current?.open()
             setTopPanel("combat")
           }}
+          onPersuasionCalculatorOpen={
+            privateGameState?.faction
+              ? () => {
+                  persuasionCalculatorRef.current?.open()
+                  setTopPanel("persuasion")
+                }
+              : undefined
+          }
           onDebugPanelOpen={
             devEndpointsEnabled
               ? () => {
@@ -456,6 +470,15 @@ const LiveGamePage = () => {
           zIndex={topPanel === "combat" ? 1001 : 1000}
           onFocus={() => setTopPanel("combat")}
         />
+        {privateGameState?.faction && (
+          <PersuasionCalculator
+            ref={persuasionCalculatorRef}
+            publicGameState={publicGameState as PublicGameState}
+            factionId={privateGameState.faction.id}
+            zIndex={topPanel === "persuasion" ? 1001 : 1000}
+            onFocus={() => setTopPanel("persuasion")}
+          />
+        )}
         <div className="flex flex-1 overflow-hidden border-t border-neutral-300">
           <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
             <SenateBar publicGameState={publicGameState as PublicGameState} />

--- a/frontend/components/GameBar.tsx
+++ b/frontend/components/GameBar.tsx
@@ -19,6 +19,7 @@ interface Props {
   publicGameState: PublicGameState
   privateGameState: PrivateGameState | undefined
   onCombatCalculatorOpen: () => void
+  onPersuasionCalculatorOpen?: () => void
   onDebugPanelOpen?: () => void
   showPlayerButtons?: boolean
 }
@@ -31,6 +32,7 @@ const GameBar = ({
   publicGameState,
   privateGameState,
   onCombatCalculatorOpen,
+  onPersuasionCalculatorOpen,
   onDebugPanelOpen,
   showPlayerButtons,
 }: Props) => {
@@ -334,6 +336,20 @@ const GameBar = ({
 
       {/* Spacer */}
       <div className="flex-1" />
+
+      {/* Persuasion Calculator */}
+      {onPersuasionCalculatorOpen && (
+        <Cell>
+          <button
+            type="button"
+            onClick={onPersuasionCalculatorOpen}
+            className="flex h-full flex-col justify-center px-4 text-sm hover:bg-neutral-100"
+          >
+            <span>Persuasion</span>
+            <span>Calculator</span>
+          </button>
+        </Cell>
+      )}
 
       {/* Combat Calculator */}
       <Cell>

--- a/frontend/components/PersuasionCalculationPanel.tsx
+++ b/frontend/components/PersuasionCalculationPanel.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { PersuasionSnapshot, calculatePersuasion } from "@/helpers/persuasion"
+
+import Checkbox from "./Checkbox"
+
+export interface PersuasionCalculationState {
+  id: number
+  persuaderId: number | null
+  targetId: number | null
+  persuaderBribe: number
+  counterBribes: Record<number, number>
+  useSeduction: boolean
+  useBlackmail: boolean
+}
+
+interface Props {
+  calculation: PersuasionCalculationState
+  snapshot: PersuasionSnapshot
+  updateCalculation: (
+    update: Partial<Omit<PersuasionCalculationState, "id">>,
+  ) => void
+}
+
+const PersuasionCalculationPanel = ({
+  calculation,
+  snapshot,
+  updateCalculation,
+}: Props) => {
+  const persuader = snapshot.persuaders.find(
+    (senator) => senator.id === calculation.persuaderId,
+  )
+  const target = snapshot.targets.find(
+    (senator) => senator.id === calculation.targetId,
+  )
+  const unopposed = calculation.useSeduction || calculation.useBlackmail
+  const counterBribeTotal = Object.values(calculation.counterBribes).reduce(
+    (total, value) => total + value,
+    0,
+  )
+  const effectiveCounterBribes = unopposed ? 0 : counterBribeTotal
+  const result =
+    persuader && target
+      ? calculatePersuasion({
+          oratory: persuader.oratory,
+          influence: persuader.influence,
+          loyalty: target.loyalty,
+          targetTalents: target.talents,
+          alignedTarget: target.faction !== null,
+          persuaderBribe: calculation.persuaderBribe,
+          counterBribes: effectiveCounterBribes,
+          evilOmens: snapshot.evilOmens,
+          eraEnds: snapshot.eraEnds,
+        })
+      : null
+
+  const targetGroups = useMemo(() => {
+    const groups = snapshot.factions
+      .filter((faction) =>
+        snapshot.targets.some((senator) => senator.faction === faction.id),
+      )
+      .map((faction) => ({
+        id: faction.id,
+        label: faction.displayName,
+        senators: snapshot.targets.filter(
+          (senator) => senator.faction === faction.id,
+        ),
+      }))
+
+    if (snapshot.targets.some((senator) => senator.faction === null)) {
+      groups.push({
+        id: -1,
+        label: "Unaligned",
+        senators: snapshot.targets.filter(
+          (senator) => senator.faction === null,
+        ),
+      })
+    }
+    return groups
+  }, [snapshot])
+
+  const clampValue = (value: number, maximum?: number) =>
+    Math.max(
+      0,
+      Math.min(maximum ?? Number.MAX_SAFE_INTEGER, Math.floor(value || 0)),
+    )
+
+  const setCounterBribe = (factionId: number, value: number) =>
+    updateCalculation({
+      counterBribes: {
+        ...calculation.counterBribes,
+        [factionId]: clampValue(value),
+      },
+    })
+
+  return (
+    <div className="grid grid-cols-2 gap-8">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor={`persuader-${calculation.id}`}
+            className="font-semibold"
+          >
+            Persuader
+          </label>
+          <select
+            id={`persuader-${calculation.id}`}
+            value={calculation.persuaderId ?? ""}
+            onChange={(event) =>
+              updateCalculation({
+                persuaderId: event.target.value
+                  ? Number(event.target.value)
+                  : null,
+                persuaderBribe: 0,
+              })
+            }
+            className="rounded-md border border-blue-600 p-1"
+          >
+            <option value="">-- select an option --</option>
+            {snapshot.persuaders.map((senator) => (
+              <option key={senator.id} value={senator.id}>
+                {senator.displayName} (ORA {senator.oratory}, INF{" "}
+                {senator.influence}, {senator.talents}T)
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor={`target-${calculation.id}`} className="font-semibold">
+            Target
+          </label>
+          <select
+            id={`target-${calculation.id}`}
+            value={calculation.targetId ?? ""}
+            onChange={(event) =>
+              updateCalculation({
+                targetId: event.target.value
+                  ? Number(event.target.value)
+                  : null,
+              })
+            }
+            className="rounded-md border border-blue-600 p-1"
+          >
+            <option value="">-- select an option --</option>
+            {targetGroups.map((group) => (
+              <optgroup key={group.id} label={group.label}>
+                {group.senators.map((senator) => (
+                  <option key={senator.id} value={senator.id}>
+                    {senator.displayName} (LOY {senator.loyalty},{" "}
+                    {senator.talents}T)
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor={`persuader-bribe-${calculation.id}`}
+            className="font-semibold"
+          >
+            Persuader bribe
+          </label>
+          <input
+            id={`persuader-bribe-${calculation.id}`}
+            type="number"
+            min={0}
+            max={persuader?.talents ?? 0}
+            value={calculation.persuaderBribe}
+            onChange={(event) =>
+              updateCalculation({
+                persuaderBribe: clampValue(
+                  Number(event.target.value),
+                  persuader?.talents ?? 0,
+                ),
+              })
+            }
+            disabled={!persuader}
+            className="rounded-md border border-blue-600 px-2 py-1 disabled:border-neutral-300 disabled:bg-neutral-100"
+          />
+        </div>
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className="mb-1 font-semibold">Cards</legend>
+          <Checkbox
+            checked={calculation.useSeduction}
+            onChange={(checked) =>
+              updateCalculation({
+                useSeduction: checked,
+                useBlackmail: checked ? false : calculation.useBlackmail,
+              })
+            }
+          >
+            Seduction
+          </Checkbox>
+          <Checkbox
+            checked={calculation.useBlackmail}
+            onChange={(checked) =>
+              updateCalculation({
+                useBlackmail: checked,
+                useSeduction: checked ? false : calculation.useSeduction,
+              })
+            }
+          >
+            Blackmail
+          </Checkbox>
+          <p className="text-sm text-neutral-600">
+            Card availability is not checked. Either card makes the attempt
+            unopposed.
+          </p>
+        </fieldset>
+      </div>
+
+      <div className="flex flex-col gap-5">
+        <fieldset className="flex flex-col gap-3">
+          <legend className="mb-1 font-semibold">Counter-bribes</legend>
+          {snapshot.factions.map((faction) => (
+            <div
+              key={faction.id}
+              className="grid grid-cols-[1fr_6rem] items-center gap-3"
+            >
+              <label htmlFor={`counter-bribe-${calculation.id}-${faction.id}`}>
+                {faction.displayName}
+              </label>
+              <input
+                id={`counter-bribe-${calculation.id}-${faction.id}`}
+                type="number"
+                min={0}
+                value={calculation.counterBribes[faction.id] ?? 0}
+                onChange={(event) =>
+                  setCounterBribe(faction.id, Number(event.target.value))
+                }
+                disabled={unopposed}
+                className="rounded-md border border-blue-600 px-2 py-1 disabled:border-neutral-300 disabled:bg-neutral-100"
+              />
+            </div>
+          ))}
+          <div className="grid grid-cols-[1fr_6rem] gap-3 border-t border-neutral-300 pt-2 font-semibold">
+            <span>Total</span>
+            <span className="px-2">
+              {unopposed ? "Ignored" : `${counterBribeTotal}T`}
+            </span>
+          </div>
+        </fieldset>
+
+        <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-2 rounded-md bg-neutral-100 px-3 py-2 text-sm">
+          <dt>Evil Omens</dt>
+          <dd>{snapshot.evilOmens}</dd>
+          <dt>Era Ends</dt>
+          <dd>{snapshot.eraEnds ? "Yes" : "No"}</dd>
+        </dl>
+
+        <div
+          aria-live="polite"
+          className="rounded-md bg-blue-50 px-4 py-4 text-center text-blue-700"
+        >
+          <div className="text-sm">Chance of success</div>
+          <strong className="text-3xl">
+            {result ? `${result.chancePercent}%` : "—"}
+          </strong>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PersuasionCalculationPanel

--- a/frontend/components/PersuasionCalculator.tsx
+++ b/frontend/components/PersuasionCalculator.tsx
@@ -1,0 +1,316 @@
+"use client"
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react"
+
+import PublicGameState from "@/classes/PublicGameState"
+import {
+  PersuasionSnapshot,
+  createPersuasionSnapshot,
+} from "@/helpers/persuasion"
+
+import PersuasionCalculationPanel, {
+  PersuasionCalculationState,
+} from "./PersuasionCalculationPanel"
+
+interface Props {
+  publicGameState: PublicGameState
+  factionId: number
+  zIndex?: number
+  onFocus?: () => void
+}
+
+export interface PersuasionCalculatorHandle {
+  open: () => void
+}
+
+const newCalculation = (id: number): PersuasionCalculationState => ({
+  id,
+  persuaderId: null,
+  targetId: null,
+  persuaderBribe: 0,
+  counterBribes: {},
+  useSeduction: false,
+  useBlackmail: false,
+})
+
+const PersuasionCalculator = forwardRef<PersuasionCalculatorHandle, Props>(
+  function PersuasionCalculator(
+    { publicGameState, factionId, zIndex = 1000, onFocus }: Props,
+    ref,
+  ) {
+    const [isOpen, setIsOpen] = useState(false)
+    const [snapshot, setSnapshot] = useState<PersuasionSnapshot | null>(null)
+    const [position, setPosition] = useState({ x: 80, y: 20 })
+    const [dragging, setDragging] = useState(false)
+    const offsetRef = useRef({ x: 0, y: 0 })
+    const nextIdRef = useRef(2)
+    const [calculations, setCalculations] = useState<
+      PersuasionCalculationState[]
+    >([newCalculation(1)])
+    const [selectedId, setSelectedId] = useState(1)
+
+    const close = useCallback(() => {
+      setIsOpen(false)
+    }, [])
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        open: () => {
+          if (isOpen) {
+            onFocus?.()
+            setPosition({
+              x: Math.max(10, (window.innerWidth - 760) / 2),
+              y: 20,
+            })
+            return
+          }
+          setSnapshot(createPersuasionSnapshot(publicGameState, factionId))
+          setCalculations([newCalculation(1)])
+          setSelectedId(1)
+          nextIdRef.current = 2
+          setIsOpen(true)
+          onFocus?.()
+          setPosition((current) => ({
+            x: Math.max(10, (window.innerWidth - 760) / 2),
+            y: current.y,
+          }))
+        },
+      }),
+      [factionId, isOpen, onFocus, publicGameState],
+    )
+
+    const handleMouseDown = (event: React.MouseEvent) => {
+      setDragging(true)
+      offsetRef.current = {
+        x: event.clientX - position.x,
+        y: event.clientY - position.y,
+      }
+    }
+
+    const handleMouseMove = useCallback(
+      (event: MouseEvent) => {
+        if (!dragging) return
+        setPosition({
+          x: event.clientX - offsetRef.current.x,
+          y: event.clientY - offsetRef.current.y,
+        })
+      },
+      [dragging],
+    )
+
+    const handleMouseUp = useCallback(() => setDragging(false), [])
+
+    useEffect(() => {
+      if (!dragging) return
+      document.addEventListener("mousemove", handleMouseMove)
+      document.addEventListener("mouseup", handleMouseUp)
+      return () => {
+        document.removeEventListener("mousemove", handleMouseMove)
+        document.removeEventListener("mouseup", handleMouseUp)
+      }
+    }, [dragging, handleMouseMove, handleMouseUp])
+
+    const selectedCalculation =
+      calculations.find((calculation) => calculation.id === selectedId) ??
+      calculations[0]
+
+    const updateSelected = (
+      update: Partial<Omit<PersuasionCalculationState, "id">>,
+    ) => {
+      setCalculations((current) =>
+        current.map((calculation) =>
+          calculation.id === selectedId
+            ? { ...calculation, ...update }
+            : calculation,
+        ),
+      )
+    }
+
+    const addCalculation = () => {
+      const id = nextIdRef.current++
+      setCalculations((current) => [...current, newCalculation(id)])
+      setSelectedId(id)
+    }
+
+    const removeCalculation = (id: number) => {
+      if (calculations.length === 1) return
+      const remaining = calculations.filter(
+        (calculation) => calculation.id !== id,
+      )
+      setCalculations(remaining)
+      if (selectedId === id) setSelectedId(remaining[0].id)
+    }
+
+    const focusTab = (id: number) => {
+      setSelectedId(id)
+      requestAnimationFrame(() =>
+        document.getElementById(`persuasion-tab-${id}`)?.focus(),
+      )
+    }
+
+    const handleTabKeyDown = (
+      event: React.KeyboardEvent<HTMLButtonElement>,
+      index: number,
+    ) => {
+      let nextIndex: number | null = null
+      if (event.key === "ArrowRight") {
+        nextIndex = (index + 1) % calculations.length
+      } else if (event.key === "ArrowLeft") {
+        nextIndex = (index - 1 + calculations.length) % calculations.length
+      } else if (event.key === "Home") {
+        nextIndex = 0
+      } else if (event.key === "End") {
+        nextIndex = calculations.length - 1
+      }
+      if (nextIndex === null) return
+      event.preventDefault()
+      focusTab(calculations[nextIndex].id)
+    }
+
+    if (!isOpen || !snapshot || !selectedCalculation) return null
+
+    const selectedTabId = `persuasion-tab-${selectedCalculation.id}`
+    const selectedPanelId = `persuasion-panel-${selectedCalculation.id}`
+
+    return (
+      <section
+        aria-labelledby="persuasion-calculator-title"
+        className="fixed w-[760px] rounded-lg border border-neutral-400 bg-white shadow-lg"
+        style={{ left: position.x, top: position.y, zIndex }}
+        onMouseDown={onFocus}
+        onFocusCapture={onFocus}
+      >
+        <header
+          className="flex cursor-grab select-none items-center justify-between px-6 py-5"
+          onMouseDown={handleMouseDown}
+        >
+          <h2 id="persuasion-calculator-title" className="text-xl">
+            Persuasion Calculator
+          </h2>
+          <button
+            type="button"
+            aria-label="Close persuasion calculator"
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={close}
+            className="text-neutral-600 hover:text-black"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="px-6 pb-6">
+          <div className="mb-4 flex flex-col gap-1 text-sm text-neutral-600">
+            <p>
+              Private virtual planning tool. These values stay in your browser
+              and cannot affect the game.
+            </p>
+            <p>
+              This snapshot was taken when the calculator opened. Close and
+              reopen it to use the latest game state.
+            </p>
+            <p>
+              All entered talents are hypothetical additions to the captured
+              values.
+            </p>
+          </div>
+
+          <div
+            role="tablist"
+            aria-label="Persuasion calculations"
+            className="mx-[-24px] mb-5 flex flex-wrap items-center gap-2 bg-neutral-100 px-6 py-2"
+          >
+            {calculations.map((calculation, index) => {
+              const calculationTarget = snapshot.targets.find(
+                (senator) => senator.id === calculation.targetId,
+              )
+              const selected = calculation.id === selectedId
+              const tabId = `persuasion-tab-${calculation.id}`
+              const panelId = `persuasion-panel-${calculation.id}`
+              return (
+                <div
+                  key={calculation.id}
+                  className={`flex items-center rounded-md ${
+                    selected
+                      ? "border border-neutral-400 bg-white"
+                      : "p-px text-neutral-600 hover:bg-white"
+                  }`}
+                >
+                  <button
+                    id={tabId}
+                    type="button"
+                    role="tab"
+                    aria-selected={selected}
+                    aria-controls={panelId}
+                    tabIndex={selected ? 0 : -1}
+                    onClick={() => setSelectedId(calculation.id)}
+                    onKeyDown={(event) => handleTabKeyDown(event, index)}
+                    className="px-2 py-1"
+                  >
+                    {calculationTarget?.displayName ??
+                      `Calculation ${index + 1}`}
+                  </button>
+                  {calculations.length > 1 && (
+                    <button
+                      type="button"
+                      aria-label={`Remove calculation ${index + 1}`}
+                      onClick={() => removeCalculation(calculation.id)}
+                      className="mr-1.5 flex h-5 w-5 items-center justify-center rounded-full text-xs text-neutral-600 hover:bg-neutral-200"
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              )
+            })}
+            <button
+              type="button"
+              aria-label="Add persuasion calculation"
+              onClick={addCalculation}
+              className="flex h-8 w-8 items-center justify-center rounded-full text-2xl hover:bg-neutral-200"
+            >
+              +
+            </button>
+          </div>
+
+          <div
+            id={selectedPanelId}
+            role="tabpanel"
+            aria-labelledby={selectedTabId}
+          >
+            <PersuasionCalculationPanel
+              calculation={selectedCalculation}
+              snapshot={snapshot}
+              updateCalculation={updateSelected}
+            />
+          </div>
+
+          <div className="mt-6 rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            <strong>Prototype limitation:</strong> Statesman loyalty modifiers,
+            including the Gracchi exception, are not included. The target&apos;s
+            snapshot Loyalty value is used unchanged.
+          </div>
+
+          <div className="mt-5 flex justify-end">
+            <button
+              type="button"
+              onClick={close}
+              className="select-none rounded-md border border-neutral-600 px-4 py-1 text-neutral-600 hover:bg-neutral-100"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </section>
+    )
+  },
+)
+
+export default PersuasionCalculator

--- a/frontend/helpers/persuasion.ts
+++ b/frontend/helpers/persuasion.ts
@@ -1,0 +1,136 @@
+import PublicGameState from "@/classes/PublicGameState"
+import getDiceProbability from "@/helpers/dice"
+import { getEvilOmensLevel } from "@/helpers/gameEffects"
+
+const FACTION_LEADER = "faction leader"
+
+export interface PersuasionSenatorSnapshot {
+  id: number
+  displayName: string
+  familyName: string
+  faction: number | null
+  oratory: number
+  influence: number
+  loyalty: number
+  talents: number
+}
+
+export interface PersuasionFactionSnapshot {
+  id: number
+  displayName: string
+}
+
+export interface PersuasionSnapshot {
+  persuaders: PersuasionSenatorSnapshot[]
+  targets: PersuasionSenatorSnapshot[]
+  factions: PersuasionFactionSnapshot[]
+  evilOmens: number
+  eraEnds: boolean
+}
+
+export interface PersuasionCalculationInput {
+  oratory: number
+  influence: number
+  loyalty: number
+  targetTalents: number
+  alignedTarget: boolean
+  persuaderBribe: number
+  counterBribes: number
+  evilOmens: number
+  eraEnds: boolean
+}
+
+export interface PersuasionCalculationResult {
+  baseNumber: number
+  chancePercent: number
+  automaticFailureFrom: number
+  highestSuccessfulRoll: number | null
+  impossible: boolean
+}
+
+const snapshotSenator = (
+  senator: PublicGameState["senators"][number],
+): PersuasionSenatorSnapshot => ({
+  id: senator.id,
+  displayName: senator.displayName,
+  familyName: senator.familyName,
+  faction: senator.faction,
+  oratory: senator.oratory,
+  influence: senator.influence,
+  loyalty: senator.loyalty,
+  talents: senator.talents,
+})
+
+export const createPersuasionSnapshot = (
+  publicGameState: PublicGameState,
+  factionId: number,
+): PersuasionSnapshot => {
+  const eligibleSenators = publicGameState.senators.filter(
+    (senator) => senator.alive && senator.location === "Rome",
+  )
+  const byFamilyName = (
+    first: PersuasionSenatorSnapshot,
+    second: PersuasionSenatorSnapshot,
+  ) => first.familyName.localeCompare(second.familyName)
+
+  const persuaders = eligibleSenators
+    .filter((senator) => senator.faction === factionId)
+    .map(snapshotSenator)
+    .sort(byFamilyName)
+  const targets = eligibleSenators
+    .filter(
+      (senator) =>
+        senator.faction !== factionId &&
+        (senator.faction === null || !senator.titles.includes(FACTION_LEADER)),
+    )
+    .map(snapshotSenator)
+    .sort(byFamilyName)
+  return {
+    persuaders,
+    targets,
+    factions: publicGameState.factions
+      .filter((faction) => faction.id !== factionId)
+      .map((faction) => ({
+        id: faction.id,
+        displayName: faction.displayName,
+      })),
+    evilOmens: getEvilOmensLevel(publicGameState.game?.effects ?? []),
+    eraEnds: publicGameState.game?.eraEnds ?? false,
+  }
+}
+
+export const calculatePersuasion = ({
+  oratory,
+  influence,
+  loyalty,
+  targetTalents,
+  alignedTarget,
+  persuaderBribe,
+  counterBribes,
+  evilOmens,
+  eraEnds,
+}: PersuasionCalculationInput): PersuasionCalculationResult => {
+  const baseNumber =
+    oratory +
+    influence +
+    persuaderBribe +
+    evilOmens -
+    loyalty -
+    targetTalents -
+    (alignedTarget ? 7 : 0) -
+    counterBribes
+  const automaticFailureFrom = eraEnds ? 9 : 10
+  const highestSuccessfulRoll = Math.min(baseNumber, automaticFailureFrom - 1)
+  const impossible = highestSuccessfulRoll < 2
+  const chancePercent = impossible
+    ? 0
+    : Math.round(getDiceProbability(2, 0, { max: highestSuccessfulRoll }) * 100)
+
+  return {
+    baseNumber,
+    chancePercent,
+    automaticFailureFrom,
+    highestSuccessfulRoll: impossible ? null : highestSuccessfulRoll,
+    impossible,
+  }
+}

--- a/frontend/tests/persuasionCalculator.spec.ts
+++ b/frontend/tests/persuasionCalculator.spec.ts
@@ -1,0 +1,189 @@
+import { expect, test } from "@playwright/test"
+
+import { Player, loginPlayers } from "./helpers/auth"
+import { deleteGame, setupGame } from "./helpers/game"
+
+const TIMEOUT = 15000
+
+test.describe("private persuasion calculator", () => {
+  let gameId: number
+  let players: Player[]
+
+  test.beforeEach(async ({ playwright }) => {
+    const result = await setupGame(playwright.request, "forum__attract_knight")
+    gameId = result.gameId
+    players = result.players
+  })
+
+  test.afterEach(async () => {
+    if (!gameId) return
+
+    try {
+      await deleteGame(players[0].api, gameId)
+    } catch (error) {
+      console.warn("Game cleanup threw an error:", error)
+    }
+
+    await Promise.all(players.map((player) => player.api.dispose()))
+  })
+
+  test("calculates an aligned target and keeps planning private", async ({
+    browser,
+    page,
+    playwright,
+  }) => {
+    const [secondPage] = await loginPlayers(
+      playwright.request,
+      browser,
+      page,
+      players,
+      2,
+    )
+
+    await Promise.all([
+      page.goto(`/games/${gameId}`),
+      secondPage.goto(`/games/${gameId}`),
+    ])
+
+    const calculatorButton = page.getByRole("button", {
+      name: "Persuasion Calculator",
+      exact: true,
+    })
+    await expect(calculatorButton).toBeVisible({ timeout: TIMEOUT })
+    await calculatorButton.click()
+
+    const calculator = page.getByRole("region", {
+      name: "Persuasion Calculator",
+    })
+    await expect(calculator).toBeVisible()
+    await expect(
+      calculator.getByText(/snapshot was taken when the calculator opened/i),
+    ).toBeVisible()
+    await expect(
+      calculator.getByText(/Statesman loyalty modifiers.*not included/),
+    ).toBeVisible()
+
+    await expect(
+      calculator.getByRole("checkbox", { name: "Seduction" }),
+    ).toBeVisible()
+    await expect(
+      calculator.getByRole("checkbox", { name: "Blackmail" }),
+    ).toBeVisible()
+    await expect(
+      calculator.getByText(/Card availability is not checked/),
+    ).toBeVisible()
+    await expect(calculator.getByText("Evil Omens")).toBeVisible()
+    await expect(calculator.getByText("Era Ends")).toBeVisible()
+
+    await calculator
+      .getByRole("combobox", { name: "Persuader", exact: true })
+      .selectOption({ label: "Cornelius (ORA 3, INF 10, 10T)" })
+    await calculator
+      .getByLabel("Target")
+      .selectOption({ label: "Claudius (LOY 7, 0T)" })
+
+    await expect(calculator.getByText("0%", { exact: true })).toBeVisible()
+    await expect(calculator.getByText(/Base number/)).toHaveCount(0)
+    await expect(calculator.getByText(/Roll .* or less/)).toHaveCount(0)
+
+    await calculator.getByLabel("Persuader bribe").fill("3")
+    await expect(calculator.getByText("3%", { exact: true })).toBeVisible()
+
+    const counterBribes = calculator
+      .getByRole("group", { name: "Counter-bribes" })
+      .getByRole("spinbutton")
+    await expect(counterBribes).toHaveCount(2)
+    await counterBribes.first().fill("1")
+    await expect(calculator.getByText("0%", { exact: true })).toBeVisible()
+
+    const seduction = calculator.getByRole("checkbox", { name: "Seduction" })
+    const blackmail = calculator.getByRole("checkbox", { name: "Blackmail" })
+    await seduction.check()
+    await expect(counterBribes.first()).toBeDisabled()
+    await expect(calculator.getByText("3%", { exact: true })).toBeVisible()
+    await blackmail.check()
+    await expect(blackmail).toBeChecked()
+    await expect(seduction).not.toBeChecked()
+    await blackmail.uncheck()
+
+    await calculator
+      .getByRole("button", { name: "Add persuasion calculation" })
+      .click()
+    await expect(
+      calculator.getByRole("tab", { name: "Calculation 2" }),
+    ).toBeVisible()
+    // The floating panel can cover the game bar. Dispatch the event directly
+    // to verify that reopening focuses it without resetting local scenarios.
+    await calculatorButton.dispatchEvent("click")
+    await expect(
+      calculator.getByRole("tab", { name: "Calculation 2" }),
+    ).toBeVisible()
+
+    // Keep the snapshot open while a real game action changes live state. The
+    // draggable calculator may overlap the action bar in the test viewport.
+    await page
+      .getByRole("button", { name: "Attract knight...", exact: true })
+      .dispatchEvent("click")
+    const actionDialog = page.locator("dialog[open]")
+    await actionDialog.getByLabel("Senator").selectOption({ index: 1 })
+    await actionDialog.getByLabel("Talents").fill("5")
+    await actionDialog.getByRole("button", { name: "Confirm" }).click()
+    await expect(actionDialog).not.toBeVisible({ timeout: TIMEOUT })
+
+    await calculator.getByRole("tab", { name: "Claudius" }).click()
+    await expect(calculator.getByLabel("Persuader bribe")).toHaveValue("3")
+    await expect(
+      calculator
+        .getByRole("combobox", { name: "Persuader", exact: true })
+        .locator("option:checked"),
+    ).toHaveText("Cornelius (ORA 3, INF 10, 10T)")
+
+    await secondPage
+      .getByRole("button", { name: "Persuasion Calculator", exact: true })
+      .click()
+    const secondCalculator = secondPage.getByRole("region", {
+      name: "Persuasion Calculator",
+    })
+    await expect(
+      secondCalculator.getByRole("tab", { name: "Calculation 1" }),
+    ).toBeVisible()
+    await expect(
+      secondCalculator.getByRole("tab", { name: "Calculation 2" }),
+    ).toHaveCount(0)
+    await expect(
+      secondCalculator.getByRole("combobox", {
+        name: "Persuader",
+        exact: true,
+      }),
+    ).toHaveValue("")
+    await expect(secondCalculator.getByLabel("Target")).toHaveValue("")
+    await expect(
+      secondCalculator.getByRole("checkbox", { name: "Seduction" }),
+    ).not.toBeChecked()
+    await expect(
+      secondCalculator.getByRole("checkbox", { name: "Blackmail" }),
+    ).not.toBeChecked()
+
+    await calculator.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(calculator).toHaveCount(0)
+    await calculatorButton.click()
+    const reopenedCalculator = page.getByRole("region", {
+      name: "Persuasion Calculator",
+    })
+    await expect(
+      reopenedCalculator.getByRole("tab", { name: "Calculation 1" }),
+    ).toBeVisible()
+    await expect(
+      reopenedCalculator.getByRole("tab", { name: "Calculation 2" }),
+    ).toHaveCount(0)
+    await expect(
+      reopenedCalculator.getByRole("combobox", {
+        name: "Persuader",
+        exact: true,
+      }),
+    ).toHaveValue("")
+    await expect(reopenedCalculator.getByLabel("Target")).toHaveValue("")
+
+    await secondPage.context().close()
+  })
+})

--- a/frontend/tests/persuasionHelper.spec.ts
+++ b/frontend/tests/persuasionHelper.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test"
+
+import { calculatePersuasion } from "../helpers/persuasion"
+
+const resultForBase = (baseNumber: number, eraEnds = false) =>
+  calculatePersuasion({
+    oratory: baseNumber,
+    influence: 0,
+    loyalty: 0,
+    targetTalents: 0,
+    alignedTarget: false,
+    persuaderBribe: 0,
+    counterBribes: 0,
+    evilOmens: 0,
+    eraEnds,
+  })
+
+test.describe("persuasion calculation", () => {
+  test("applies every modifier to the base number", () => {
+    const result = calculatePersuasion({
+      oratory: 3,
+      influence: 10,
+      loyalty: 7,
+      targetTalents: 2,
+      alignedTarget: true,
+      persuaderBribe: 5,
+      counterBribes: 3,
+      evilOmens: 2,
+      eraEnds: false,
+    })
+
+    expect(result.baseNumber).toBe(1)
+    expect(result.chancePercent).toBe(0)
+    expect(result.impossible).toBe(true)
+  })
+
+  test("uses the normal automatic-failure limit", () => {
+    expect(resultForBase(1)).toMatchObject({
+      chancePercent: 0,
+      highestSuccessfulRoll: null,
+      impossible: true,
+    })
+    expect(resultForBase(2)).toMatchObject({
+      chancePercent: 3,
+      highestSuccessfulRoll: 2,
+      impossible: false,
+    })
+    expect(resultForBase(8).chancePercent).toBe(72)
+    expect(resultForBase(9)).toMatchObject({
+      chancePercent: 83,
+      automaticFailureFrom: 10,
+      highestSuccessfulRoll: 9,
+    })
+    expect(resultForBase(10).chancePercent).toBe(83)
+    expect(resultForBase(20).chancePercent).toBe(83)
+  })
+
+  test("uses the Era Ends automatic-failure limit", () => {
+    expect(resultForBase(1, true).chancePercent).toBe(0)
+    expect(resultForBase(2, true).chancePercent).toBe(3)
+    expect(resultForBase(8, true)).toMatchObject({
+      chancePercent: 72,
+      automaticFailureFrom: 9,
+      highestSuccessfulRoll: 8,
+    })
+    expect(resultForBase(9, true).chancePercent).toBe(72)
+    expect(resultForBase(20, true).chancePercent).toBe(72)
+  })
+})


### PR DESCRIPTION
## Summary

This PR provides a functional prototype for #729: a private persuasion calculator based on the Living Rules v1.07B and the existing project patterns.

The calculator is informational only. It reads the current board state when opened and performs all subsequent scenario changes locally in the player’s browser. It never initiates or modifies a real persuasion.

## Calculator behaviour

* Opens from a dedicated **Persuasion** button in the game bar.
* Captures a snapshot of the current board state when opened.
* Keeps that snapshot unchanged if the live game state subsequently changes.
* Closing and reopening the calculator captures a fresh snapshot and resets all scenarios.
* Pressing the Persuasion button while the calculator is already open brings it to the front.
* Supports multiple independent scenarios through tabs.
* Allows the player to select an eligible persuader from their own faction.
* Displays the persuader’s ORA, INF and personal Talents.
* Allows the player to select an eligible persuasion target.
* Displays the target’s LOY and personal Talents as captured when the calculator was opened.
* Allows hypothetical Talents to be added to the persuader’s bid.
* Provides a separate hypothetical counter-bribe field for every opposing faction.
* Displays the accumulated counter-bribe total.
* Makes **Seduction** and **Blackmail** available as hypothetical options even when the player does not hold those cards.
* Treats Seduction and Blackmail as mutually exclusive.
* Disables and ignores all counter-bribes when either card is selected.
* Shows the captured **Evil Omens** and **Era Ends** values as reminder rows.
* Displays a single calculated result: the probability of success.

## Calculation

The calculation takes into account:

* the persuader’s Oratory and Influence;
* the target’s Loyalty and personal treasury;
* hypothetical Talents added by the persuader;
* hypothetical counter-bribes from every opposing faction;
* the additional `+7` resistance of an aligned senator;
* the counter-bribe prevention effect of the selected Seduction or Blackmail card;
* the captured Evil Omens level;
* the automatic-failure threshold.

The displayed percentage already incorporates automatic failure:

* a modified roll of `10+` normally fails automatically;
* a modified roll of `9+` fails automatically when Era Ends applies.

Attempts that cannot succeed are displayed as `0%`.

## Privacy and isolation

The calculator uses private local React state only.

It:

* does not call persuasion REST endpoints;
* does not send WebSocket messages;
* does not use shared or persistent storage;
* does not dispatch game actions;
* does not execute a real persuasion;
* does not alter or block a real persuasion;
* does not interfere with persuasion activity performed by this player or any other player.

The existing multiplayer synchronization used by the combat calculator remains unchanged. The persuasion calculator deliberately does not use that synchronization because its scenarios must remain private.

## Snapshot and Talent interpretation

All Talent inputs represent hypothetical additions to the values captured when the calculator was opened.

If the calculator is opened after a real persuasion has already transferred Talents, those Talents are already part of the captured senator treasury. The calculator does not reconstruct an earlier game state or persuasion history.

## Deliberate prototype limitations

* Special Statesman relationships and the Gracchi modifiers are not calculated in this prototype.
* This exclusion is shown explicitly because the related persuasion and bribery behaviour is being audited separately.
* Seduction and Blackmail are modelling switches and do not check the player’s actual hand.
* The calculator only uses the current board snapshot and does not reproduce previous bidding steps.

## Review disclaimers

The explanatory disclaimers currently shown in the calculator interface are intentionally prominent so that reviewers can clearly understand the prototype’s privacy model, assumptions and exclusions during review.

These texts are review aids. They may be shortened or removed from the final production interface once the intended behaviour and limitations have been reviewed and agreed.

## Reuse and code structure

* Reuses the project’s existing dice-probability helper.
* Reuses the existing Evil Omens selector and checkbox component.
* Follows the established floating-calculator positioning, focus and z-index patterns.
* Keeps the persuasion calculation in a dedicated pure helper with focused tests.
* Introduces no backend or database changes.
* Does not duplicate or modify the combat calculator’s synchronization logic.

## Validation

* Prettier formatting passed.
* ESLint passed.
* TypeScript checking passed.
* Next.js production build passed.
* Persuasion probability helper tests passed.
* The calculator has been tested manually in a local multiplayer game.
* GitHub frontend CI passed, including the production build and all 11 Playwright tests.
* The GitHub backend change filter passed. The backend build-and-test job was correctly skipped because this PR contains no backend changes.

The implementation was created with ChatGPT and Cloud. I tested the calculator in my local clone, and it appears to work as intended.

Closes #729
