### PR TITLE
fix: spare the accused from the mob after a popular appeal (§1.09.421)

### DIFF
--- a/backend/rorapp/actions/call_popular_appeal.py
+++ b/backend/rorapp/actions/call_popular_appeal.py
@@ -15,6 +15,7 @@ from rorapp.helpers.popular_appeal import (
     ACCUSED_KILLED,
     popular_appeal_outcome,
 )
+from rorapp.helpers.special_major_prosecution import censor_in_rome
 from rorapp.helpers.text import pluralize
 from rorapp.models import AvailableAction, Faction, Game, Senator, Log
 
@@ -133,13 +134,12 @@ class CallPopularAppealAction(ActionBase):
             # Mortality chits for each point exceeding 11
             excess = result - 11
             if excess > 0:
-                senators = Senator.objects.filter(game=game_id)
-                vulnerable = [accused.id, prosecutor.id]
                 chits = set(random_resolver.draw_mortality_chits(excess))
+                # Only the Censor and the Prosecutor are vulnerable to the mob (1.09.421)
                 victims = [
                     senator
-                    for senator in senators
-                    if senator.id in vulnerable
+                    for senator in (censor_in_rome(game_id), prosecutor)
+                    if senator is not None
                     and senator.alive
                     and get_senator_codes(senator.code)[0] in chits
                 ]

--- a/backend/rorapp/actions/call_popular_appeal.py
+++ b/backend/rorapp/actions/call_popular_appeal.py
@@ -135,7 +135,6 @@ class CallPopularAppealAction(ActionBase):
             excess = result - 11
             if excess > 0:
                 chits = set(random_resolver.draw_mortality_chits(excess))
-                # Only the Censor and the Prosecutor are vulnerable to the mob (1.09.421)
                 victims = [
                     senator
                     for senator in (censor_in_rome(game_id), prosecutor)


### PR DESCRIPTION
Closes #799.

A popular appeal that comes up "Accused Freed" draws one mortality chit for each point the modified roll exceeds 11. Those chits were being checked against the accused and the prosecutor, so the senator the crowd had just acquitted could be killed by the same crowd, while the Censor who brought the frame-up was never at risk.

> In addition, one Mortality Chit is drawn for each number which exceeds 11 on the modified roll in order to see if either the Censor and/or the Prosecutor (the only two vulnerable to the chit draw) is killed by a mob enraged over this obvious frame-up. (§1.09.421)

### Implementation notes

Special major prosecution of an assassin (§1.09.74) already a form of this. No prosecutor is appointed for that trial, so `SpecialMajorProsecutionAppealEffect` drew against the Censor alone and reached him through `censor_in_rome`. `CallPopularAppealAction` now uses the same lookup, which is where the guard against a Censor outside Rome comes from.

### Out of scope

`eligible_prosecutors` in `propose_major_prosecution.py` and `propose_minor_prosecution.py` does not filter on `location == "Rome"`, although §1.09.411 says the Prosecutor can be any Senator in Rome. Separate bug for later if true.

### Testing

Four-line change with no new test, the existing popular appeal coverage should exercise both branches of the roll.

- `pytest`: 602 passed
- `mypy .`: no issues found in 432 source files
