### PR TITLE
refactor: use the pluralize helper for count labels

### DIFF
--- a/frontend/components/CombatCalculator.tsx
+++ b/frontend/components/CombatCalculator.tsx
@@ -19,6 +19,7 @@ import {
   createProposalCalculation,
   getDeployedForces,
 } from "@/helpers/deploymentProposal"
+import { pluralize } from "@/helpers/text"
 import useIsMobile from "@/hooks/isMobile"
 
 import CombatCalculatorItem from "./CombatCalculatorItem"
@@ -363,8 +364,7 @@ const CombatCalculator = forwardRef<CombatCalculatorHandle, GenericActionFormPro
 
         if (additionalLegionsNeeded > 0) {
           unitsNeeded.push(
-            `${additionalLegionsNeeded} more regular legion` +
-              (additionalLegionsNeeded > 1 ? "s" : ""),
+            pluralize(additionalLegionsNeeded, "more regular legion"),
           )
         }
       }
@@ -384,8 +384,7 @@ const CombatCalculator = forwardRef<CombatCalculatorHandle, GenericActionFormPro
           (availableVeteranLegions?.length ?? 0)
         if (additionalVeteransNeeded > 0) {
           unitsNeeded.push(
-            `${additionalVeteransNeeded} more veteran legion` +
-              (additionalVeteransNeeded > 1 ? "s" : ""),
+            pluralize(additionalVeteransNeeded, "more veteran legion"),
           )
         }
       }
@@ -402,10 +401,7 @@ const CombatCalculator = forwardRef<CombatCalculatorHandle, GenericActionFormPro
         const additionalFleetsNeeded =
           calculation.fleets - deployed.fleets - (availableFleets?.length ?? 0)
         if (additionalFleetsNeeded > 0) {
-          unitsNeeded.push(
-            `${additionalFleetsNeeded} more fleet` +
-              (additionalFleetsNeeded > 1 ? "s" : ""),
-          )
+          unitsNeeded.push(pluralize(additionalFleetsNeeded, "more fleet"))
         }
       }
 

--- a/frontend/components/GameBar.tsx
+++ b/frontend/components/GameBar.tsx
@@ -77,7 +77,7 @@ const GameBar = ({
           }
         >
           <div className="flex flex-col gap-2">
-            {game.deckCount} card{game.deckCount !== 1 ? "s" : ""} in the deck
+            {pluralize(game.deckCount, "card")} in the deck
           </div>
         </Popover>
       </Cell>
@@ -318,8 +318,7 @@ const GameBar = ({
             <div className="flex max-w-96 flex-col gap-3">
               <div className="flex justify-between gap-4">
                 <span>
-                  {privateGameState.faction.cards.length} card
-                  {privateGameState.faction.cards.length !== 1 ? "s" : ""}
+                  {pluralize(privateGameState.faction.cards.length, "card")}
                 </span>
                 <span>
                   {privateGameState.faction.treasury}T in faction treasury

--- a/frontend/components/GameMain.tsx
+++ b/frontend/components/GameMain.tsx
@@ -181,8 +181,7 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
               <Popover
                 trigger={
                   <span className="px-2 text-sm text-neutral-600">
-                    {deceasedSenators.length} deceased senator
-                    {deceasedSenators.length !== 1 ? "s" : ""}
+                    {pluralize(deceasedSenators.length, "deceased senator")}
                   </span>
                 }
               >
@@ -525,8 +524,7 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
                         )}
                         {legions.length > 0 && (
                           <span>
-                            {legions.length}{" "}
-                            {legions.length > 1 ? "legions" : "legion"}
+                            {pluralize(legions.length, "legion")}
                             <> ({forceListToString(legions)})</>
                           </span>
                         )}
@@ -535,8 +533,7 @@ const GameMain = ({ publicGameState, privateGameState }: Props) => {
                         )}
                         {fleets.length > 0 && (
                           <span>
-                            {fleets.length}{" "}
-                            {fleets.length > 1 ? "fleets" : "fleet"}
+                            {pluralize(fleets.length, "fleet")}
                             <> ({forceListToString(fleets)})</>
                           </span>
                         )}

--- a/frontend/components/customActionForms/AdvancedVoteForm.tsx
+++ b/frontend/components/customActionForms/AdvancedVoteForm.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react"
 
 import Senator from "@/classes/Senator"
+import { pluralize } from "@/helpers/text"
 import useCustomActionForm from "@/hooks/useCustomActionForm"
 
 import { CustomActionFormProps } from "../ActionBar"
@@ -285,8 +286,7 @@ const AdvancedVoteForm = ({
                   <div className="flex justify-between gap-6">
                     <div className="flex flex-col gap-1">
                       <span className="text-sm text-neutral-600">
-                        {votesFor(senator)}{" "}
-                        {votesFor(senator) === 1 ? "vote" : "votes"}
+                        {pluralize(votesFor(senator), "vote")}
                       </span>
                       <div className="flex gap-1">
                         <button

--- a/frontend/components/customActionForms/PlaySecretBodyguardForm.tsx
+++ b/frontend/components/customActionForms/PlaySecretBodyguardForm.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { pluralize } from "@/helpers/text"
 import useCustomActionForm from "@/hooks/useCustomActionForm"
 
 import { CustomActionFormProps } from "../ActionBar"
@@ -170,16 +171,12 @@ const PlaySecretBodyguardForm = ({
               </div>
               <div>
                 <p className="font-semibold">
-                  With {count} bodyguard{count !== 1 ? "s" : ""}:
+                  With {pluralize(count, "bodyguard")}:
                 </p>
                 <ul className="ml-10 list-disc">
                   <li>{outcomeLabel(modifiedRoll)}</li>
                   {modifiedRoll > 2 && (
-                    <li>
-                      {" "}
-                      {count} chance{count !== 1 ? "s" : ""} to catch the
-                      assassin
-                    </li>
+                    <li> {pluralize(count, "chance")} to catch the assassin</li>
                   )}
                 </ul>
               </div>

--- a/frontend/components/customActionForms/RedistributeTalentsForm.tsx
+++ b/frontend/components/customActionForms/RedistributeTalentsForm.tsx
@@ -2,6 +2,7 @@
 
 import { AllocationEntry } from "@/classes/AvailableAction"
 import Senator from "@/classes/Senator"
+import { pluralize } from "@/helpers/text"
 import useCustomActionForm from "@/hooks/useCustomActionForm"
 
 import { CustomActionFormProps } from "../ActionBar"
@@ -126,7 +127,7 @@ const RedistributeTalentsForm = ({
             <span
               className={`min-w-[180px] ${balanced ? "text-neutral-600" : "text-red-600"}`}
             >
-              Total: {allocTotal} / {total} {total === 1 ? "talent" : "talents"}
+              Total: {allocTotal} / {pluralize(total, "talent")}
             </span>
             <div className="flex gap-2">
               <button

--- a/frontend/helpers/date.ts
+++ b/frontend/helpers/date.ts
@@ -1,5 +1,7 @@
 import { utcToZonedTime } from "date-fns-tz"
 
+import { pluralize } from "@/helpers/text"
+
 interface FormatDateOptions {
   showWeekday?: boolean
 }
@@ -38,23 +40,23 @@ export const formatElapsedDate = (isoString: string, timezone: string) => {
   }
   const hours = Math.floor(minutes / 60)
   if (hours < 1) {
-    return `${minutes} ${minutes === 1 ? "min" : "mins"} ago`
+    return `${pluralize(minutes, "min")} ago`
   }
   const days = Math.floor(hours / 24)
   if (days < 1) {
-    return `${hours} ${hours === 1 ? "hour" : "hours"} ago`
+    return `${pluralize(hours, "hour")} ago`
   }
   const weeks = Math.floor(days / 7)
   if (weeks < 1) {
-    return `${days} ${days === 1 ? "day" : "days"} ago`
+    return `${pluralize(days, "day")} ago`
   }
   const months = Math.floor(days / 30)
   if (months < 1) {
-    return `${weeks} ${weeks === 1 ? "week" : "weeks"} ago`
+    return `${pluralize(weeks, "week")} ago`
   }
   const years = Math.floor(days / 365)
   if (years < 1) {
-    return `${months} ${months === 1 ? "month" : "months"} ago`
+    return `${pluralize(months, "month")} ago`
   }
-  return `${years} ${years === 1 ? "year" : "years"} ago`
+  return `${pluralize(years, "year")} ago`
 }


### PR DESCRIPTION
Closes #774.

`pluralize(count, noun)` has lived in `frontend/helpers/text.ts` since the legion and fleet counters were added, but most of the frontend still does it by hand, so to speak. This replaces all(?) 18 remaining sites with the helper.

### Behaviour

No rendered text changes. Three sites tested `count > 1` rather than `count !== 1`, so they would have rendered `0 legion`, but all three sit inside a `count > 0` guard and the case was unreachable.

### Implementation notes

The helper suffixes the whole noun phrase, so `pluralize(n, "more regular legion")` gives `3 more regular legions` and no site needed a special case. Two read a little differently after the swap:

- `RedistributeTalentsForm` keeps its `Total: 3 / 5 talents` shape by leaving `allocTotal` outside the call: `Total: {allocTotal} / {pluralize(total, "talent")}`.
- `GameMain` and `AdvancedVoteForm` lose a `{" "}` separator each, since the helper emits the space between the count and the noun itself.

`helpers/date.ts` accounts for 6 of the 18 (`min`, `hour`, `day`, `week`, `month`, `year`); the rest are spread across `CombatCalculator`, `GameBar`, `GameMain`, `AdvancedVoteForm`, `PlaySecretBodyguardForm` and `RedistributeTalentsForm`.

`CombatCalculator.tsx` is not prettier clean on `main`, so it was edited by hand rather than run through prettier, which keeps the diff to the lines that actually changed.

### Out of scope

`GameEffects.tsx` has a similar looking cluster of `level === 1 ? ... : ...` ternaries, but those pick between different labels (`Drought` / `Severe drought`, `Evil omens` / `Evil omens x2`) rather than singular and plural, so the helper does not apply there.

### Testing

`npx tsc --noEmit` clean, `npm run build` succeeds, `npx eslint` clean on all 7 changed files. `npm run lint` is already broken on `main` (`next lint` was removed in Next 16), so eslint was invoked directly